### PR TITLE
feat: canonicalize identifier conventions across plugin source (phase 1)

### DIFF
--- a/plugins/vsdd-factory/rules/spec-format.md
+++ b/plugins/vsdd-factory/rules/spec-format.md
@@ -15,10 +15,38 @@
 
 ### Numbering
 
-- `S` = subsystem (01–99)
-- `SS` = section within subsystem (01–99)
+- `S` = PRD section / top-level subsystem grouping (1–9)
+- `SS` = subsection within the section (matches an L2 subsystem; 01–99)
 - `NNN` = contract number (001–999)
-- Example: `BC-1.01.001` — Subsystem 1, Section 01, Contract 001
+- Example: `BC-1.01.001` — Section 1, Subsection 01, Contract 001
+
+### Sharded Layout
+
+BCs are organized into per-subsystem shard directories under
+`behavioral-contracts/`, one shard per subsystem registered in ARCH-INDEX:
+
+```
+.factory/specs/behavioral-contracts/
+├── BC-INDEX.md
+├── ss-01/
+│   ├── BC-1.01.001.md
+│   ├── BC-1.01.002.md
+│   └── ...
+├── ss-02/
+│   ├── BC-2.02.001.md
+│   └── ...
+└── ss-NN/
+    └── ...
+```
+
+The shard directory name is the **bare `SS-NN` identifier** (lowercased,
+e.g., `ss-01/`) — NOT the descriptive subsystem name (NOT `ss-01-hook-dispatcher/`).
+Subsystem descriptive names live authoritatively in ARCH-INDEX Subsystem
+Registry and in `architecture/SS-NN-<name>.md` section files.
+
+The sharded layout scales to projects with hundreds or thousands of BCs
+without making the directory unbrowsable. Small projects (under ~50 BCs)
+may keep a flat layout, but the canonical convention is sharded.
 
 ### File Format
 
@@ -48,7 +76,7 @@
 
 ## Traceability
 - PRD: <requirement ID or section>
-- Stories: <STORY-NNN references>
+- Stories: <S-N.MM references>
 - VPs: <VP-NNN references>
 ```
 
@@ -59,7 +87,7 @@
 
 | ID | Title | Subsystem | Status | Stories |
 |----|-------|-----------|--------|---------|
-| BC-1.01.001 | ... | ... | draft/reviewed/green | STORY-001 |
+| BC-1.01.001 | ... | ... | draft/reviewed/green | S-1.01 |
 ```
 
 ## Verification Properties (VP-NNN)
@@ -150,13 +178,27 @@ Supplementary documents live in `.factory/specs/prd-supplements/`:
 | `integration-points.md` | External service contracts |
 | `module-criticality.md` | CRITICAL/HIGH/MEDIUM/LOW classification |
 
-## Story Format (STORY-NNN)
+## Story Format (S-N.MM)
+
+### ID Format
+
+- **Stories** use `S-N.MM` (section.story, zero-padded):
+  - `N` = section / epic-grouping (single digit, matches the parent epic `E-N`)
+  - `MM` = zero-padded story number within that section (e.g., `01`, `15`)
+  - Examples: `S-1.01`, `S-3.15`, `S-0.02`
+  - Filename: `S-N.MM-<short-description>.md` (e.g., `S-1.01-foundational-types.md`)
+- **Epics** use `E-N` (single digit). Epic `E-N` directly contains all `S-N.*`
+  stories. Filename: `E-N-<short-description>.md` under `.factory/stories/epics/`.
+- **Story `N` and BC `S` are different hierarchies.** BC `S` (in
+  BC-S.SS.NNN) is the subsystem number; story `N` (in S-N.MM) is the
+  epic/release-milestone grouping. A single story can implement BCs from
+  multiple subsystems via the `subsystems: [SS-NN, ...]` frontmatter array.
 
 ```markdown
-# STORY-NNN: <Title>
+# S-N.MM: <Title>
 
 ## Epic
-<Epic reference>
+<E-N reference>
 
 ## Description
 <User story format: As a..., I want..., so that...>
@@ -177,7 +219,7 @@ Supplementary documents live in `.factory/specs/prd-supplements/`:
 <from-scratch | gene-transfusion>
 
 ## Dependencies
-- <STORY-NNN references>
+- <S-N.MM references>
 
 ## Wave
 <Wave number for scheduling>

--- a/plugins/vsdd-factory/rules/worktree-protocol.md
+++ b/plugins/vsdd-factory/rules/worktree-protocol.md
@@ -7,7 +7,7 @@
 ```
 main              ← production releases only
   └── develop     ← integration branch, PRs target here
-       └── feature/STORY-NNN-<desc>  ← per-story work
+       └── feature/S-N.MM-<desc>  ← per-story work
 ```
 
 - `factory-artifacts` is an **orphan branch** — no relationship to main/develop.
@@ -22,26 +22,26 @@ All story worktrees live in `.worktrees/` at the project root:
 
 ```
 .worktrees/
-├── STORY-001/    # git worktree, branch: feature/STORY-001-<desc>
-├── STORY-002/
-└── STORY-003/
+├── S-1.01/    # git worktree, branch: feature/S-1.01-<desc>
+├── S-1.02/
+└── S-1.03/
 ```
 
 ### Creating a Worktree
 
 ```bash
-git worktree add .worktrees/STORY-NNN -b feature/STORY-NNN-<desc> develop
+git worktree add .worktrees/S-N.MM -b feature/S-N.MM-<desc> develop
 ```
 
 - Always branch from `develop`.
-- Branch name must match pattern: `feature/STORY-NNN-<short-description>`.
+- Branch name must match pattern: `feature/S-N.MM-<short-description>`.
 - One worktree per story — never share worktrees between stories.
 
 ### Working in a Worktree
 
 - All implementation for a story happens inside its worktree.
 - Micro-commits per test pass (TDD progression visible in git history).
-- Commit message format: `feat(STORY-NNN): <description>` or `test(STORY-NNN): <description>`.
+- Commit message format: `feat(S-N.MM): <description>` or `test(S-N.MM): <description>`.
 
 ### Merging a Story
 
@@ -49,8 +49,8 @@ git worktree add .worktrees/STORY-NNN -b feature/STORY-NNN-<desc> develop
 2. PR created targeting `develop`.
 3. PR reviewed (adversarial + code review).
 4. Squash merge to `develop`.
-5. Worktree removed: `git worktree remove .worktrees/STORY-NNN`.
-6. Branch cleaned up: `git branch -d feature/STORY-NNN-<desc>`.
+5. Worktree removed: `git worktree remove .worktrees/S-N.MM`.
+6. Branch cleaned up: `git branch -d feature/S-N.MM-<desc>`.
 
 ### Wave Integration
 

--- a/plugins/vsdd-factory/skills/check-input-drift/SKILL.md
+++ b/plugins/vsdd-factory/skills/check-input-drift/SKILL.md
@@ -110,14 +110,14 @@ This reads the `inputs:` field, concatenates the current contents of those files
 | Artifact | Stored Hash | Current Hash | Inputs Changed |
 |----------|-------------|-------------|----------------|
 | prd.md | be246a0 | f3a91c2 | domain-spec/L2-INDEX.md |
-| STORY-005.md | a1b2c3d | e4f5g6h | prd.md |
+| S-1.05-foundational-types.md | a1b2c3d | e4f5g6h | prd.md |
 
 ### Uncomputed Hashes (never populated)
 
 | Artifact | Status |
 |----------|--------|
 | BC-2.01.005.md | input-hash: null |
-| STORY-042.md | input-hash: "[md5]" |
+| S-3.05-cost-estimation.md | input-hash: "[md5]" |
 
 ### Current Artifacts (hash matches)
 

--- a/plugins/vsdd-factory/skills/consistency-validation/SKILL.md
+++ b/plugins/vsdd-factory/skills/consistency-validation/SKILL.md
@@ -11,7 +11,7 @@ description: >
 
 Before loading detail files, validate index files for structural completeness:
 - Check `architecture/ARCH-INDEX.md` references all existing section files
-- Check `behavioral-contracts/BC-INDEX.md` references all BC files
+- Check `behavioral-contracts/BC-INDEX.md` references all BC files (recursive — BCs live in `behavioral-contracts/ss-NN/` shard directories)
 - Check `verification-properties/VP-INDEX.md` references all VP files
 - Check `adversarial-reviews/ADV-P[N]-INDEX.md` references all finding files (if exists)
 - Check `evaluations/EVAL-INDEX.md` references all per-scenario evaluations (if exists)
@@ -130,13 +130,13 @@ Query: cross-reference product brief sections against `domain-spec/L2-INDEX.md` 
 ### Rule 16: L2→L3 Chain Completeness
 Validate that every L2 CAP-NNN maps to at least one L3 BC-S.SS.NNN behavioral contract.
 Report capabilities with no BC coverage.
-Query: cross-reference `domain-spec/L2-INDEX.md` CAP entries against `behavioral-contracts/` files.
+Query: cross-reference `domain-spec/L2-INDEX.md` CAP entries against `behavioral-contracts/ss-NN/` files (recursive).
 
 ### Rule 17: L3→L4 Chain Completeness
 Validate that every L3 BC-S.SS.NNN that requires formal verification maps to at least
 one L4 VP-NNN. Report BCs with missing VP coverage and no documented justification for
 omission.
-Query: cross-reference `behavioral-contracts/` files against `verification-properties/` files.
+Query: cross-reference `behavioral-contracts/ss-NN/` files (recursive) against `verification-properties/` files.
 
 ### Rule 18: L1→L4 Full Chain Integrity
 Validate the complete L1→L2→L3→L4 chain end-to-end. For each L1 section, trace through
@@ -147,7 +147,7 @@ Query: for each L1 section, verify L2 CAP exists, L3 BC exists, and L4 VP exists
 ### Rule 19: BC-to-Story Mapping
 Validate that every L3 BC-S.SS.NNN is covered by at least one story. Report BCs with
 no story mapping.
-Query: cross-reference `behavioral-contracts/` files against story files in `phase-2-stories/stories/`.
+Query: cross-reference `behavioral-contracts/ss-NN/` files (recursive) against story files in `phase-2-stories/stories/`.
 
 ### Rule 20: AC-to-BC Traceability
 Validate that every story AC-NNN traces to a BC precondition or postcondition. Report
@@ -186,7 +186,7 @@ Query: validate .factory/ui-traceability.yaml for completeness.
 Every numbered precondition, postcondition, and invariant clause in every active BC
 must have at least one AC tracing to it. Gap Register entries with non-empty
 justification (min 10 chars) count as covered.
-Query: parse BC files in `behavioral-contracts/` for clause counts (preconditions,
+Query: parse BC files in `behavioral-contracts/ss-NN/` (recursive) for clause counts (preconditions,
 postconditions, invariants). For each clause, grep story files for trace references
 matching the specific BC ID + clause type + clause number. Report uncovered clauses
 with severity: postconditions = Critical, preconditions/invariants = Major.

--- a/plugins/vsdd-factory/skills/create-prd/SKILL.md
+++ b/plugins/vsdd-factory/skills/create-prd/SKILL.md
@@ -107,7 +107,7 @@ Criticality determines review depth, test coverage requirements, and holdout sce
 ### Subsystem 01: <Name>
 
 #### Section 01: <Name>
-- BC-1.01.001: <title> — see behavioral-contracts/BC-1.01.001.md
+- BC-1.01.001: <title> — see behavioral-contracts/ss-01/BC-1.01.001.md
 - BC-1.01.002: <title>
 
 ## Cross-Cutting Concerns
@@ -123,9 +123,12 @@ Criticality determines review depth, test coverage requirements, and holdout sce
 <Things that need resolution>
 ```
 
-### Individual BCs (`.factory/specs/behavioral-contracts/BC-S.SS.NNN.md`)
+### Individual BCs (`.factory/specs/behavioral-contracts/ss-NN/BC-S.SS.NNN.md`)
 
-One file per contract, following `spec-format.md` format.
+One file per contract, sharded into per-subsystem `ss-NN/` directories,
+following `spec-format.md` format. Shard directory name is the bare
+`SS-NN` identifier (lowercased) — descriptive subsystem names live in
+ARCH-INDEX Subsystem Registry, not in the directory name.
 
 ### BC Index (`.factory/specs/behavioral-contracts/BC-INDEX.md`)
 

--- a/plugins/vsdd-factory/skills/create-story/SKILL.md
+++ b/plugins/vsdd-factory/skills/create-story/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: create-story
 description: Create or refine a single story spec with full acceptance criteria, tasks, and implementation details. Takes a story ID and produces a sprint-ready story file.
-argument-hint: "[STORY-NNN]"
+argument-hint: "[S-N.MM]"
 disable-model-invocation: true
 allowed-tools: Read, Write, Edit, Bash, AskUserQuestion
 ---
@@ -17,15 +17,15 @@ Flesh out a single story into a sprint-ready specification.
 ## Templates
 
 Read and follow the output format in:
-- `${CLAUDE_PLUGIN_ROOT}/templates/story-template.md` — STORY-NNN format
+- `${CLAUDE_PLUGIN_ROOT}/templates/story-template.md` — S-N.MM format
 
 ## Input
 
-`$ARGUMENTS` — story ID (e.g., `STORY-001`)
+`$ARGUMENTS` — story ID (e.g., `S-1.01`)
 
 ## Prerequisites
 
-- Story file should exist in `.factory/stories/STORY-NNN.md` (at least a stub from decomposition)
+- Story file should exist in `.factory/stories/S-N.MM-<short>.md` (at least a stub from decomposition)
 - PRD and architecture docs available for reference
 
 ## Process
@@ -88,14 +88,14 @@ These patterns invalidate a story. If you catch any, fix before proceeding:
 - "TBD", "TODO", or "implement later" in any section
 - "Add appropriate error handling" without specifying which errors
 - "Write tests for the above" without actual test descriptions
-- "Similar to STORY-NNN" without repeating the relevant details
+- "Similar to S-N.MM" without repeating the relevant details
 - Acceptance criteria without testable assertions
 - File list that says "and other files as needed"
 - Tasks that describe what to do without specifying how
 
 ## Output
 
-Updated `.factory/stories/STORY-NNN.md` with full specification.
+Updated `.factory/stories/S-N.MM-<short>.md` with full specification.
 
 ## Lessons Learned (apply to ALL projects)
 
@@ -126,4 +126,4 @@ Fix issues inline. This is a cheap filter — catch obvious gaps before delivery
 
 1. Commit to factory-artifacts.
 2. Update STORY-INDEX.md status to `ready`.
-3. Tell the user: "Story STORY-NNN is sprint-ready. Use `/deliver-story STORY-NNN` to start implementation."
+3. Tell the user: "Story S-N.MM is sprint-ready. Use `/deliver-story S-N.MM` to start implementation."

--- a/plugins/vsdd-factory/skills/decompose-stories/SKILL.md
+++ b/plugins/vsdd-factory/skills/decompose-stories/SKILL.md
@@ -31,8 +31,8 @@ Break the PRD and architecture into implementable stories organized by dependenc
 ## Templates
 
 Read and follow the output format in:
-- `${CLAUDE_PLUGIN_ROOT}/templates/story-template.md` — STORY-NNN format
-- `${CLAUDE_PLUGIN_ROOT}/templates/epic-template.md` — epic structure
+- `${CLAUDE_PLUGIN_ROOT}/templates/story-template.md` — S-N.MM format
+- `${CLAUDE_PLUGIN_ROOT}/templates/epic-template.md` — epic structure (E-N format)
 - `${CLAUDE_PLUGIN_ROOT}/templates/wave-schedule-template.md` — wave schedule
 - `${CLAUDE_PLUGIN_ROOT}/templates/holdout-scenario-template.md` — hidden acceptance scenarios
 - `${CLAUDE_PLUGIN_ROOT}/templates/traceability-matrix-template.md` — requirement traceability
@@ -77,7 +77,14 @@ For each epic, break into stories. Each story should be:
 - **Testable** — has clear acceptance criteria from BCs
 - **Small enough** — 1-3 days of implementation work
 
-Write each story to `.factory/stories/STORY-NNN.md` following `spec-format.md` story format.
+Write each story to `.factory/stories/S-N.MM-<short>.md` following `spec-format.md` story format.
+
+Story IDs use `S-N.MM` (section.story zero-padded). The `N` is the section/epic
+grouping (matches the parent epic `E-N`); `MM` is the zero-padded story number
+within that section. Example: `S-1.01`, `S-3.15`. The `S` in BC IDs (BC-S.SS.NNN)
+and the `N` in story IDs (S-N.MM) are intentionally different hierarchies — BC `S`
+is the subsystem number, story `N` is the epic/wave grouping. Stories cross
+subsystem boundaries via the `subsystems: [SS-NN, ...]` frontmatter array.
 
 ### 3. Build Dependency Graph
 
@@ -91,14 +98,14 @@ Write to `.factory/stories/dependency-graph.md`:
 # Story Dependency Graph
 
 ## Dependencies
-STORY-002 → STORY-001  (002 depends on 001)
-STORY-003 → STORY-001
-STORY-004 → STORY-002, STORY-003
+S-1.02 → S-1.01  (S-1.02 depends on S-1.01)
+S-1.03 → S-1.01
+S-1.04 → S-1.02, S-1.03
 
 ## Independent Groups
-[STORY-001]           # Wave 1
-[STORY-002, STORY-003] # Wave 2 (both depend on 001)
-[STORY-004]           # Wave 3
+[S-1.01]              # Wave 1
+[S-1.02, S-1.03]      # Wave 2 (both depend on S-1.01)
+[S-1.04]              # Wave 3
 ```
 
 ### 4. Assign Waves
@@ -121,7 +128,7 @@ Write `.factory/stories/STORY-INDEX.md`:
 
 | ID | Title | Epic | Wave | Status | Dependencies |
 |----|-------|------|------|--------|-------------|
-| STORY-001 | ... | ... | 1 | draft | none |
+| S-1.01 | ... | E-1 | 1 | draft | none |
 ```
 
 ### 6. Initialize Sprint State
@@ -131,15 +138,15 @@ Write `.factory/stories/sprint-state.yaml`:
 ```yaml
 current_wave: 1
 stories:
-  STORY-001:
+  S-1.01:
     status: pending
     wave: 1
     branch: null
     worktree: null
-  STORY-002:
+  S-1.02:
     status: blocked
     wave: 2
-    blocked_by: [STORY-001]
+    blocked_by: [S-1.01]
 ```
 
 ### 7. Create Holdout Scenarios
@@ -158,7 +165,7 @@ These patterns invalidate a story. If you catch any, fix before proceeding:
 - "TBD", "TODO", or "implement later" in any section
 - "Add appropriate error handling" without specifying which errors
 - "Write tests for the above" without actual test descriptions
-- "Similar to STORY-NNN" without repeating the relevant details
+- "Similar to S-N.MM" without repeating the relevant details
 - Acceptance criteria without testable assertions
 - File list that says "and other files as needed"
 - Tasks that describe what to do without specifying how
@@ -184,7 +191,7 @@ Story decomposition complete:
   Wave 1: <N> stories (ready to start)
   Holdout scenarios: <N>
 
-Next: `/create-story STORY-001` to flesh out the first story, or `/deliver-story STORY-001` to start implementation.
+Next: `/create-story S-1.01` to flesh out the first story, or `/deliver-story S-1.01` to start implementation.
 ```
 
 ## After Writing

--- a/plugins/vsdd-factory/skills/decompose-stories/steps/step-c-dependency-graph.md
+++ b/plugins/vsdd-factory/skills/decompose-stories/steps/step-c-dependency-graph.md
@@ -11,7 +11,7 @@ Analyze story dependencies to determine execution order.
 
 ## Procedure
 
-1. Read all `STORY-NNN.md` files
+1. Read all `S-N.MM-<short>.md` story files
 2. For each story, identify which other stories must complete first
 3. Identify stories that are independent (can run in parallel)
 4. Write the dependency graph:
@@ -20,14 +20,14 @@ Analyze story dependencies to determine execution order.
 # Story Dependency Graph
 
 ## Dependencies
-STORY-002 → STORY-001  (002 depends on 001)
-STORY-003 → STORY-001
-STORY-004 → STORY-002, STORY-003
+S-1.02 → S-1.01  (S-1.02 depends on S-1.01)
+S-1.03 → S-1.01
+S-1.04 → S-1.02, S-1.03
 
 ## Independent Groups
-[STORY-001]           # Wave 1
-[STORY-002, STORY-003] # Wave 2 (both depend on 001)
-[STORY-004]           # Wave 3
+[S-1.01]              # Wave 1
+[S-1.02, S-1.03]      # Wave 2 (both depend on S-1.01)
+[S-1.04]              # Wave 3
 ```
 
 ## Artifacts

--- a/plugins/vsdd-factory/skills/decompose-stories/steps/step-d-wave-schedule.md
+++ b/plugins/vsdd-factory/skills/decompose-stories/steps/step-d-wave-schedule.md
@@ -28,7 +28,7 @@ Write `.factory/stories/STORY-INDEX.md`:
 
 | ID | Title | Epic | Wave | Status | Dependencies |
 |----|-------|------|------|--------|-------------|
-| STORY-001 | ... | ... | 1 | draft | none |
+| S-1.01 | ... | E-1 | 1 | draft | none |
 ```
 
 ### 3. Initialize Sprint State
@@ -38,15 +38,15 @@ Write `.factory/stories/sprint-state.yaml`:
 ```yaml
 current_wave: 1
 stories:
-  STORY-001:
+  S-1.01:
     status: pending
     wave: 1
     branch: null
     worktree: null
-  STORY-002:
+  S-1.02:
     status: blocked
     wave: 2
-    blocked_by: [STORY-001]
+    blocked_by: [S-1.01]
 ```
 
 ## Artifacts

--- a/plugins/vsdd-factory/skills/deliver-story/SKILL.md
+++ b/plugins/vsdd-factory/skills/deliver-story/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: deliver-story
 description: Use when delivering a single story through the VSDD TDD pipeline. Dispatches fresh specialist subagents (test-writer → implementer → demo-recorder → pr-manager → devops-engineer) via the per-story-delivery orchestrator workflow. Each step runs in isolated context to preserve reasoning quality and prevent context exhaustion.
-argument-hint: "[STORY-NNN]"
+argument-hint: "[S-N.MM]" # canonical S-N.MM format (e.g., S-1.01); legacy STORY-NNN accepted
 disable-model-invocation: true
 allowed-tools: Read, Bash, Glob, Grep, AskUserQuestion, Task
 ---
@@ -24,13 +24,13 @@ Violating the letter of the rule is violating the spirit of the rule. "I already
 
 Before any other action, say verbatim:
 
-> I'm using the deliver-story skill to dispatch STORY-NNN through the per-story-delivery orchestrator workflow.
+> I'm using the deliver-story skill to dispatch S-N.MM through the per-story-delivery orchestrator workflow.
 
 Then create a TodoWrite entry per step in the workflow. Mark each in-progress before dispatching and completed after the subagent returns.
 
 ## Input
 
-`$ARGUMENTS` — story ID (e.g., `STORY-001`)
+`$ARGUMENTS` — story ID (e.g., `S-1.01`)
 
 ## Prerequisites (check before dispatching anything)
 
@@ -54,21 +54,21 @@ For each step below, launch a **fresh subagent** via the Task tool. Pass only th
 
 ### Step 1 — Create worktree (devops-engineer)
 
-Dispatch `devops-engineer` with task: "Create worktree `.worktrees/STORY-NNN/` on branch `feature/STORY-NNN-<desc>` from `develop`."
+Dispatch `devops-engineer` with task: "Create worktree `.worktrees/S-N.MM/` on branch `feature/S-N.MM-<desc>` from `develop`."
 
 **Exit condition:** `git worktree list` shows the new worktree on the correct branch. Verify before proceeding.
 
 ### Step 2 — Generate stubs (test-writer as Stub Architect)
 
-Dispatch `test-writer` with task: "Create compilable stubs in `.worktrees/STORY-NNN/` matching the story's file list. Use `todo!()` or `unimplemented!()` bodies. Commit: `feat(STORY-NNN): add module stubs`."
+Dispatch `test-writer` with task: "Create compilable stubs in `.worktrees/S-N.MM/` matching the story's file list. Use `todo!()` or `unimplemented!()` bodies. Commit: `feat(S-N.MM): add module stubs`."
 
 **Exit condition:** `cargo check` passes inside the worktree. If it fails, dispatch a new test-writer to fix stubs — do not proceed until clean.
 
 ### Step 3 — Write failing tests (test-writer as Test Writer)
 
-Dispatch `test-writer` with task: "Write failing tests in `.worktrees/STORY-NNN/` for each acceptance criterion / BC. Commit: `test(STORY-NNN): add failing tests for <BC-ref>`."
+Dispatch `test-writer` with task: "Write failing tests in `.worktrees/S-N.MM/` for each acceptance criterion / BC. Commit: `test(S-N.MM): add failing tests for <BC-ref>`."
 
-**Red Gate (mandatory).** After dispatch returns, independently run `cd .worktrees/STORY-NNN && cargo test` and verify:
+**Red Gate (mandatory).** After dispatch returns, independently run `cd .worktrees/S-N.MM && cargo test` and verify:
 
 - Tests compile
 - All new tests fail
@@ -81,7 +81,7 @@ Record the Red Gate outcome in `.factory/cycles/<cycle-id>/<story-id>/implementa
 
 ### Step 4 — Implement (implementer)
 
-Dispatch `implementer` with task: "Implement in `.worktrees/STORY-NNN/` via TDD. For each failing test, write the minimum code to make it pass. Micro-commit per test: `feat(STORY-NNN): implement <behavior>`. Do not write code not covered by a test."
+Dispatch `implementer` with task: "Implement in `.worktrees/S-N.MM/` via TDD. For each failing test, write the minimum code to make it pass. Micro-commit per test: `feat(S-N.MM): implement <behavior>`. Do not write code not covered by a test."
 
 If the story has `implementation_strategy: gene-transfusion`, include in the task: "Read `.factory/semport/<module>/<module>-target-design.md` and the reference source files listed in the story. Use the translation strategy. Mark uncertain translations `// SEMPORT-REVIEW`."
 
@@ -89,19 +89,19 @@ If the story has `implementation_strategy: gene-transfusion`, include in the tas
 
 ### Step 5 — Record demos (demo-recorder)
 
-Dispatch `demo-recorder` with task: "Record per-AC demos in `.worktrees/STORY-NNN/docs/demo-evidence/<STORY-ID>/`. Use VHS for CLI or Playwright for web. Capture both success and error paths. Generate `docs/demo-evidence/<STORY-ID>/evidence-report.md`."
+Dispatch `demo-recorder` with task: "Record per-AC demos in `.worktrees/S-N.MM/docs/demo-evidence/<STORY-ID>/`. Use VHS for CLI or Playwright for web. Capture both success and error paths. Generate `docs/demo-evidence/<STORY-ID>/evidence-report.md`."
 
 **Exit condition:** every acceptance criterion has at least one demo artifact referenced in the evidence report.
 
 ### Step 6 — Push feature branch (implementer)
 
-Dispatch `implementer` with task: "Push `feature/STORY-NNN-<desc>` to remote origin."
+Dispatch `implementer` with task: "Push `feature/S-N.MM-<desc>` to remote origin."
 
-**Exit condition:** `git ls-remote origin feature/STORY-NNN-<desc>` returns the expected SHA.
+**Exit condition:** `git ls-remote origin feature/S-N.MM-<desc>` returns the expected SHA.
 
 ### Step 7 — PR lifecycle (pr-manager)
 
-Dispatch `pr-manager` with task: "Run the full PR process for STORY-NNN. Feature branch: `feature/STORY-NNN-<desc>`. Target: `develop`. Follow your 9-step process: populate PR description from `${CLAUDE_PLUGIN_ROOT}/templates/pr-description-template.md`, verify demo evidence, create PR via github-ops, security review, pr-reviewer convergence loop, wait for CI, dependency check, merge. Do NOT skip any step."
+Dispatch `pr-manager` with task: "Run the full PR process for S-N.MM. Feature branch: `feature/S-N.MM-<desc>`. Target: `develop`. Follow your 9-step process: populate PR description from `${CLAUDE_PLUGIN_ROOT}/templates/pr-description-template.md`, verify demo evidence, create PR via github-ops, security review, pr-reviewer convergence loop, wait for CI, dependency check, merge. Do NOT skip any step."
 
 **Do not compose the PR body yourself.** pr-manager owns the full PR lifecycle and uses its own templates. Your job here is delegation, not authorship.
 
@@ -109,15 +109,15 @@ Dispatch `pr-manager` with task: "Run the full PR process for STORY-NNN. Feature
 
 ### Step 8 — Cleanup (devops-engineer)
 
-Dispatch `devops-engineer` with task: "Remove worktree `.worktrees/STORY-NNN/` and delete local branch `feature/STORY-NNN-<desc>`."
+Dispatch `devops-engineer` with task: "Remove worktree `.worktrees/S-N.MM/` and delete local branch `feature/S-N.MM-<desc>`."
 
-**Exit condition:** `git worktree list` no longer shows the worktree; `git branch --list 'feature/STORY-NNN-*'` returns empty for this story.
+**Exit condition:** `git worktree list` no longer shows the worktree; `git branch --list 'feature/S-N.MM-*'` returns empty for this story.
 
 ### Step 9 — State update
 
 Update `.factory/stories/sprint-state.yaml`: story status → `completed`.
 Update `.factory/stories/STORY-INDEX.md`: status column for this story.
-Commit to `factory-artifacts` branch: `factory(phase-3): STORY-NNN delivered`.
+Commit to `factory-artifacts` branch: `factory(phase-3): S-N.MM delivered`.
 
 ## Context Discipline for Dispatches
 
@@ -220,7 +220,7 @@ Stop and check yourself if you find yourself thinking any of these:
 Tell the user:
 
 ```
-Story STORY-NNN delivered:
+Story S-N.MM delivered:
   Red Gate:       PASSED (see .factory/cycles/<cycle-id>/<story-id>/implementation/red-gate-log.md)
   Implementation: <N> micro-commits
   Demos:          <N> artifacts in docs/demo-evidence/<STORY-ID>/

--- a/plugins/vsdd-factory/skills/phase-1-prd-revision/SKILL.md
+++ b/plugins/vsdd-factory/skills/phase-1-prd-revision/SKILL.md
@@ -10,10 +10,10 @@ agents:
 inputs:
   - .factory/specs/architecture-feasibility-report.md
   - .factory/specs/prd.md
-  - .factory/specs/behavioral-contracts/
+  - .factory/specs/behavioral-contracts/         # sharded into ss-NN/ subdirs
 outputs:
   - .factory/specs/prd.md (updated)
-  - .factory/specs/behavioral-contracts/ (updated)
+  - .factory/specs/behavioral-contracts/ss-NN/   # updated BCs in their shards
 gate: Architect approves or max 3 iterations reached
 ---
 

--- a/plugins/vsdd-factory/skills/phase-f3-incremental-stories/SKILL.md
+++ b/plugins/vsdd-factory/skills/phase-f3-incremental-stories/SKILL.md
@@ -30,9 +30,9 @@ Read all existing story specs from `.factory/stories/`:
 ### Step 2: Decompose Feature into Stories
 
 Spawn `story-writer` agent to:
-- Break the PRD delta into implementable per-file stories (STORY-NNN.md)
+- Break the PRD delta into implementable per-file stories (`S-N.MM-<short>.md`)
 - Each story covers one logical unit of work
-- Continue the story ID sequence (if last is STORY-005, new ones start at STORY-006)
+- Continue the story ID sequence within the appropriate section (if the last story in section N is `S-N.05`, new ones start at `S-N.06`; new sections begin at `S-N.01`)
 - Each story must reference:
   - The new/modified behavioral contracts (BC-S.SS.NNN format, DF-020)
   - The verification properties it must uphold (VP-NNN)
@@ -41,7 +41,7 @@ Spawn `story-writer` agent to:
   - Implementation strategy: tdd or gene-transfusion
 
 Use `templates/story-template.md` for each story.
-Write each story as a separate per-file STORY-NNN.md (not monolithic).
+Write each story as a separate per-file `S-N.MM-<short>.md` (not monolithic).
 
 ### Step 3: Dependency Graph Extension
 

--- a/plugins/vsdd-factory/skills/phase-f3-incremental-stories/steps/step-02-decompose-feature.md
+++ b/plugins/vsdd-factory/skills/phase-f3-incremental-stories/steps/step-02-decompose-feature.md
@@ -13,7 +13,7 @@ Spawn `product-owner` agent to break the PRD delta into implementable stories.
 1. Spawn `product-owner` agent
 2. Break the PRD delta into implementable stories
 3. Each story covers one logical unit of work
-4. Continue the story ID sequence (if last is STORY-005, new ones start at STORY-006)
+4. Continue the story ID sequence within the appropriate section (if the last story in section N is `S-N.05`, new ones start at `S-N.06`)
 5. Each story must reference:
    - The new/modified behavioral contracts it satisfies (BC-S.SS.NNN format, DF-020)
    - The verification properties it must uphold (VP-NNN)

--- a/plugins/vsdd-factory/skills/register-artifact/SKILL.md
+++ b/plugins/vsdd-factory/skills/register-artifact/SKILL.md
@@ -20,9 +20,11 @@ Parse `$ARGUMENTS` for the file path. Determine the artifact type from the path:
 
 | Path Pattern | Type | INDEX File |
 |-------------|------|------------|
-| `behavioral-contracts/BC-*.md` | Behavioral Contract | `behavioral-contracts/BC-INDEX.md` |
+| `behavioral-contracts/ss-NN/BC-*.md` (canonical, sharded) | Behavioral Contract | `behavioral-contracts/BC-INDEX.md` |
+| `behavioral-contracts/BC-*.md` (legacy flat layout) | Behavioral Contract | `behavioral-contracts/BC-INDEX.md` |
 | `verification-properties/VP-*.md` | Verification Property | `verification-properties/VP-INDEX.md` |
-| `stories/STORY-*.md` | Story | `stories/STORY-INDEX.md` |
+| `stories/S-*.md` (canonical, S-N.MM format) | Story | `stories/STORY-INDEX.md` |
+| `stories/STORY-*.md` (legacy STORY-NNN format) | Story | `stories/STORY-INDEX.md` |
 | `holdout-scenarios/HS-*.md` | Holdout Scenario | `holdout-scenarios/HS-INDEX.md` |
 
 If the path doesn't match any pattern, report: "Unrecognized artifact type. This skill registers BCs, VPs, stories, and holdout scenarios."
@@ -90,7 +92,7 @@ Add a new row to the INDEX table matching the existing format:
 
 **STORY-INDEX row:**
 ```
-| STORY-NNN | <title> | <epic_id> | <points> | <priority> | <depends_on> | <status> |
+| S-N.MM | <title> | <epic_id> | <points> | <priority> | <depends_on> | <status> |
 ```
 
 **HS-INDEX row:**
@@ -115,7 +117,7 @@ If `$ARGUMENTS` contains multiple file paths (space-separated), process each one
 Registered N artifacts:
   - BC-2.01.005 → BC-INDEX.md
   - BC-2.01.006 → BC-INDEX.md
-  - STORY-042 → STORY-INDEX.md
+  - S-3.05 → STORY-INDEX.md
 Skipped 1 (already registered):
   - BC-2.01.001
 ```

--- a/plugins/vsdd-factory/skills/spec-drift/SKILL.md
+++ b/plugins/vsdd-factory/skills/spec-drift/SKILL.md
@@ -16,7 +16,7 @@ Compare what was specified against what was built. Find divergences.
 
 Read all spec documents:
 - `.factory/specs/prd.md`
-- `.factory/specs/behavioral-contracts/*`
+- `.factory/specs/behavioral-contracts/**/*.md` (recursive — BCs are sharded into `ss-NN/` directories)
 - `.factory/specs/verification-properties/*`
 - `.factory/specs/architecture/*`
 - `.factory/specs/prd-supplements/*`

--- a/plugins/vsdd-factory/skills/spec-versioning/SKILL.md
+++ b/plugins/vsdd-factory/skills/spec-versioning/SKILL.md
@@ -71,7 +71,7 @@ Every implementation commit message references the spec version:
 ```
 feat(notifications): add delivery engine
 
-Implements STORY-008.
+Implements S-1.08.
 Spec version: 1.3.0
 ```
 
@@ -99,9 +99,9 @@ Current spec version: 1.4.0
 
 | Story | Built Against | Drift | Severity | Action Needed |
 |-------|--------------|-------|----------|---------------|
-| STORY-001 | 1.0.0 | 4 minor | LOW | Review new reqs for overlap |
-| STORY-003 | 1.1.0 | 3 minor | LOW | Review new reqs for overlap |
-| STORY-010 | 1.2.0 | 1 major, 1 minor | HIGH | Mandatory review |
+| S-1.01 | 1.0.0 | 4 minor | LOW | Review new reqs for overlap |
+| S-1.03 | 1.1.0 | 3 minor | LOW | Review new reqs for overlap |
+| S-1.10 | 1.2.0 | 1 major, 1 minor | HIGH | Mandatory review |
 ```
 
 ### When to Run Drift Detection

--- a/plugins/vsdd-factory/templates/behavioral-contract-template.md
+++ b/plugins/vsdd-factory/templates/behavioral-contract-template.md
@@ -28,8 +28,15 @@ removal_reason: null             # why removed
 # Behavioral Contract BC-S.SS.NNN: [Title]
 
 > **One-per-file:** Each behavioral contract lives in its own file.
-> Filename convention: `BC-S.SS.NNN.md` (e.g., `BC-2.3.045.md`)
-> Numbering: BC-S.SS.NNN where S = PRD section, SS = subsection (L2 subsystem), NNN = sequential.
+> Filename: `BC-S.SS.NNN.md` (e.g., `BC-2.03.045.md`)
+> Path: `.factory/specs/behavioral-contracts/ss-NN/BC-S.SS.NNN.md`
+> BCs are sharded into per-subsystem directories. The shard directory name is
+> the bare `SS-NN` identifier in lowercase (e.g., `ss-01/`, `ss-02/`) — NOT
+> the descriptive subsystem name. Subsystem descriptive names live
+> authoritatively in ARCH-INDEX Subsystem Registry and in the
+> `architecture/SS-NN-<name>.md` section files.
+> Numbering: BC-S.SS.NNN where S = PRD section, SS = subsection (L2 subsystem,
+> matches the shard `ss-NN` directory), NNN = sequential.
 
 ## Description
 
@@ -85,7 +92,7 @@ when scanning BC-INDEX or reviewing anchor justifications.]
 | L2 Capability | CAP-NNN |
 | L2 Domain Invariants | DI-NNN (if applicable) |
 | Architecture Module | [module name] (filled by architect) |
-| Stories | STORY-NNN (filled by story-writer) |
+| Stories | S-N.MM (filled by story-writer) |
 
 ## Related BCs (Recommended)
 
@@ -103,7 +110,7 @@ when scanning BC-INDEX or reviewing anchor justifications.]
 
 <!-- v1.1: Added for direct link to implementing story. -->
 
-[STORY-NNN] — [short story title]
+[S-N.MM] — [short story title]
 
 ## VP Anchors (Recommended)
 

--- a/plugins/vsdd-factory/templates/epic-index-template.md
+++ b/plugins/vsdd-factory/templates/epic-index-template.md
@@ -13,14 +13,17 @@ traces_to: prd.md
 # Epic Index
 
 > Epics group related stories for wave scheduling and dependency management.
-> EPIC-NNN IDs are lifecycle-scoped (append-only, never reused).
+> Epic IDs use `E-N` format (single digit, append-only, never reused).
+> Epic `E-N` directly contains all stories with `story_id: S-N.*` (i.e.,
+> story section number matches epic number — `E-3` contains all `S-3.*`).
+> Filename: `E-N-<short-description>.md` under `.factory/stories/epics/`.
 
 | Epic ID | Title | Stories | Priority | Status |
 |---------|-------|---------|----------|--------|
-| EPIC-001 | [title] | STORY-001, STORY-002 | P0/P1/P2 | active / complete |
+| E-1 | [title] | S-1.01, S-1.02 | P0/P1/P2 | active / complete |
 
 ## Epic-to-Capability Mapping
 
 | Epic ID | Capabilities (CAP-NNN) | Subsystems (SS-NN) |
 |---------|----------------------|-------------------|
-| EPIC-001 | CAP-001, CAP-002 | SS-01 |
+| E-1 | CAP-001, CAP-002 | SS-01 |

--- a/plugins/vsdd-factory/templates/prd-template.md
+++ b/plugins/vsdd-factory/templates/prd-template.md
@@ -70,27 +70,29 @@ supplements: [interface-definitions.md, error-taxonomy.md, test-vectors.md, nfr-
 
 ## 2. Behavioral Contracts Index
 
-> Individual BC files live in the `behavioral-contracts/` directory.
+> Individual BC files live in `behavioral-contracts/ss-NN/` shard directories,
+> one shard per subsystem registered in ARCH-INDEX.
 > Grouped by L2 domain subsystem (CAP-NNN).
 > Each BC uses hierarchical numbering: BC-S.SS.NNN where S = section,
-> SS = subsection (matching L2 subsystem), NNN = sequential within subsystem.
+> SS = subsection (matching L2 subsystem; matches the shard `ss-NN` directory),
+> NNN = sequential within subsystem.
 
 ### 2.1 [Subsystem Name] (CAP-001)
 
 | BC ID | Title | Priority |
 |-------|-------|----------|
-| BC-2.1.001 | [one-line summary] | P0 |
-| BC-2.1.002 | [one-line summary] | P1 |
+| BC-2.01.001 | [one-line summary] | P0 |
+| BC-2.01.002 | [one-line summary] | P1 |
 
-> Full contracts: `behavioral-contracts/BC-2.1.001.md`, `behavioral-contracts/BC-2.1.002.md`
+> Full contracts: `behavioral-contracts/ss-01/BC-2.01.001.md`, `behavioral-contracts/ss-01/BC-2.01.002.md`
 
 ### 2.2 [Subsystem Name] (CAP-002)
 
 | BC ID | Title | Priority |
 |-------|-------|----------|
-| BC-2.2.001 | [one-line summary] | P0 |
+| BC-2.02.001 | [one-line summary] | P0 |
 
-> Full contract: `behavioral-contracts/BC-2.2.001.md`
+> Full contract: `behavioral-contracts/ss-02/BC-2.02.001.md`
 
 ### 2.N [Subsystem Name] (CAP-NNN)
 

--- a/plugins/vsdd-factory/templates/review-findings-template.md
+++ b/plugins/vsdd-factory/templates/review-findings-template.md
@@ -1,13 +1,13 @@
 ---
 document_type: pr-review-findings
-story_id: STORY-NNN
+story_id: S-N.MM
 pr_number: {PR_NUMBER}
 status: "{converged|in-review|escalated}"
 producer: pr-manager
 timestamp: "{YYYY-MM-DDTHH:MM:SS}"
 ---
 
-# PR Review Findings: STORY-NNN (PR #{PR_NUMBER})
+# PR Review Findings: S-N.MM (PR #{PR_NUMBER})
 
 ## Convergence Summary
 

--- a/plugins/vsdd-factory/templates/story-index-template.md
+++ b/plugins/vsdd-factory/templates/story-index-template.md
@@ -17,13 +17,18 @@ traces_to: prd.md
 
 | Story ID | Title | Epic | Points | Priority | Depends On | Status |
 |----------|-------|------|--------|----------|------------|--------|
-| STORY-001 | [title] | EPIC-001 | [1-13] | P0/P1/P2 | -- | draft |
-| STORY-002 | [title] | EPIC-001 | [1-13] | P0/P1/P2 | STORY-001 | draft |
+| S-1.01 | [title] | E-1 | [1-13] | P0/P1/P2 | -- | draft |
+| S-1.02 | [title] | E-1 | [1-13] | P0/P1/P2 | S-1.01 | draft |
 
 **Status values:** draft, ready, in-progress, merged, blocked
 
+**ID format:**
+- Stories: `S-N.MM` where `N` is the section/epic grouping (single digit) and `MM` is the zero-padded story number within that section. Examples: `S-1.01`, `S-3.15`.
+- Epics: `E-N` where `N` matches the section number used by stories. Epic `E-3` directly contains all `S-3.*` stories.
+- Story `N` (section/epic) and BC `S` (subsystem number in BC-S.SS.NNN) are intentionally different hierarchies — a story can implement BCs from multiple subsystems.
+
 **Rules:**
-- Every story must have a unique sequential ID (append-only numbering, Policy 1)
+- Every story must have a unique ID within its section (append-only numbering, Policy 1)
 - Points must be 1-13 (no story exceeds 13 points)
 - Dependencies must be acyclic (topological sort)
 - P0 stories must not depend on P1/P2 stories

--- a/plugins/vsdd-factory/templates/story-template.md
+++ b/plugins/vsdd-factory/templates/story-template.md
@@ -1,8 +1,8 @@
 ---
 document_type: story
 level: ops
-story_id: "STORY-NNN"
-epic_id: "EPIC-NNN"
+story_id: "S-N.MM"
+epic_id: "E-N"
 version: "1.1"
 status: draft
 producer: story-writer
@@ -29,15 +29,21 @@ assumption_validations: []     # ASM-NNN IDs this story validates
 risk_mitigations: []           # R-NNN IDs this story mitigates
 ---
 
-> **Execute:** `/vsdd-factory:deliver-story STORY-NNN`
+> **Execute:** `/vsdd-factory:deliver-story S-N.MM`
 
-# STORY-NNN: [Title]
+# S-N.MM: [Title]
 
 > **One-per-file:** Each story lives in its own file.
-> Filename convention: `STORY-NNN-[short-description].md`
+> Filename convention: `S-N.MM-[short-description].md` (e.g., `S-1.01-foundational-types.md`).
+> Story IDs use `S-N.MM` format where `N` is the section/epic-grouping (single digit,
+> matches the parent epic `E-N`) and `MM` is the zero-padded story number within that
+> section (e.g., `S-3.05` = section 3, story 5).
+> Story `N` (section/epic) and BC `S` (subsystem number in BC-S.SS.NNN) are
+> intentionally different hierarchies — a story can implement BCs from multiple
+> subsystems via the `subsystems: [SS-NN, ...]` frontmatter array.
 > The story-writer produces individual files under `.factory/stories/`
 > and a companion `STORY-INDEX.md` listing all stories with status and dependencies.
-> Story numbering is continuous across cycles -- no resets (DF-030).
+> Story numbering is append-only across cycles within a section -- no resets (DF-030).
 
 ## Narrative
 - **As a** [actor]
@@ -136,7 +142,7 @@ Target: <= 20-30% of agent context window. If over budget, split the story.
 
 | Story | Key Decisions | Patterns Established | Gotchas Discovered |
 |-------|--------------|---------------------|-------------------|
-| [STORY-NNN] | [decisions made] | [patterns to follow] | [pitfalls to avoid] |
+| [S-N.MM] | [decisions made] | [patterns to follow] | [pitfalls to avoid] |
 
 _Populated by the story-writer from completed stories in the same epic.
 Each new story carries forward lessons from its predecessors to prevent

--- a/plugins/vsdd-factory/templates/tech-debt-register-template.md
+++ b/plugins/vsdd-factory/templates/tech-debt-register-template.md
@@ -19,7 +19,7 @@ last_updated: YYYY-MM-DDTHH:MM:SS
 
 | ID | Source | Description | Priority | Introduced | Cycle | Story | Due |
 |----|--------|-------------|----------|-----------|-------|-------|-----|
-| TD-001 | [source type] | [description] | P0/P1/P2 | vX.Y.Z | [cycle-id] | STORY-NNN or — | vX.Y.Z or — |
+| TD-001 | [source type] | [description] | P0/P1/P2 | vX.Y.Z | [cycle-id] | S-N.MM or — | vX.Y.Z or — |
 
 ### Source Types
 
@@ -38,7 +38,7 @@ last_updated: YYYY-MM-DDTHH:MM:SS
 
 | ID | Resolved In | Story | Resolution |
 |----|------------|-------|------------|
-| TD-NNN | vX.Y.Z | STORY-NNN | [how it was resolved] |
+| TD-NNN | vX.Y.Z | S-N.MM | [how it was resolved] |
 
 ## Tech Debt as Feature Mode Cycles
 

--- a/plugins/vsdd-factory/templates/traceability-matrices-template.md
+++ b/plugins/vsdd-factory/templates/traceability-matrices-template.md
@@ -19,40 +19,40 @@ traces_to: STORY-INDEX.md
 
 | BC-S.SS.NNN | Stories | Full Coverage? |
 |-------------|---------|---------------|
-| BC-2.1.001 | STORY-003, STORY-005 | Yes |
+| BC-2.01.001 | S-1.03, S-1.05 | Yes |
 
 ## VP to Stories Matrix
 
 | VP-NNN | Stories Exercising It | BC Source |
 |--------|----------------------|-----------|
-| VP-001 | STORY-003 | BC-2.1.001 |
+| VP-001 | S-1.03 | BC-2.01.001 |
 
 ## NFR to Stories Matrix
 
 | NFR-NNN | Stories Implementing It | Validation Method |
 |---------|------------------------|-------------------|
-| NFR-001 | STORY-007 | Benchmark: 1000 files in ≤2s |
+| NFR-001 | S-2.07 | Benchmark: 1000 files in ≤2s |
 
 ## BC Clause Coverage Matrix
 
 | BC-S.SS.NNN | Clause | Type | Covering AC | Story |
 |-------------|--------|------|-------------|-------|
-| BC-2.1.001 | 1 | precondition | AC-003 | STORY-005 |
-| BC-2.1.001 | 2 | postcondition | AC-001 | STORY-003 |
-| BC-2.1.001 | 3 | postcondition | -- | GAP-001 (justified) |
+| BC-2.01.001 | 1 | precondition | AC-003 | S-1.05 |
+| BC-2.01.001 | 2 | postcondition | AC-001 | S-1.03 |
+| BC-2.01.001 | 3 | postcondition | -- | GAP-001 (justified) |
 
 ## Edge Case Coverage Matrix
 
 | Source | EC/Error ID | Description | Story | AC/EC Reference |
 |--------|-------------|-------------|-------|----------------|
-| BC-2.1.001 | EC-001 | Malformed input | STORY-005 | EC-003 |
-| error-taxonomy | E-val-001 | Validation failure | STORY-003 | AC-007 |
+| BC-2.01.001 | EC-001 | Malformed input | S-1.05 | EC-003 |
+| error-taxonomy | E-val-001 | Validation failure | S-1.03 | AC-007 |
 
 ## Gap Register
 
 | Gap ID | Level | Source | Clause/Item | Justification | Resolution Target |
 |--------|-------|--------|-------------|---------------|-------------------|
-| GAP-001 | L1 | BC-2.1.001 postcondition 3 | [min 10 chars justification] | v2.0.0 |
+| GAP-001 | L1 | BC-2.01.001 postcondition 3 | [min 10 chars justification] | v2.0.0 |
 
 **Level:** L1 (BC clause) / L2 (edge case or error) / L3 (NFR, holdout, UI state)
 

--- a/plugins/vsdd-factory/templates/traceability-matrix-template.md
+++ b/plugins/vsdd-factory/templates/traceability-matrix-template.md
@@ -17,7 +17,7 @@ traces_to: ""
 
 | L1 Section | L2 CAP-NNN | L3 BC-S.SS.NNN | NFR-NNN | Story | AC-NNN | Test | Source File | VP-NNN | Proof Status |
 |------------|-----------|----------------|---------|-------|--------|------|------------|--------|-------------|
-| [section ref] | CAP-001 | BC-1.01.001 | NFR-001 | STORY-001 | AC-001 | test_BC_1_01_001_xxx | src/module.rs | VP-001 | [proven/pending/withdrawn] |
+| [section ref] | CAP-001 | BC-1.01.001 | NFR-001 | S-1.01 | AC-001 | test_BC_1_01_001_xxx | src/module.rs | VP-001 | [proven/pending/withdrawn] |
 
 ## Reverse Traceability (Proof → L1)
 

--- a/plugins/vsdd-factory/templates/wave-schedule-template.md
+++ b/plugins/vsdd-factory/templates/wave-schedule-template.md
@@ -27,8 +27,8 @@ traces_to: STORY-INDEX.md
 
 | Group | Stories | Points | Complexity | Agent Scope |
 |-------|---------|--------|-----------|-------------|
-| A | STORY-001, STORY-002 | 3, 5 | S, M | 2 stories/agent |
-| B | STORY-003 | 13 | XL | 1 story/agent |
+| A | S-1.01, S-1.02 | 3, 5 | S, M | 2 stories/agent |
+| B | S-1.03 | 13 | XL | 1 story/agent |
 
 ### Wave 2 (depends on Wave 1)
 


### PR DESCRIPTION
# [FIX-CANON-001] Canonicalize Identifier Conventions Across Plugin Source

**Cycle:** v1.0-brownfield-backfill
**Type:** Maintenance / Refactor (no story ID — plugin meta-canonicalization)
**Mode:** brownfield-onboarding (vsdd-factory dogfooding itself)
**Convergence:** Phase 1 of 2 — 26 files updated; remaining ~5 file types flagged for follow-up PR

![Type](https://img.shields.io/badge/type-refactor-blue)
![Files](https://img.shields.io/badge/files-26%20modified-yellow)
![Tests](https://img.shields.io/badge/tests-not%20applicable-lightgrey)
![Coverage](https://img.shields.io/badge/coverage-docs%2Fschema%20only-lightgrey)

Aligns vsdd-factory plugin templates, skills, and rules with the canonical identifier conventions used by **prism** (the working real-world consumer of this plugin) and decided during vsdd-factory's own brownfield onboarding cycle. Three coupled changes: (1) sharded BC layout, (2) `S-N.MM` story IDs, (3) `E-N` epic IDs.

---

## Architecture Changes

```mermaid
graph TD
    Old["Plugin Source v1.0.0-beta.4<br/>flat BC layout, STORY-NNN, EPIC-NNN"]
    New["Plugin Source post-PR<br/>sharded BC layout, S-N.MM, E-N"]

    Old -->|"behavioral-contract-template.md"| Sharding["+ Shard Convention<br/>behavioral-contracts/ss-NN/BC-S.SS.NNN.md"]
    Old -->|"story-template.md<br/>story-index-template.md"| StoryFmt["S-N.MM<br/>(section.story zero-padded)"]
    Old -->|"epic-index-template.md"| EpicFmt["E-N<br/>(single-digit, matches story section)"]
    Sharding --> New
    StoryFmt --> New
    EpicFmt --> New

    style Old fill:#FFB6C1
    style New fill:#90EE90
```

<details>
<summary><strong>Architecture Decision Record</strong></summary>

### ADR-CANON: Adopt prism-style identifier conventions as plugin canonical

**Context:** vsdd-factory shipped v1.0.0-beta.4 with templates teaching `STORY-NNN`/`EPIC-NNN`/flat-BC-layout. Meanwhile, **prism** (the only working real-world consumer of the plugin) uses `S-N.MM`/`E-N` and would benefit from a sharded BC layout if its catalog grew. vsdd-factory's own brownfield onboarding produced **1,851 BCs across 10 subsystems** — the flat layout was unbrowsable.

**Decision:** Update plugin source to teach prism's conventions. Sharded BC layout becomes mandatory pattern (`ss-NN/`); story IDs use `S-N.MM`; epic IDs use `E-N`. Document the intentional separation between BC `S` (subsystem number) and story `N` (epic/release-milestone grouping).

**Rationale:**
- Section grouping (`S-3.05`) gives semantic richness `STORY-042` lacks
- `E-3` directly contains `S-3.*` stories (no separate mapping needed)
- Sharded BC layout scales beyond ~50 BCs (essential at 1,851)
- Aligns plugin with what prism already proves works

**Alternatives Considered:**
1. **Keep `STORY-NNN`** — rejected: prism deviated for good reasons; templates should match real-world usage
2. **Keep flat BC layout** — rejected: doesn't scale; vsdd-factory's own onboarding broke at flat
3. **Add new format alongside old** — rejected: doubles cognitive load; no path to consolidation

**Consequences:**
- (+) Future consumers learn the proven convention from day one
- (+) Eliminates the prism-vs-templates inconsistency
- (-) Existing pre-rc.1 projects using `STORY-NNN` continue to work (no runtime enforcement) but should migrate
- Scope: 26 files modified; ~5 file types deferred to phase-2 follow-up

</details>

---

## Coupled Changes

| Change | Old | New | Rationale |
|--------|-----|-----|-----------|
| BC shard layout | `behavioral-contracts/BC-S.SS.NNN.md` (flat) | `behavioral-contracts/ss-NN/BC-S.SS.NNN.md` (sharded) | Scales beyond 50 BCs |
| Story IDs | `STORY-NNN` | `S-N.MM` (section.story zero-padded) | Section grouping, denser, prism-aligned |
| Epic IDs | `EPIC-NNN` | `E-N` | Matches story section number |

### Hierarchy clarification (now documented in `rules/spec-format.md`)

Story `N` (section/epic) and BC `S` (subsystem number) are **intentionally different hierarchies**:
- BC `S` = subsystem number (BC-1.* belongs to SS-01)
- Story `N` = epic/release-milestone grouping (S-1.* belongs to E-1)
- A story can implement BCs from multiple subsystems via `subsystems: [SS-NN, ...]` frontmatter

---

## Files Modified (26)

```mermaid
flowchart LR
    Templates["10 templates<br/>(behavioral-contract, story,<br/>story-index, epic-index, prd,<br/>review-findings, traceability,<br/>tech-debt, wave-schedule)"]
    Rules["2 rules<br/>(spec-format, worktree-protocol)"]
    Skills["12 skills<br/>(create-story, decompose-stories,<br/>create-prd, create-architecture,<br/>register-artifact, spec-drift,<br/>phase-1-prd-revision,<br/>consistency-validation, deliver-story,<br/>check-input-drift, spec-versioning,<br/>phase-f3-incremental-stories)"]

    Templates --> NewConventions["Canonical Identifier Conventions<br/>S-N.MM / E-N / ss-NN/"]
    Rules --> NewConventions
    Skills --> NewConventions
```

---

## Spec Traceability

This PR has no behavioral contracts of its own (it modifies the plugin source, not the product). It implicates:

| Affected Spec | Source File | Effect |
|---------------|------------|--------|
| Plugin schema | `rules/spec-format.md` | New section: BC shard layout + story/epic ID grammar |
| BC template | `templates/behavioral-contract-template.md` | Filename convention updated to shard path |
| Story template | `templates/story-template.md` | story_id format `S-N.MM`; filename convention updated |
| Epic template | `templates/epic-index-template.md` | epic_id format `E-N` |

Downstream impact (verified manually — no automated traceability yet for plugin meta-changes):
- prism continues to work — already uses these conventions
- Existing v1.0.0-beta.4 consumers continue to work — no runtime enforcement of ID format

---

## Test Evidence

### Validation summary

| Check | Status | Notes |
|-------|--------|-------|
| `grep -rn STORY-NNN plugins/vsdd-factory/` (expected: low) | 5 remaining | All in tests/*.bats fixtures, workflows/*.lobster, docs/FACTORY.md — flagged for Phase 2 |
| `grep -rn EPIC-NNN plugins/vsdd-factory/` (expected: low) | 2 remaining | docs/FACTORY.md, holdout-scenario-template — flagged for Phase 2 |
| `grep -rn 'behavioral-contracts/BC-' plugins/vsdd-factory/` (expected: 0 in templates) | 5 remaining | All in tests/*.bats — flagged for Phase 2 |
| Plugin templates use new conventions | ✅ | All 10 templates updated |
| Rules document new conventions | ✅ | spec-format.md updated |
| Skills use new conventions | ✅ | 12 skills updated |
| `validate-template-compliance` hook unchanged | ✅ | Hook greps `document_type`, not ID format — no enforcement change |
| prism-style sample diff verified | ✅ | story-template.md diff matches prism's `story_id: S-1.01` pattern |

### What this PR does NOT change

- **No runtime enforcement of new format** — `validate-template-compliance.sh` hooks document_type, not ID grammar. Pre-rc.1 projects with `STORY-NNN` still work.
- **No migration tooling** — projects upgrading should manually rename. Future task: write a migration skill.

---

## Phase 2 Follow-up

Files with remaining stale references that need a Phase 2 PR:

- `tests/*.bats`: 3 fixtures (`STORY-001-good.md`, `STORY-002-bad-subsystem.md`, `STORY-003-bad-sync.md`) need rename + bats `printf` updates (`hook-robustness.bats`, `policy-enforcement.bats`)
- `workflows/*.lobster`: 5 lobster files have `story_id: STORY-NNN` placeholders (greenfield, code-delivery, phase-2-story-decomposition, finding-format, corpus-lint)
- `docs/FACTORY.md`: EPIC-NNN cross-reference
- `templates/holdout-scenario-template.md`: EPIC-NNN reference
- `agents/{story-writer,product-owner,architect}.md`: ID-format awareness pass

These were deferred because they're a separate concern (test fixtures vs schema docs) and reduce PR size for review.

---

## Test Plan

- [ ] PR reviewer confirms 3 coupled changes are correctly applied
- [ ] PR reviewer verifies no `validate-template-compliance` regression (hook unchanged)
- [ ] Manual smoke test: open a fresh story-writer agent, confirm it generates `S-N.MM` format
- [ ] Manual smoke test: open create-story skill, confirm argument-hint shows `[S-N.MM]`
- [ ] Phase 2 PR opened to address the 5 deferred file types
- [ ] Plugin release v1.0.0-rc.1 includes both phase 1 + phase 2 of canonicalization

---

## Migration path for existing consumers

This PR will ship in plugin v1.0.0-rc.1. Pre-rc.1 projects using `STORY-NNN` are still readable (no runtime enforcement). New projects should use `S-N.MM` from the start. Sharded BC layout is mandatory for new projects (recommended at 50+ BCs).

---

## Related

- Discovered during vsdd-factory's own brownfield onboarding (cycle `v1.0-brownfield-backfill`, see `.factory/cycles/v1.0-brownfield-backfill/INDEX.md`)
- vsdd-factory's `.factory/` already uses these conventions (committed in `63e3a3f`, `f344b56`, `5aadf49`)
- prism reference convention: `../prism/.factory/stories/STORY-INDEX.md`