### PR TITLE
release: v1.0.0-beta.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,110 @@
 # Changelog
 
+## 1.0.0-beta.6 — S-6.01 create-adr skill + E-7 process codification (2026-04-26)
+
+This release ships two CONVERGED feature deliveries (S-6.01 + E-7) plus
+substantial spec backfill (10 ADRs, 27 BCs, 5 VPs, 2 FRs, 2 epics, 3 stories).
+The standout meta-property is self-referential dogfooding: vsdd-factory used
+its own VSDD process to find and codify gaps in vsdd-factory itself.
+
+### Added
+
+- **`/vsdd-factory:create-adr` skill (S-6.01).** Closes the per-artifact
+  `create-*` skill family gap (alongside `create-prd`, `create-story`,
+  `create-architecture`, `create-domain-spec`, `create-brief`). Scaffolds
+  new ADR records with: collision-free ID allocation against `decisions/`
+  filesystem AND ARCH-INDEX, frontmatter from `templates/adr-template.md`
+  with `status=proposed` always at creation, optional bidirectional
+  supersession patch (new ADR `supersedes:` ↔ old ADR `superseded_by:`),
+  ARCH-INDEX row insertion in numeric order, optional `--brownfield`
+  annotation, optional `--dry-run` flag, atomic-or-nothing rollback on
+  any failure. Spec converged through 8 adversarial passes (trajectory
+  19 → 4 → 2 → 1 → 1 → 0 → 0 → 0); 26 bats tests cover 8 ACs, 12 BCs
+  (BC-6.20.001-012), 3 VPs (VP-058/059/060).
+- **Process codification (E-7) — 8 lessons codified into plugin source:**
+  - **Spec-First Gate** in `agents/story-writer.md`: blocks
+    `status=ready` without canonical `BC-N.NN.NNN` pattern in
+    `behavioral_contracts:` and AC↔BC bidirectional traces.
+    (BC-5.36.001-002)
+  - **Capability Anchor Justification** in `agents/product-owner.md`:
+    every BC must verbatim-cite `capabilities.md` for its CAP.
+    (BC-5.36.003-004)
+  - **Partial-Fix-Regression discipline** in `agents/adversary.md`:
+    every pass after pass-1 checks prior-pass fix propagation to
+    bodies, sibling files, prose; flags `[process-gap]` for
+    codification follow-up. (BC-5.36.005-006)
+  - **Defensive Sweep discipline** in `agents/state-manager.md`:
+    corpus-wide grep before declaring count-changing update complete.
+    (BC-5.37.001-002)
+  - **Cycle-Closing Checklist** in `agents/orchestrator/orchestrator.md`:
+    references `rules/lessons-codification.md` before declaring
+    sub-cycle CONVERGED. (BC-8.28.002)
+  - **NEW hook `validate-count-propagation.sh`** (BC-7.05.001-002):
+    PostToolUse drift detector across PRD / STATE.md / ARCH-INDEX /
+    BC-INDEX / VP-INDEX. Exits 2 on drift, runs <500ms.
+  - **NEW rule `rules/lessons-codification.md`** (BC-8.28.001):
+    meta-discipline — every novel adversary process catch (not content
+    defect) MUST trigger codification follow-up before sub-cycle closure.
+  - **`validate-template-compliance.sh` extended** (BC-7.05.003) to
+    enforce VP multi-BC `source_bc=primary, bcs[]=full list` convention.
+  - **`hooks-registry.toml`** registers new hook (BC-7.05.004).
+
+  Spec converged through 7 adversarial passes (trajectory
+  12 → 5 → 1 → 2 → 2 → 0 → 0); 16 bats tests cover both stories.
+- **Spec backfill — 10 ADRs (ADR-004..013):** TOML config; multi-sink
+  observability natively in dispatcher; HOST_ABI_VERSION as separate
+  semver constant; always-on dispatcher self-telemetry;
+  parallel-within-tier sequential-between-tier execution;
+  activation-skill-driven platform binary selection; StoreData-typed
+  linker for host functions; dual hooks.json + hooks-registry.toml
+  during migration; legacy-bash-adapter as universal current router;
+  cycle-keyed adversarial review structure.
+- **27 new behavioral contracts** across SS-05/06/07/08 (12 for
+  create-adr, 15 for E-7 codification surfaces).
+- **5 new verification properties** (VP-058..062 — atomicity, ID
+  monotonicity proptest, bidirectional supersession, agent prompt
+  static-check, multi-axis process-codification surface invariant).
+- **2 new functional requirements** (FR-041, FR-042).
+- **2 new epics** (E-6 VSDD Self-Improvement / Tooling Backlog;
+  E-7 Process Codification — Self-Improvement).
+- **L4-verification-property-template.md schema note** pinning
+  `source_bc=primary, bcs[]=full list` convention for multi-BC VPs.
+
+### Fixed
+
+- **`validate-novelty-assessment.sh` false-positive on filename matchers.**
+  Hook was matching `ADR-013-adversarial-review-structure.md` as a
+  review file. Tightened the matcher to anchor on
+  `.factory/cycles/<key>/adversarial-reviews/` directory paths; added
+  explicit skip for `*/architecture/decisions/ADR-*.md`.
+
+### Process Notes
+
+The pass-4 reset on the e7-spec sub-cycle (F-020 SS-09 mis-citation
+across two artifacts) was BC-5.36.005/006 partial-fix-regression
+discipline working as designed: a fresh-perspective adversary caught
+a 2-artifact mis-citation that 3 prior passes missed. The pass-1
+review of E-7 specs caught a meta dogfood failure: PRD body still
+cited "1,863-BC catalog" while the new BCs were being authored to
+codify the very defensive-sweep tooling that detects this drift class.
+Cumulative findings closed: 27 across 15 spec passes total.
+
+### Identifier Counts (post-release)
+
+| Type | Pre-beta.6 | Post-beta.6 |
+|------|-----------|-------------|
+| BCs (total) | 1,851 | 1,878 (+27) |
+| VPs | 57 | 62 (+5) |
+| FRs | 40 | 42 (+2) |
+| Epics | 6 | 8 (+2) |
+| Stories | 41 | 44 (+3) |
+| ADRs | 3 | 13 (+10) |
+
+### Migration
+
+No breaking changes. Codified disciplines apply to NEW spec sub-cycles;
+existing artifacts are not retroactively re-validated.
+
 ## 1.0.0-beta.4 — cache fix + stderr capture + SHA-currency gate (2026-04-25)
 
 Same-day patch on top of beta.3. Three follow-ups from the prior beta

--- a/plugins/vsdd-factory/agents/adversary.md
+++ b/plugins/vsdd-factory/agents/adversary.md
@@ -75,6 +75,32 @@ Write findings to `.factory/cycles/<current>/adversarial-reviews/`:
 <Are these findings genuinely new, or retreading known issues?>
 ```
 
+### Process-Gap Tagging (S-7.02)
+
+When a finding identifies a gap in **process or tooling** — not a content defect in a
+specific artifact — tag it `[process-gap]` in the finding header or observation text.
+
+A finding qualifies as a process-gap when it identifies a gap in:
+- An agent prompt or workflow step (not a gap in a specific spec artifact)
+- A hook or validation script (missing enforcement)
+- A rule file or governance document (missing policy)
+- A pipeline template (structural gap in output format)
+
+Contrast with a **content defect**: a specific BC, VP, story, or doc with wrong information.
+Content defects are fixed in place — no `[process-gap]` tag needed unless the same defect
+pattern recurs 3+ times (then it becomes a process gap).
+
+**Example:**
+```
+## Observations
+- [process-gap] story-writer.md has no spec-first gate — agents can set status:ready
+  without behavioral_contracts being populated. See rules/lessons-codification.md.
+```
+
+The orchestrator scans for `[process-gap]` tags during the Cycle-Closing Checklist
+(see `agents/orchestrator/orchestrator.md`) to ensure every process gap receives a
+codification follow-up before the cycle is declared CLOSED.
+
 ## Self-Validation Loop (AgenticAKM Pattern)
 
 Before finalizing findings, run a self-validation loop on each finding:
@@ -175,6 +201,41 @@ Every adversarial pass must sample at least 5 stories and verify bidirectional B
 - Systematic pattern across 3+ stories: **HIGH** with pattern flag
 
 This axis catches the specific class of drift where frontmatter changes (un-retirements, re-anchoring, burst-cycle fixes) fail to propagate to the human-readable body. The drift is invisible to index-level sanity checks but catastrophic for implementers working from the body.
+
+### Partial-Fix Regression Discipline (S-7.01)
+
+For every adversarial pass after pass 1, you MUST explicitly verify that prior-pass
+fixes have fully propagated. This is a required review axis — not optional.
+
+**For every finding closed in a prior pass** (visible via the convergence report or
+fix commit), verify ALL THREE of the following:
+
+(a) **Bodies of files where frontmatter was changed**: If a prior fix updated a
+    file's frontmatter (e.g., changed a BC ID, a title, a status), confirm the fix
+    also propagated to that file's body content (Traceability tables, prose sections,
+    AC text). Frontmatter-only fixes with unchanged bodies are incomplete.
+
+(b) **Sibling files in the same architectural layer**: If a fix applied to one BC
+    in a subsystem, check whether the same pattern exists in sibling BCs in the same
+    subsystem (SS-NN). If a fix applied to one agent prompt, check whether the same
+    gap exists in sibling agent prompts of the same type. "Same layer" means:
+    - Same-subsystem BCs (BC-S.SS.NNN where SS is the same)
+    - Same-type agent prompts (story-writer, product-owner, adversary are all builder/reviewer agents)
+    - Same-type template files (all BC templates, all story templates)
+
+(c) **Prose that references the changed value**: If a fix changed a count, a title,
+    or a canonical value, grep for all files that reference the old value. Files that
+    still contain the old reference are unfixed propagation gaps.
+
+**Severity for "fix applied to primary, sibling not updated":**
+- Blast radius = 1 file: MEDIUM
+- Blast radius = 2+ files: HIGH
+
+**Intent adjudication rule:** The adversary cannot adjudicate whether a sibling
+should receive the same fix — that depends on authorial intent. When the intent
+is unclear, report the difference as a finding with severity LOW and tag it
+`(pending intent verification)`. The orchestrator or human adjudicates. Do NOT
+silently skip differences that might be intentional.
 
 ### Fresh-Context Compounding Value
 

--- a/plugins/vsdd-factory/agents/orchestrator/orchestrator.md
+++ b/plugins/vsdd-factory/agents/orchestrator/orchestrator.md
@@ -383,6 +383,30 @@ When making gate decisions, read **index files** — do NOT load all detail file
 - Wave schedule output: `../../templates/wave-schedule-template.md`
 - Mode decision guide: `skills/mode-decision-guide/SKILL.md`
 
+## Cycle-Closing Checklist (S-7.02)
+
+Before declaring any sub-cycle CONVERGED or CLOSED, the orchestrator MUST
+complete this checklist. Reference: `rules/lessons-codification.md`.
+
+1. **Review novel findings from each adversarial pass** in the convergence report.
+
+2. **Identify process-gap findings** (tagged `[process-gap]` by the adversary):
+   - These are gaps in agent prompts, hooks, rule files, or pipeline workflow.
+   - Content defects (wrong BC, wrong VP, wrong story text) do NOT require
+     codification follow-up unless the same defect recurs 3+ times.
+
+3. **For each process-gap finding**, confirm ONE of the following exists:
+   - A follow-up story in STORY-INDEX.md targeting the appropriate self-improvement
+     epic (at minimum `status: draft`), OR
+   - A justified deferral entry in STATE.md Drift Items table with an explicit
+     target release and reason.
+
+4. **The cycle is NOT CLOSED** until step 3 is satisfied for every process-gap
+   finding. Open follow-up stories or record deferrals before declaring CONVERGED.
+
+Enforcement: the adversary tags process-gap findings; the state-manager logs
+confirmed codifications in `cycles/<cycle>/lessons.md` with `[codified]` tag.
+
 ## Failure & Escalation
 - **Level 1 (self-correct):** If a spawned agent returns incomplete output, re-spawn with more specific task description.
 - **Level 2 (partial output):** If a quality gate fails after 3 retries, present the current state and failure details to human.

--- a/plugins/vsdd-factory/agents/product-owner.md
+++ b/plugins/vsdd-factory/agents/product-owner.md
@@ -188,6 +188,33 @@ Every domain invariant (DI-NNN) in `domain-spec/invariants.md` must be enforced 
 
 Orphan invariants are invisible until adversarial review catches them — lifting them at creation time prevents a full convergence pass of rework.
 
+## Capability Anchor Justification (S-7.01)
+
+Every behavioral contract MUST include a **Capability Anchor Justification** row
+in its Traceability section. The justification MUST cite the specific capability
+name and file verbatim from `specs/domain-spec/capabilities.md`. Example:
+
+> CAP-017 ("Create and manage formal ADR records") per capabilities.md §CAP-017
+
+A bare `CAP-NNN` with no verbatim citation is insufficient. The capability name
+must be quoted exactly as it appears in `capabilities.md` — do not paraphrase.
+
+The adversary is explicitly instructed (per adversary policy 5 — Semantic
+Anchoring Audit) to treat a missing or non-verbatim Capability Anchor Justification
+as a MEDIUM-severity finding. This means every BC with a bare `capability: CAP-NNN`
+frontmatter field but no verbatim justification in the Traceability section will
+generate a finding in the next adversarial pass.
+
+**How to write a compliant justification:**
+
+1. Open `specs/domain-spec/capabilities.md` and locate the CAP-NNN entry.
+2. Copy the exact capability title from the H2 or table row.
+3. Write in the BC Traceability section:
+   ```
+   | Capability Anchor Justification | CAP-NNN ("<exact title>") per capabilities.md §CAP-NNN |
+   ```
+4. If no existing capability fits semantically, propose a new CAP — do not force-fit.
+
 ## Anchor Justification Requirement
 
 When creating or modifying any BC, you must explicitly justify the capability anchor choice:

--- a/plugins/vsdd-factory/agents/state-manager.md
+++ b/plugins/vsdd-factory/agents/state-manager.md
@@ -137,6 +137,43 @@ When the orchestrator sends you an update:
 5. **Blocking issue resolved:** Move from STATE.md Blocking Issues to `cycles/<cycle>/blocking-issues-resolved.md`.
 6. **Session checkpoint:** Replace the previous checkpoint in STATE.md with the new one. Archive the old checkpoint to `cycles/<cycle>/session-checkpoints.md`.
 
+### Defensive Sweep Discipline (S-7.02)
+
+Before declaring any count-changing update complete (e.g., "BC count is now 1,875"),
+the state-manager MUST run a corpus-wide grep to identify all files that still
+contain the old count as a literal string.
+
+**Minimum sweep coverage:**
+
+```bash
+grep -r "<old_count>" \
+  .factory/STATE.md \
+  .factory/specs/architecture/ARCH-INDEX.md \
+  .factory/specs/behavioral-contracts/BC-INDEX.md \
+  .factory/specs/verification-properties/VP-INDEX.md \
+  .factory/stories/STORY-INDEX.md \
+  .factory/specs/architecture/SS-*.md \
+  .factory/specs/prd.md \
+  2>/dev/null || true
+```
+
+Any file still containing the old count after the update is a propagation gap —
+fix it before committing. The sweep uses anchored context regexes to avoid false
+positives: search for "NNN BCs", "NNN VPs", "NNN stories", "total_bcs: NNN" rather
+than bare numbers.
+
+**Log sweep results in the commit message** before pushing, e.g.:
+```
+Count-propagation sweep: updated 4 files. Old count (1,863) removed from:
+STATE.md, ARCH-INDEX.md, BC-INDEX.md, prd.md.
+```
+
+If any file was found with the old count but intentionally NOT updated (e.g., a
+historical changelog entry), explicitly note this in the commit message with justification.
+
+This discipline closes F-027 from s6.01-pass-1.md: state-manager declared "count
+change complete" after updating only 2 of 4 index files.
+
 ### Anti-Patterns (NEVER do these)
 
 - **NEVER** append full burst narratives to STATE.md

--- a/plugins/vsdd-factory/agents/story-writer.md
+++ b/plugins/vsdd-factory/agents/story-writer.md
@@ -216,6 +216,32 @@ After producing all stories, update each BC's Traceability section:
 - Fill the "Stories" row with the STORY-NNN IDs that cover the BC
 - This enables bidirectional traceability: BC -> Stories and Stories -> BC
 
+## Spec-First Gate (S-7.01)
+
+A story's `status:` field MUST NOT be set to `ready` if `behavioral_contracts: []`
+is empty (or absent) — `behavioral_contracts` must be non-empty before `ready`.
+The status must remain `draft` until a product-owner has authored and anchored BCs
+for this story (i.e., `behavioral_contracts:` is a non-empty array with canonical
+BC IDs matching `BC-\d+\.\d{2}\.\d{3}`). Note: `behavioral_contracts:` is the
+canonical field name; the alias `bcs:` is also accepted — this gate applies to both.
+
+Every entry in `behavioral_contracts:` MUST match the canonical pattern
+`BC-\d+\.\d{2}\.\d{3}` — no BC-TBD placeholders are allowed in a `ready` story.
+
+**AC↔BC bidirectional traces** must be present before the status=ready transition:
+- Every AC in the story body must cite a BC via `(traces to BC-S.SS.NNN ...)`.
+- Every BC in the `behavioral_contracts:` frontmatter array must be cited by at
+  least one AC in the story body.
+
+If a story is written with `behavioral_contracts: []` during initial decomposition,
+add a frontmatter comment: `# BC status: pending PO authorship`. This signals the
+product-owner that BC authoring is required before this story can be dispatched.
+
+This gate applies to:
+- New stories being written for the first time.
+- Status-transition edits (`draft → ready`).
+- Any burst that changes story `status:` to `ready`.
+
 ## Rules
 
 - No story exceeds 13 story points

--- a/plugins/vsdd-factory/bin/validate-template-compliance.sh
+++ b/plugins/vsdd-factory/bin/validate-template-compliance.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+# validate-template-compliance.sh (bin/) — VP multi-BC source_bc convention check
+#
+# Extends template compliance validation with VP-specific enforcement:
+# When a VP file has a `bcs:` array with >1 entry, the file MUST also have
+# a non-empty `source_bc:` field that names the primary BC being exercised.
+#
+# Rule: IF len(bcs) > 1 THEN source_bc MUST be non-empty AND source_bc MUST appear in bcs[].
+#
+# Scope: VP-*.md files or files with document_type: verification-property.
+# Other file types are passed through without checking.
+#
+# Exit 0 on pass or if not a VP file.
+# Exit 2 on violation with structured warning to stderr.
+#
+# S-7.02 / BC-7.05.003
+# Multi-BC source_bc convention established in commit 7765573.
+
+set -euo pipefail
+
+if ! command -v jq &>/dev/null; then
+  exit 0
+fi
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [[ -z "$FILE_PATH" ]] || [[ ! -f "$FILE_PATH" ]]; then
+  exit 0
+fi
+
+# Scope: VP-*.md files or document_type: verification-property
+BASENAME=$(basename "$FILE_PATH")
+IS_VP=0
+case "$BASENAME" in
+  VP-*.md) IS_VP=1 ;;
+esac
+
+if [[ "$IS_VP" -eq 0 ]]; then
+  # Check document_type frontmatter
+  DOC_TYPE=$(awk '
+    /^---$/{ fm++; next }
+    fm==1 && /^document_type:/ {
+      sub(/^document_type:[ \t]*/, "")
+      gsub(/["'"'"']/, "")
+      gsub(/^[ \t]+|[ \t]+$/, "")
+      print
+      exit
+    }
+  ' "$FILE_PATH")
+  if [[ "$DOC_TYPE" == "verification-property" ]]; then
+    IS_VP=1
+  fi
+fi
+
+if [[ "$IS_VP" -eq 0 ]]; then
+  exit 0
+fi
+
+# Extract VP ID for error messages
+VP_ID="$BASENAME"
+if [[ "$BASENAME" =~ (VP-[0-9]+) ]]; then
+  VP_ID="${BASH_REMATCH[1]}"
+fi
+
+# Extract `bcs:` array entries from frontmatter (YAML list format)
+# Supports both: bcs: [BC-A, BC-B] and multi-line list
+BCS_COUNT=0
+BCS_LIST=()
+IN_BCS=0
+
+while IFS= read -r line; do
+  # Detect end of frontmatter
+  if [[ "$IN_BCS" -eq -1 ]]; then
+    break
+  fi
+
+  # Single-line array: bcs: [BC-5.01.001, BC-5.01.002]
+  if [[ "$line" =~ ^bcs:[[:space:]]*\[(.+)\] ]]; then
+    IFS=',' read -ra entries <<< "${BASH_REMATCH[1]}"
+    for entry in "${entries[@]}"; do
+      entry=$(echo "$entry" | tr -d '[:space:]"'"'"'')
+      [[ -n "$entry" ]] && BCS_LIST+=("$entry") && ((BCS_COUNT++))
+    done
+    break
+  fi
+
+  # Multi-line list start: bcs:
+  if [[ "$line" =~ ^bcs:[[:space:]]*$ ]]; then
+    IN_BCS=1
+    continue
+  fi
+
+  # Multi-line list items: "  - BC-5.01.001"
+  if [[ "$IN_BCS" -eq 1 ]]; then
+    if [[ "$line" =~ ^[[:space:]]*-[[:space:]]*(BC-[0-9.]+) ]]; then
+      BCS_LIST+=("${BASH_REMATCH[1]}")
+      BCS_COUNT=$((BCS_COUNT + 1))
+    elif [[ "$line" =~ ^[a-z] ]]; then
+      IN_BCS=0  # Another frontmatter key — end of bcs list
+    fi
+  fi
+done < <(awk '/^---$/{fm++; if(fm==2) exit} fm==1{print}' "$FILE_PATH")
+
+# If bcs list has 0 or 1 entries, multi-BC rule does not apply — pass
+if [[ "$BCS_COUNT" -le 1 ]]; then
+  exit 0
+fi
+
+# Extract source_bc field from frontmatter
+SOURCE_BC=$(awk '
+  /^---$/{ fm++; next }
+  fm==1 && /^source_bc:/ {
+    sub(/^source_bc:[ \t]*/, "")
+    gsub(/["'"'"']/, "")
+    gsub(/^[ \t]+|[ \t]+$/, "")
+    print
+    exit
+  }
+' "$FILE_PATH")
+
+# Validate: source_bc must be non-empty
+if [[ -z "$SOURCE_BC" ]]; then
+  echo "TEMPLATE COMPLIANCE WARNING: ${VP_ID} has multiple bcs[] (${BCS_COUNT} entries) but missing source_bc field." >&2
+  echo "  Convention: when len(bcs) > 1, source_bc must name the primary BC being exercised." >&2
+  echo "  Ref: commit 7765573 (VP multi-BC source_bc convention)." >&2
+  exit 2
+fi
+
+# Validate: source_bc must appear in bcs[] list
+FOUND=0
+for bc in "${BCS_LIST[@]}"; do
+  if [[ "$bc" == "$SOURCE_BC" ]]; then
+    FOUND=1
+    break
+  fi
+done
+
+if [[ "$FOUND" -eq 0 ]]; then
+  echo "TEMPLATE COMPLIANCE WARNING: ${VP_ID} source_bc='${SOURCE_BC}' is not in bcs[] list." >&2
+  echo "  source_bc must be one of: ${BCS_LIST[*]}" >&2
+  exit 2
+fi
+
+exit 0

--- a/plugins/vsdd-factory/commands/create-adr.md
+++ b/plugins/vsdd-factory/commands/create-adr.md
@@ -1,0 +1,28 @@
+---
+description: Scaffold a new ADR file with frontmatter, insert ARCH-INDEX row, optionally patch a superseded ADR bidirectionally, and validate template compliance. Atomic-or-nothing.
+argument-hint: "--title <text> --subsystems <SS-NN[,...]> [--supersedes <ADR-NNN>] [--brownfield] [--id <ADR-NNN>] [--dry-run]"
+---
+
+Use the `vsdd-factory:create-adr` skill via the Skill tool.
+
+Arguments: $ARGUMENTS
+
+## Flags
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--title <text>` | YES | Decision title. Used verbatim in ARCH-INDEX row; slug-derived for filename. |
+| `--subsystems <SS-NN[,...]>` | YES | Comma-separated subsystem IDs (e.g., `SS-06,SS-08`). Validated against ARCH-INDEX registry. |
+| `--supersedes <ADR-NNN>` | no | Existing ADR being superseded. Patches old ADR with `superseded_by`. Also implies `--brownfield`. |
+| `--brownfield` | no | Injects Source/Origin warning requiring implementation evidence before ADR can be accepted. |
+| `--id <ADR-NNN>` | no | Override auto-allocated ID. Refused if ID already exists. |
+| `--dry-run` | no | Print proposed ID + slug only. No files written. |
+
+## Examples
+
+```
+/vsdd-factory:create-adr --title "Use Rust for dispatcher" --subsystems "SS-01,SS-09"
+/vsdd-factory:create-adr --title "Replace WASM with native plugins" --subsystems "SS-02" --supersedes "ADR-002"
+/vsdd-factory:create-adr --title "Adopt OpenTelemetry" --subsystems "SS-03" --brownfield
+/vsdd-factory:create-adr --title "Test ID" --subsystems "SS-06" --dry-run
+```

--- a/plugins/vsdd-factory/hooks-registry.toml
+++ b/plugins/vsdd-factory/hooks-registry.toml
@@ -493,6 +493,26 @@ binary_allow = ["bash", "jq"]
 shell_bypass_acknowledged = "legacy-bash-adapter runs unported hooks"
 env_allow = ["PATH", "HOME", "TMPDIR", "CLAUDE_PROJECT_DIR", "CLAUDE_PLUGIN_ROOT", "VSDD_SESSION_ID"]
 
+[[hooks]]
+name = "validate-count-propagation"
+event = "PostToolUse"
+tool = "Edit|Write"
+plugin = "hook-plugins/legacy-bash-adapter.wasm"
+priority = 430
+timeout_ms = 5000
+on_error = "continue"
+
+[hooks.config]
+script_path = "hooks/validate-count-propagation.sh"
+
+[hooks.capabilities]
+env_allow = ["PATH", "HOME", "TMPDIR", "CLAUDE_PROJECT_DIR", "CLAUDE_PLUGIN_ROOT", "VSDD_SESSION_ID"]
+
+[hooks.capabilities.exec_subprocess]
+binary_allow = ["bash", "jq"]
+shell_bypass_acknowledged = "legacy-bash-adapter runs unported hooks"
+env_allow = ["PATH", "HOME", "TMPDIR", "CLAUDE_PROJECT_DIR", "CLAUDE_PLUGIN_ROOT", "VSDD_SESSION_ID"]
+
 # ---------- PreToolUse ----------
 
 [[hooks]]

--- a/plugins/vsdd-factory/hooks/validate-count-propagation.sh
+++ b/plugins/vsdd-factory/hooks/validate-count-propagation.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+# validate-count-propagation.sh — PostToolUse lint hook for cross-document count drift
+#
+# Triggered: PostToolUse Write/Edit on ARCH-INDEX.md, BC-INDEX.md, VP-INDEX.md,
+#            STATE.md, STORY-INDEX.md, PRD.md, or SS-NN-*.md architecture files.
+#
+# Behavior:
+#   1. Extract count-bearing patterns from the modified file using anchored regexes.
+#   2. Grep corpus index files for the same count-keyword pairs.
+#   3. If the same keyword appears in a sibling document at a DIFFERENT numeric value,
+#      emit a structured warning to stderr and exit 2.
+#   4. Exit 0 on no drift OR if count is absent from a sibling file (absence != drift).
+#
+# Scope limit: reports drift, does not modify files, does not interpret semantics.
+# Performance: deterministic, <200ms on typical corpus.
+#
+# S-7.02 / BC-7.05.001, BC-7.05.002
+
+set -euo pipefail
+
+if ! command -v jq &>/dev/null; then
+  exit 0
+fi
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+# Skip if no file path provided or file does not exist
+if [[ -z "$FILE_PATH" ]] || [[ ! -f "$FILE_PATH" ]]; then
+  exit 0
+fi
+
+# Only trigger for index/state/architecture files
+BASENAME=$(basename "$FILE_PATH")
+case "$BASENAME" in
+  ARCH-INDEX.md|BC-INDEX.md|VP-INDEX.md|STATE.md|PRD.md|prd.md|STORY-INDEX.md) ;;
+  SS-[0-9][0-9]-*.md) ;;
+  *) exit 0 ;;
+esac
+
+# Resolve corpus root: walk up from file path to find known anchor
+CORPUS_ROOT=""
+DIR=$(dirname "$FILE_PATH")
+while [[ "$DIR" != "/" ]]; do
+  if [[ -d "$DIR/.factory" ]] || [[ -f "$DIR/STATE.md" ]] || [[ "$(basename "$DIR")" == ".factory" ]]; then
+    CORPUS_ROOT="$DIR"
+    break
+  fi
+  DIR=$(dirname "$DIR")
+done
+if [[ -z "$CORPUS_ROOT" ]]; then
+  CORPUS_ROOT=$(dirname "$FILE_PATH")
+fi
+
+# Build list of sibling index files to check (only those that exist, excluding source file)
+SIBLING_FILES=()
+for candidate in \
+  "$CORPUS_ROOT/.factory/STATE.md" \
+  "$CORPUS_ROOT/.factory/specs/architecture/ARCH-INDEX.md" \
+  "$CORPUS_ROOT/.factory/specs/behavioral-contracts/BC-INDEX.md" \
+  "$CORPUS_ROOT/.factory/specs/verification-properties/VP-INDEX.md" \
+  "$CORPUS_ROOT/.factory/stories/STORY-INDEX.md" \
+  "$CORPUS_ROOT/STATE.md" \
+  "$CORPUS_ROOT/ARCH-INDEX.md" \
+  "$CORPUS_ROOT/BC-INDEX.md" \
+  "$CORPUS_ROOT/VP-INDEX.md" \
+  "$CORPUS_ROOT/STORY-INDEX.md"; do
+  if [[ -f "$candidate" ]] && [[ "$candidate" != "$FILE_PATH" ]]; then
+    SIBLING_FILES+=("$candidate")
+  fi
+done
+
+# If no siblings found, nothing to compare against — exit clean
+if [[ ${#SIBLING_FILES[@]} -eq 0 ]]; then
+  exit 0
+fi
+
+# Extract count-bearing pairs from a file.
+# Outputs lines of format: KEYWORD:COUNT
+# Supported patterns:
+#   "NNN BCs" / "NNN,NNN BCs" — count before keyword
+#   "BCs | NNN" / "BCs: NNN" — keyword before count (table or YAML)
+#   "total_bcs: NNN" / "total_vps: NNN" — YAML frontmatter keys
+_extract_counts() {
+  local path="$1"
+  while IFS= read -r line; do
+    local count keyword
+    # Pattern A: count before keyword
+    if [[ "$line" =~ ([0-9][0-9,]+)[[:space:]]+(BCs|VPs|stories|capabilities|subsystems) ]]; then
+      keyword="${BASH_REMATCH[2]}"
+      count="${BASH_REMATCH[1]//,/}"
+      echo "${keyword}:${count}"
+    fi
+    # Pattern B: keyword before count (table cell or colon-value)
+    if [[ "$line" =~ (BCs|VPs|stories|capabilities)[[:space:]]*[|:][[:space:]]*([0-9][0-9,]+) ]]; then
+      keyword="${BASH_REMATCH[1]}"
+      count="${BASH_REMATCH[2]//,/}"
+      echo "${keyword}:${count}"
+    fi
+    # Pattern C: YAML "total_bcs: NNN"
+    if [[ "$line" =~ total_bcs:[[:space:]]*([0-9][0-9,]+) ]]; then
+      count="${BASH_REMATCH[1]//,/}"
+      echo "BCs:${count}"
+    fi
+    # Pattern D: YAML "total_vps: NNN"
+    if [[ "$line" =~ total_vps:[[:space:]]*([0-9][0-9,]+) ]]; then
+      count="${BASH_REMATCH[1]//,/}"
+      echo "VPs:${count}"
+    fi
+  done < "$path"
+}
+
+# Extract counts from modified file (first occurrence per keyword wins)
+declare -A SOURCE_COUNTS
+while IFS=: read -r kw cnt; do
+  [[ -z "$kw" || -z "$cnt" ]] && continue
+  if [[ -z "${SOURCE_COUNTS[$kw]:-}" ]]; then
+    SOURCE_COUNTS["$kw"]="$cnt"
+  fi
+done < <(_extract_counts "$FILE_PATH")
+
+# Nothing to compare if no count patterns found
+if [[ ${#SOURCE_COUNTS[@]} -eq 0 ]]; then
+  exit 0
+fi
+
+DRIFT_DETECTED=0
+DRIFT_MESSAGES=()
+
+for keyword in "${!SOURCE_COUNTS[@]}"; do
+  source_count="${SOURCE_COUNTS[$keyword]}"
+
+  for sibling in "${SIBLING_FILES[@]}"; do
+    # Extract first matching count for this keyword from sibling
+    sib_count=""
+    while IFS=: read -r kw cnt; do
+      if [[ "$kw" == "$keyword" ]]; then
+        sib_count="$cnt"
+        break
+      fi
+    done < <(_extract_counts "$sibling")
+
+    # Absence of keyword in sibling is NOT drift — only report mismatch
+    if [[ -n "$sib_count" ]] && [[ "$sib_count" != "$source_count" ]]; then
+      DRIFT_DETECTED=1
+      DRIFT_MESSAGES+=("COUNT DRIFT DETECTED: '${source_count} ${keyword}' in $(basename "$FILE_PATH") but '${sib_count} ${keyword}' in $(basename "$sibling").")
+      DRIFT_MESSAGES+=("  Run: grep -r \"${keyword}\" .factory/specs/ .factory/STATE.md to reconcile.")
+    fi
+  done
+done
+
+if [[ "$DRIFT_DETECTED" -eq 1 ]]; then
+  for msg in "${DRIFT_MESSAGES[@]}"; do
+    echo "$msg" >&2
+  done
+  exit 2
+fi
+
+exit 0

--- a/plugins/vsdd-factory/hooks/validate-novelty-assessment.sh
+++ b/plugins/vsdd-factory/hooks/validate-novelty-assessment.sh
@@ -32,20 +32,24 @@ if [[ -z "$FILE_PATH" ]] || [[ ! -f "$FILE_PATH" ]]; then
 fi
 
 # Only trigger for adversarial review pass files in .factory/
-# Match: pass-N.md, adversarial-delta-review.md, adversarial-spec-review.md,
-#        round-N-review.md, spec-review-pass*.md, gemini-review.md
+# Match: pass-N.md (incl. <scope>-pass-N.md), adversarial-*-review.md (specs/),
+#        round-N-review.md, spec-review-pass*.md, gemini-review.md.
+# Anchor to adversarial-reviews/ directory to avoid false-positives on ADRs
+# whose filenames mention "adversarial-review" (e.g., ADR-013).
 case "$FILE_PATH" in
-  *.factory/*pass-[0-9]*.md) ;;
-  *.factory/*adversarial-*review*.md) ;;
+  *.factory/cycles/*/adversarial-reviews/*pass-[0-9]*.md) ;;
+  *.factory/cycles/*/adversarial-reviews/*-pass-[0-9]*.md) ;;
+  *.factory/specs/adversarial-*review*.md) ;;
   *.factory/*round-[0-9]*-review*.md) ;;
   *.factory/*gemini-review*.md) ;;
   *.factory/*spec-review-pass*.md) ;;
   *) exit 0 ;;
 esac
 
-# Skip index files and finding files (they don't need novelty assessment)
+# Skip index files, finding files, and ADRs (they don't need novelty assessment)
 case "$FILE_PATH" in
   *INDEX*.md|*FINDINGS.md|*ADV-*.md|*convergence-summary*.md|*convergence-trajectory*.md) exit 0 ;;
+  */architecture/decisions/ADR-*.md) exit 0 ;;
 esac
 
 ERRORS=""

--- a/plugins/vsdd-factory/rules/lessons-codification.md
+++ b/plugins/vsdd-factory/rules/lessons-codification.md
@@ -1,0 +1,76 @@
+---
+document_type: rule
+rule_id: lessons-codification
+version: "1.0"
+subsystems: [SS-05, SS-07, SS-08]
+created: 2026-04-26
+traces_to: .factory/STATE.md#Lessons-Learned
+stories: [S-7.02]
+---
+
+# Rule: Novel Adversary Process Catch → Codification Follow-Up
+
+## Summary
+
+Every novel adversary process catch (process gap, not content defect) MUST trigger
+a codification follow-up before sub-cycle closure. Codification = update agent
+prompts, templates, and/or hooks. Track in STATE.md Lessons Learned section.
+
+## Definition of "Novel Process Catch"
+
+A finding qualifies as a **novel process catch** when it identifies a gap in:
+- An agent prompt or workflow step (not a gap in a specific spec artifact)
+- A hook or validation script (missing enforcement)
+- A rule file or governance document (missing policy)
+- A pipeline template (structural gap in output format)
+
+The adversary tags such findings with `[process-gap]` in the Observations section.
+
+Contrast with a **content defect**: a specific BC, VP, story, or doc that has
+wrong information. Content defects are fixed in place — no codification follow-up
+required unless the same defect pattern appears systematically (3+ instances).
+
+## Required Follow-Up Protocol
+
+When the orchestrator closes a sub-cycle, it MUST:
+
+1. **Scan** the final convergence report for any `[process-gap]` tagged findings.
+
+2. **For each process-gap finding**, open a follow-up E-N story (in the
+   appropriate self-improvement epic) OR record a deferred item in the Drift
+   Items table of STATE.md with an explicit justification for deferral.
+
+3. **Do not declare CLOSED** until either:
+   - A follow-up story exists (at minimum in STORY-INDEX.md with `status: draft`), OR
+   - A justified deferral is logged in STATE.md Drift Items with a target release.
+
+## Enforcement
+
+- The **orchestrator** references this rule during the cycle-closing checklist.
+  See `agents/orchestrator/orchestrator.md` — Cycle-Closing Checklist section.
+
+- The **adversary** tags process-gap findings with `[process-gap]` at finding
+  creation time, enabling automated scan in step 1 above.
+
+- The **state-manager** logs confirmed codifications in `cycles/<cycle>/lessons.md`
+  using the tag `[codified]` once the follow-up story is created or merged.
+
+## Canonical Example
+
+E-7 (self-improvement epic) was created specifically to codify lessons from the
+v1.0-brownfield-backfill cycle. Stories S-7.01 and S-7.02 are direct codification
+follow-ups from process-gap findings in s6.01-pass-1.md:
+
+| Finding | Tag | Codification Story |
+|---------|-----|--------------------|
+| F-001: empty behavioral_contracts in story | [process-gap] | S-7.01 (story-writer spec-first gate) |
+| F-011: missing capability anchor justification | [process-gap] | S-7.01 (product-owner anchor requirement) |
+| F-023: adversary didn't check sibling-file propagation | [process-gap] | S-7.01 (adversary partial-fix-regression axis) |
+| F-027: state-manager declared count change complete prematurely | [process-gap] | S-7.02 (defensive sweep + hook) |
+
+## Cross-References
+
+- `agents/orchestrator/orchestrator.md` — Cycle-Closing Checklist (references this rule)
+- `agents/adversary.md` — Partial-Fix-Regression Discipline (tags [process-gap])
+- `agents/state-manager.md` — Defensive Sweep Discipline (companion process rule)
+- E-7 (self-improvement epic) — canonical example of this rule applied in production

--- a/plugins/vsdd-factory/skills/create-adr/SKILL.md
+++ b/plugins/vsdd-factory/skills/create-adr/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: create-adr
+description: Scaffold a new ADR file from template, allocate collision-free ID, insert ARCH-INDEX row, patch any superseded ADR bidirectionally, and validate template compliance. Atomic-or-nothing execution.
+argument-hint: "--title <text> --subsystems <SS-NN[,...]> [--supersedes <ADR-NNN>] [--brownfield] [--id <ADR-NNN>] [--dry-run]"
+disable-model-invocation: true
+allowed-tools: Read, Write, Edit, Bash
+---
+
+## Hard Gate
+
+Do NOT ghost-write ADR section prose. Template placeholder text is preserved verbatim. The skill scaffolds structure only — the architect agent fills content. Every write is atomic: if any step fails, all prior writes in that invocation are reverted.
+
+# Create ADR
+
+Scaffold a new Architectural Decision Record (ADR) from `adr-template.md`, allocate the next sequential ADR-NNN ID, insert the ARCH-INDEX row, optionally patch a superseded ADR bidirectionally, and run `validate-template-compliance.sh` as the final gate.
+
+## Arguments
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--title <text>` | YES | Human-readable decision title. Used as-is in the ARCH-INDEX row. Slug-derived for the filename. |
+| `--subsystems <SS-NN[,SS-NN...]>` | YES | Comma-separated list of affected subsystem IDs from ARCH-INDEX Subsystem Registry (e.g., `SS-06,SS-08`). |
+| `--supersedes <ADR-NNN>` | no | Existing ADR being superseded. Triggers bidirectional patch (sets `superseded_by` on the old ADR). Also implies `--brownfield`. |
+| `--brownfield` | no | Injects a non-skippable warning comment in the `Source / Origin` section requiring implementation evidence. |
+| `--id <ADR-NNN>` | no | Override auto-allocated ID. Refused if that ID already exists in the filesystem or ARCH-INDEX. |
+| `--dry-run` | no | Allocates ID and validates inputs; prints proposed ID + slug; writes nothing. Required by VP-059 harness. |
+
+## Process
+
+### Step 1: Validate ARCH-INDEX has Architecture Decisions section
+
+Read `ARCH-INDEX.md`. If `## Architecture Decisions` section header is absent, exit non-zero with message and write nothing.
+
+### Step 2: Validate subsystems against ARCH-INDEX Subsystem Registry (BC-6.20.005)
+
+Parse `--subsystems` list. For each `SS-NN` ID, confirm it appears in the ARCH-INDEX Subsystem Registry table. On unknown ID, exit non-zero with the invalid ID and the list of valid IDs. No files written.
+
+Validation order (BC-6.20.008 invariant 5): `--title` first; subsystem registry second; supersedes existence third; ID allocation/override last.
+
+### Step 3: Validate --supersedes exists (BC-6.20.006)
+
+If `--supersedes ADR-NNN` supplied, confirm `decisions/ADR-NNN-*.md` exists. If not found, exit non-zero with the missing ID. No files written.
+
+### Step 4: Allocate ADR ID (BC-6.20.001)
+
+Scan both:
+- Filesystem: `decisions/ADR-[0-9][0-9][0-9]-*.md` filenames
+- ARCH-INDEX: `## Architecture Decisions` table rows (parse `ADR-NNN` from each `| ADR-NNN |` row)
+
+Take the maximum of all found numbers across both sources. Propose `ADR-<max+1>` zero-padded to three digits (e.g., max=013 → propose ADR-014).
+
+If the filesystem ID set and the ARCH-INDEX ID set are NOT identical (mismatch), report the inconsistency and exit non-zero. No files written. (BC-6.20.003)
+
+If `--id ADR-NNN` supplied: confirm it does not already exist in either source. If it does, exit non-zero with "ADR-NNN already exists at decisions/ADR-NNN-*.md. Omit --id to auto-allocate or choose a free ID." (BC-6.20.002)
+
+Derive `<slug>` from `--title`: lowercase; whitespace runs → single `-`; strip all non-`[a-z0-9-]` characters (including non-ASCII — strip, do NOT transliterate); collapse consecutive `-`; trim leading/trailing `-`. The original title is used unchanged in the ARCH-INDEX row. (BC-6.20.008)
+
+### Step 5: Dry-run exit
+
+If `--dry-run` flag supplied, print `Dry-run: proposed ADR ID = ADR-NNN, slug = <slug>` and exit 0. No writes.
+
+### Step 6: Write ADR file (BC-6.20.004, BC-6.20.009)
+
+Render the new ADR file from `adr-template.md`:
+
+| Frontmatter field | Value |
+|-------------------|-------|
+| `document_type` | `adr` (literal) |
+| `adr_id` | `ADR-NNN` (allocated ID) |
+| `status` | `proposed` (always at creation — never `accepted`) |
+| `date` | today's ISO-8601 date (YYYY-MM-DD) |
+| `subsystems_affected` | YAML array from `--subsystems` list |
+| `supersedes` | `ADR-NNN` if `--supersedes` supplied; `null` otherwise |
+| `superseded_by` | `null` (always at creation) |
+
+Section bodies (Context, Decision, Rationale, Consequences, Alternatives Considered, Source / Origin) are copied VERBATIM from the template — no ghost-writing, no prose generation.
+
+If `--brownfield` flag is set OR `--supersedes` is set (implies brownfield), inject the following non-skippable warning comment immediately after the `## Source / Origin` header line (BC-6.20.010):
+
+```markdown
+<!-- BROWNFIELD: You MUST cite implementation evidence (file:line from crates/ or
+     legacy-design-docs/) before this ADR can be accepted. Omitting evidence is a
+     template-compliance failure. -->
+```
+
+Write file to `decisions/ADR-NNN-<slug>.md`. If write fails, exit non-zero. No ARCH-INDEX row inserted yet.
+
+### Step 7: Bidirectional supersession patch (BC-6.20.007)
+
+If `--supersedes ADR-NNN` supplied, patch the frontmatter of `decisions/ADR-NNN-<existing-slug>.md` by setting `superseded_by: ADR-<new>` (replacing the existing `superseded_by:` line only — no other content changed).
+
+Check file writeability before attempting the patch. If the old ADR is not writable, trigger rollback (Step 9 path A): delete the newly written ADR file, exit non-zero.
+
+The patch is applied via direct write to the existing file (not a rename) so that filesystem permission checks are enforced correctly.
+
+### Step 8: ARCH-INDEX row insertion (BC-6.20.008)
+
+Insert one new row into the `## Architecture Decisions` table, positioned immediately after the row for the current highest ADR, maintaining ascending numeric order.
+
+Row format:
+```
+| ADR-NNN | <decision-title> | <subsystems joined by ", "> | decisions/ADR-NNN-<slug>.md |
+```
+
+The `<decision-title>` is the original unsanitized `--title` value. The `<slug>` matches the filename.
+
+Write directly to `ARCH-INDEX.md` (not via temp-file rename) so that a read-only ARCH-INDEX fails the write and triggers rollback (Step 9 path B): revert supersession patch (if applied), delete the new ADR file, exit non-zero.
+
+If ARCH-INDEX lacks the `## Architecture Decisions` section (caught in Step 1, but re-checked here as a defense), exit non-zero.
+
+### Step 9: Run validate-template-compliance.sh (BC-6.20.011)
+
+Execute:
+```
+${VALIDATE_BIN} decisions/ADR-NNN-<slug>.md
+```
+
+If exit code 0: print `Template compliance: PASS` and proceed to Step 10.
+
+If exit code non-zero: print any output from the validator, then print:
+```
+Template compliance: FAIL — ADR-NNN not registered. Fix the issues above and re-run.
+```
+Then apply partial rollback (BC-6.20.012 EC-002):
+- Revert ARCH-INDEX row insertion
+- Revert supersession patch (if applied)
+- Leave the ADR file on disk (intentional — the implementer inspects it to fix the issues)
+Exit non-zero.
+
+### Step 10: Emit structured event (BC-6.20.009)
+
+Emit event via `bin/emit-event`:
+```
+emit-event type=adr.scaffolded adr_id=ADR-NNN slug=<slug> subsystems=<csv> path=decisions/ADR-NNN-<slug>.md
+```
+
+Event is failure-tolerant (always exit 0 per emit-event contract). Failure to emit does NOT fail the skill.
+
+### Step 11: Print guidance block to stdout
+
+```
+Template compliance: PASS
+
+ADR-NNN scaffolded at: decisions/ADR-NNN-<slug>.md
+
+Sections to flesh out:
+  - Context      (2-5 paragraphs: background, forces, constraints)
+  - Decision     (1-3 paragraphs: the choice itself)
+  - Rationale    (2-5 paragraphs: why this, not alternatives)
+  - Consequences (Positive / Negative sub-headings)
+  - Alternatives Considered (top 2-3 options rejected)
+  - Source / Origin (MUST cite implementation evidence for brownfield ADRs)
+
+Recommended next step:
+  Spawn architect agent: "Flesh out ADR-NNN sections. File: .factory/specs/architecture/decisions/ADR-NNN-<slug>.md"
+```
+
+Exit 0.
+
+## Atomicity Contract (BC-6.20.012)
+
+The skill treats all writes as a single atomic unit. If any step fails:
+
+| Failure point | Revert actions |
+|--------------|----------------|
+| ADR file write fails | Nothing to revert. Exit non-zero. |
+| Supersession patch fails | Delete new ADR file. Exit non-zero. |
+| ARCH-INDEX insertion fails | Revert supersession patch (if applied). Delete new ADR file. Exit non-zero. |
+| Validation fails | Revert ARCH-INDEX row. Revert supersession patch (if applied). Leave ADR file on disk. Exit non-zero. |
+
+Revert messages are always specific: e.g., "Deleted ADR-NNN-slug.md", "Reverted ARCH-INDEX row for ADR-NNN", "Restored ADR-MMM superseded_by to null".
+
+The skill never exits 0 after a partial-state failure.
+
+After a full rollback (all paths except validation failure), re-invocation with the same arguments succeeds (idempotent). After a validation failure (file left on disk), re-invocation triggers the duplicate-ID check and exits non-zero — user must delete the leftover file first.
+
+## Edge Cases
+
+| ID | Scenario | Behavior |
+|----|----------|----------|
+| EC-001 | `decisions/` directory does not exist | Skill creates it before scanning; filesystem count treated as zero |
+| EC-002 | ARCH-INDEX has ADR-013 in table but no file exists | Mismatch detected; skill refuses; user reconciles manually |
+| EC-003 | `--title` contains special characters (`/`, `<`, `>`) | Slug strips them; title in ARCH-INDEX row uses original unsanitized title |
+| EC-004 | `--supersedes ADR-NNN` already has `superseded_by` set | Skill warns "ADR-NNN is already superseded by ADR-MMM" but does NOT block |
+| EC-005 | `validate-template-compliance.sh` not found or not executable | Exit non-zero: "validate-template-compliance.sh not found at expected path — cannot complete AC-7" |
+| EC-006 | `--subsystems` contains unknown SS-ID (e.g., `SS-99`) | Exit non-zero with list of valid SS-IDs from ARCH-INDEX Subsystem Registry |
+| EC-007 | Concurrent invocations write same ADR-NNN | Loser detects collision via duplicate-ID check and rolls back per BC-6.20.012. Users SHOULD serialize. |
+| EC-008 | No arguments supplied | Print usage summary; exit 0 without writing anything |
+| EC-009 | `--title` absent with other args present | Exit non-zero with usage error before any other argument is processed; no side-effects |
+| EC-010 | ARCH-INDEX has uncommitted local edits | Warn via stderr: "WARNING: ARCH-INDEX.md has uncommitted local changes..." then proceed |
+
+## Output Files
+
+| File | Action | Notes |
+|------|--------|-------|
+| `.factory/specs/architecture/decisions/ADR-NNN-<slug>.md` | created | New ADR file scaffolded from template |
+| `.factory/specs/architecture/ARCH-INDEX.md` | modified | New row inserted in Architecture Decisions table |
+| `.factory/specs/architecture/decisions/ADR-MMM-<old-slug>.md` | modified (if `--supersedes`) | `superseded_by` field patched to `ADR-NNN` |
+
+## Environment Variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `DECISIONS_DIR` | `.factory/specs/architecture/decisions/` | Path to decisions directory (overridable for tests) |
+| `ARCH_INDEX` | `.factory/specs/architecture/ARCH-INDEX.md` | Path to ARCH-INDEX (overridable for tests) |
+| `ADR_TEMPLATE` | `plugins/vsdd-factory/templates/adr-template.md` | Path to ADR template (read-only) |
+| `VALIDATE_BIN` | `plugins/vsdd-factory/bin/validate-template-compliance.sh` | Path to validation script (mockable via `MOCK_VALIDATE_EXIT`) |
+
+## Self-Review (before delivery)
+
+1. Does the new ADR file contain `status: proposed`? (Never `accepted` at creation.)
+2. Does the ARCH-INDEX row use the original unsanitized title (not the slug)?
+3. Is the brownfield annotation present when `--brownfield` or `--supersedes` was supplied?
+4. Did `validate-template-compliance.sh` exit 0?
+5. Is the guidance block printed to stdout?

--- a/plugins/vsdd-factory/templates/L4-verification-property-template.md
+++ b/plugins/vsdd-factory/templates/L4-verification-property-template.md
@@ -9,7 +9,7 @@ phase: 1b
 inputs: [prd.md, architecture.md]
 input-hash: "[md5]"
 traces_to: prd.md
-source_bc: BC-S.SS.NNN
+source_bc: BC-S.SS.NNN  # Primary BC. For VPs that span multiple BCs, set this to the dominant BC and use the `bcs:` list field below to enumerate all covered BCs. The body Source Contract section labels primary vs partial coverage explicitly. Schema note: a future revision may rename this to `source_bcs: [...]` for VPs covering N>1 BCs; until then, primary-singleton + `bcs:` list is the canonical pattern (see VP-058 for an example).
 module: [implementation module name]
 proof_method: kani|proptest|fuzz|manual|tla+
 feasibility: feasible|needs-research|infeasible

--- a/plugins/vsdd-factory/tests/codify-lessons.bats
+++ b/plugins/vsdd-factory/tests/codify-lessons.bats
@@ -1,0 +1,107 @@
+#!/usr/bin/env bats
+# codify-lessons.bats — TDD tests for S-7.01 + S-7.02 codify-lessons delivery
+#
+# S-7.01: Agent prompt discipline (story-writer, product-owner, adversary)
+# S-7.02: Defensive sweep + hook + meta-rule
+
+# ---------- S-7.01: Agent prompt tests (BC-5.36.001–007) ----------
+
+@test "BC-5.36.001: story-writer.md contains spec-first gate" {
+  grep -q "behavioral_contracts.*non-empty" plugins/vsdd-factory/agents/story-writer.md
+  grep -qE "BC-\\\\d\\+\\\\.\\\\d\\{2\\}\\\\.\\\\d\\{3\\}" plugins/vsdd-factory/agents/story-writer.md
+}
+
+@test "BC-5.36.002: story-writer.md requires AC↔BC bidirectional trace" {
+  grep -qi "AC.*BC.*bidirectional" plugins/vsdd-factory/agents/story-writer.md
+}
+
+@test "BC-5.36.003: product-owner.md requires Capability Anchor Justification cell" {
+  grep -q "Capability Anchor Justification" plugins/vsdd-factory/agents/product-owner.md
+}
+
+@test "BC-5.36.004: product-owner.md requires verbatim citation from capabilities.md" {
+  grep -qi "verbatim" plugins/vsdd-factory/agents/product-owner.md
+  grep -q "capabilities.md" plugins/vsdd-factory/agents/product-owner.md
+}
+
+@test "BC-5.36.005: adversary.md requires partial-fix-regression check" {
+  grep -qi "partial.fix.regression" plugins/vsdd-factory/agents/adversary.md
+}
+
+@test "BC-5.36.006: adversary.md requires propagation check to bodies, sibling files, prose" {
+  grep -qi "bodies" plugins/vsdd-factory/agents/adversary.md
+  grep -qi "sibling files" plugins/vsdd-factory/agents/adversary.md
+  grep -qi "prose" plugins/vsdd-factory/agents/adversary.md
+}
+
+@test "BC-5.36.007: all three agents updated in the delivery branch" {
+  # Verify all 3 agent files were modified somewhere in this branch
+  # (checks branch diff vs origin/main, robust to additional review-cycle fix commits)
+  cd /Users/jmagady/Dev/vsdd-factory/.worktrees/codify-lessons
+  merge_base=$(git merge-base HEAD origin/main 2>/dev/null || git merge-base HEAD main 2>/dev/null || echo "")
+  if [[ -z "$merge_base" ]]; then
+    # Fallback: check last 5 commits
+    files_in_branch=$(git diff --name-only HEAD~5 HEAD | grep -c 'agents/' || true)
+  else
+    files_in_branch=$(git diff --name-only "$merge_base" HEAD | grep -c 'agents/')
+  fi
+  [ "$files_in_branch" -ge 3 ]
+}
+
+# ---------- S-7.02: Defensive sweep + hook + meta-rule (BC-5.37.001–002, BC-7.05.001–004, BC-8.28.001–002) ----------
+
+@test "BC-5.37.001: state-manager.md requires defensive sweep" {
+  grep -qi "defensive sweep" plugins/vsdd-factory/agents/state-manager.md
+  grep -qi "corpus.wide grep" plugins/vsdd-factory/agents/state-manager.md
+}
+
+@test "BC-5.37.002: state-manager.md requires sweep result logging" {
+  grep -qi "log.*sweep result" plugins/vsdd-factory/agents/state-manager.md
+}
+
+@test "BC-7.05.001: validate-count-propagation.sh exists and is executable" {
+  [ -x plugins/vsdd-factory/hooks/validate-count-propagation.sh ]
+}
+
+@test "BC-7.05.001-drift: validate-count-propagation.sh exits 2 on drift" {
+  # Set up fixture with intentional drift
+  TMPTEST=$(mktemp -d)
+  cat > "$TMPTEST/BC-INDEX.md" <<'HEREDOC'
+---
+total_bcs: 100
+---
+HEREDOC
+  cat > "$TMPTEST/STATE.md" <<'HEREDOC'
+BCs | 200 |
+HEREDOC
+  # Run hook on STATE.md change — capture exit status without triggering set -e
+  run bash plugins/vsdd-factory/hooks/validate-count-propagation.sh \
+    <<< '{"tool_input":{"file_path":"'"$TMPTEST"'/STATE.md"}}'
+  [ "$status" -eq 2 ]
+}
+
+@test "BC-7.05.002: validate-count-propagation.sh runs <500ms" {
+  start=$(date +%s%N)
+  echo '{"tool_input":{"file_path":"/dev/null"}}' | bash plugins/vsdd-factory/hooks/validate-count-propagation.sh || true
+  end=$(date +%s%N)
+  elapsed_ms=$(( (end - start) / 1000000 ))
+  [ "$elapsed_ms" -lt 500 ]
+}
+
+@test "BC-7.05.003: validate-template-compliance.sh enforces VP multi-BC convention" {
+  grep -qi "multi.bc\|source_bc.*primary\|bcs.*list" plugins/vsdd-factory/bin/validate-template-compliance.sh ||
+  grep -qi "source_bc" plugins/vsdd-factory/bin/validate-template-compliance.sh
+}
+
+@test "BC-7.05.004: hooks-registry.toml registers validate-count-propagation" {
+  grep -q "validate-count-propagation" plugins/vsdd-factory/hooks-registry.toml
+}
+
+@test "BC-8.28.001: lessons-codification.md exists" {
+  [ -f plugins/vsdd-factory/rules/lessons-codification.md ]
+  grep -qi "novel.*process catch.*codification follow-up" plugins/vsdd-factory/rules/lessons-codification.md
+}
+
+@test "BC-8.28.002: orchestrator references lessons-codification.md in cycle-closing" {
+  grep -q "lessons-codification" plugins/vsdd-factory/agents/orchestrator/orchestrator.md
+}

--- a/plugins/vsdd-factory/tests/create-adr.bats
+++ b/plugins/vsdd-factory/tests/create-adr.bats
@@ -1,0 +1,437 @@
+#!/usr/bin/env bats
+# create-adr.bats — TDD tests for the create-adr skill (S-6.01)
+# Status: FAILING — skill not yet implemented. RED phase of TDD.
+#
+# Each @test maps directly to the test function names listed in the story spec
+# acceptance criteria (AC-1 through AC-8).  The tests call a thin driver script
+# at helpers/create-adr-driver.sh which is currently a stub that exits 1.  In
+# the GREEN phase the implementer replaces the stub with real logic while the
+# test assertions stay unchanged.
+#
+# CLI surface under test:
+#   create-adr-driver.sh --title <title> [--subsystems <SS-NN,...>]
+#                        [--supersedes <ADR-NNN>] [--brownfield] [--id <ADR-NNN>]
+#
+# Environment variables wired in setup():
+#   DECISIONS_DIR  — path to fixture decisions/ directory
+#   ARCH_INDEX     — path to fixture ARCH-INDEX.md
+#   ADR_TEMPLATE   — path to real adr-template.md (read-only reference)
+#   VALIDATE_BIN   — path to mock validate-template-compliance.sh
+
+PLUGIN_ROOT="${BATS_TEST_DIRNAME}/.."
+DRIVER="${BATS_TEST_DIRNAME}/helpers/create-adr-driver.sh"
+
+# ---------------------------------------------------------------------------
+# setup / teardown
+# ---------------------------------------------------------------------------
+
+setup() {
+  TEST_TMPDIR=$(mktemp -d)
+  export TEST_TMPDIR
+
+  # Build fixture decisions/ directory with ADR-001 through ADR-013 stubs.
+  DECISIONS_DIR="$TEST_TMPDIR/decisions"
+  mkdir -p "$DECISIONS_DIR"
+  export DECISIONS_DIR
+
+  _make_adr_stub() {
+    local num="$1" slug="$2" ss="$3"
+    local id; id=$(printf "ADR-%03d" "$num")
+    cat > "$DECISIONS_DIR/${id}-${slug}.md" <<FRONTMATTER
+---
+document_type: adr
+adr_id: ${id}
+status: proposed
+date: 2026-01-01
+subsystems_affected: [${ss}]
+supersedes: null
+superseded_by: null
+---
+
+# ${id}: stub
+FRONTMATTER
+  }
+
+  _make_adr_stub  1  "rust-dispatcher"                "SS-01, SS-09"
+  _make_adr_stub  2  "wasm-plugin-abi"                "SS-01, SS-02, SS-04"
+  _make_adr_stub  3  "wasi-preview1"                  "SS-02, SS-04"
+  _make_adr_stub  4  "toml-config"                    "SS-01, SS-09"
+  _make_adr_stub  5  "multi-sink-observability"       "SS-01, SS-03"
+  _make_adr_stub  6  "host-abi-version"               "SS-01, SS-02"
+  _make_adr_stub  7  "always-on-telemetry"            "SS-01, SS-03"
+  _make_adr_stub  8  "parallel-within-tier"           "SS-01"
+  _make_adr_stub  9  "activation-platform-selection"  "SS-09"
+  _make_adr_stub 10  "storedata-linker"               "SS-01, SS-02"
+  _make_adr_stub 11  "dual-hook-routing-tables"       "SS-07, SS-09"
+  _make_adr_stub 12  "legacy-bash-adapter-router"     "SS-04, SS-07"
+  _make_adr_stub 13  "adversarial-review-structure"   "SS-05, SS-06"
+
+  # Build fixture ARCH-INDEX.md with the matching Architecture Decisions table.
+  ARCH_INDEX="$TEST_TMPDIR/ARCH-INDEX.md"
+  export ARCH_INDEX
+  cat > "$ARCH_INDEX" <<'ARCHINDEX'
+---
+document_type: architecture-index
+---
+
+# Architecture Index: vsdd-factory (fixture)
+
+## Subsystem Registry
+
+| SS-ID | Name |
+|-------|------|
+| SS-01 | Hook Dispatcher Core |
+| SS-02 | Hook SDK and Plugin ABI |
+| SS-03 | Observability Sinks |
+| SS-04 | Plugin Ecosystem |
+| SS-05 | Pipeline Orchestration |
+| SS-06 | Skill Catalog |
+| SS-07 | Hook Bash Layer |
+| SS-08 | Templates and Rules |
+| SS-09 | Configuration and Activation |
+| SS-10 | CLI Tools and Bin |
+
+## Architecture Decisions
+
+| ID      | Decision Summary                                             | Subsystems            | File                                               |
+|---------|--------------------------------------------------------------|-----------------------|----------------------------------------------------|
+| ADR-001 | Compiled Rust dispatcher per platform                        | SS-01, SS-09          | decisions/ADR-001-rust-dispatcher.md               |
+| ADR-002 | WASM (wasmtime) plugin ABI                                   | SS-01, SS-02, SS-04   | decisions/ADR-002-wasm-plugin-abi.md               |
+| ADR-003 | WASI preview 1 for v1.0; preview 2 deferred                  | SS-02, SS-04          | decisions/ADR-003-wasi-preview1.md                 |
+| ADR-004 | TOML for all configuration files                             | SS-01, SS-09          | decisions/ADR-004-toml-config.md                   |
+| ADR-005 | Multi-sink observability natively in dispatcher              | SS-01, SS-03          | decisions/ADR-005-multi-sink-observability.md      |
+| ADR-006 | HOST_ABI_VERSION as separate semver constant                 | SS-01, SS-02          | decisions/ADR-006-host-abi-version.md              |
+| ADR-007 | Always-on dispatcher self-telemetry                          | SS-01, SS-03          | decisions/ADR-007-always-on-telemetry.md           |
+| ADR-008 | Parallel-within-tier, sequential-between-tier execution      | SS-01                 | decisions/ADR-008-parallel-within-tier.md          |
+| ADR-009 | Activation-skill-driven platform binary selection            | SS-09                 | decisions/ADR-009-activation-platform-selection.md |
+| ADR-010 | StoreData-typed linker for host functions (invoke.rs pattern)| SS-01, SS-02          | decisions/ADR-010-storedata-linker.md              |
+| ADR-011 | Dual hooks.json + hooks-registry.toml during migration       | SS-07, SS-09          | decisions/ADR-011-dual-hook-routing-tables.md      |
+| ADR-012 | Legacy-bash-adapter as universal current router              | SS-04, SS-07          | decisions/ADR-012-legacy-bash-adapter-router.md    |
+| ADR-013 | Cycle-keyed adversarial review structure                     | SS-05, SS-06          | decisions/ADR-013-adversarial-review-structure.md  |
+ARCHINDEX
+
+  # Point at the real adr-template.md (read-only; tests never write to it).
+  ADR_TEMPLATE="$PLUGIN_ROOT/templates/adr-template.md"
+  export ADR_TEMPLATE
+
+  # Build a mock validate-template-compliance.sh whose exit code is controlled
+  # by MOCK_VALIDATE_EXIT (default 0 = pass).
+  VALIDATE_BIN="$TEST_TMPDIR/validate-template-compliance.sh"
+  export VALIDATE_BIN
+  cat > "$VALIDATE_BIN" <<'VALIDATE'
+#!/usr/bin/env bash
+# Mock validate-template-compliance.sh for create-adr tests.
+# Exits with MOCK_VALIDATE_EXIT (default 0).
+exit "${MOCK_VALIDATE_EXIT:-0}"
+VALIDATE
+  chmod +x "$VALIDATE_BIN"
+}
+
+teardown() {
+  rm -rf "$TEST_TMPDIR"
+}
+
+# ---------------------------------------------------------------------------
+# Helper: run the driver with standard env wired in
+# ---------------------------------------------------------------------------
+
+_run_driver() {
+  run "$DRIVER" "$@"
+}
+
+# ---------------------------------------------------------------------------
+# AC-1: ID allocation
+# ---------------------------------------------------------------------------
+
+@test "AC-1 [BC-6.20.001]: skill allocates next sequential ID with no collision" {
+  # With ADR-001..ADR-013 in DECISIONS_DIR, the skill must propose ADR-014.
+  # Driver is a stub → exits 1 (RED).
+  _run_driver --title "New Decision" --subsystems "SS-06"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ADR-014"* ]]
+}
+
+@test "AC-1 [BC-6.20.002]: skill refuses duplicate --id override" {
+  # ADR-001 already exists; driver must exit non-zero.
+  _run_driver --title "New Decision" --subsystems "SS-06" --id "ADR-001"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"already exists"* ]] || [[ "$stderr" == *"already exists"* ]]
+}
+
+@test "AC-1 [BC-6.20.003]: skill blocks on filesystem-vs-index mismatch" {
+  # Remove ADR-013 from the filesystem but leave it in ARCH-INDEX → mismatch.
+  rm "$DECISIONS_DIR/ADR-013-adversarial-review-structure.md"
+  _run_driver --title "New Decision" --subsystems "SS-06"
+  [ "$status" -ne 0 ]
+  # Must report the inconsistency, not just silently fail.
+  [[ "$output" == *"inconsisten"* ]] || [[ "$output" == *"mismatch"* ]] || [[ "$output" == *"ADR-013"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# AC-2: Frontmatter scaffold
+# ---------------------------------------------------------------------------
+
+@test "AC-2 [BC-6.20.004]: status is always 'proposed' at creation" {
+  _run_driver --title "New Decision" --subsystems "SS-06"
+  [ "$status" -eq 0 ]
+  # The newly written file must contain status: proposed
+  new_file=$(find "$DECISIONS_DIR" -name "ADR-014-*.md" 2>/dev/null | head -1)  # STDERR-EXEMPT: find on tmpdir; absence/presence is the assertion
+  [ -n "$new_file" ]
+  grep -q "status: proposed" "$new_file"
+}
+
+@test "AC-2 [BC-6.20.004]: date matches today's ISO-8601" {
+  today=$(date +%Y-%m-%d)
+  _run_driver --title "New Decision" --subsystems "SS-06"
+  [ "$status" -eq 0 ]
+  new_file=$(find "$DECISIONS_DIR" -name "ADR-014-*.md" 2>/dev/null | head -1)  # STDERR-EXEMPT: find on tmpdir; absence/presence is the assertion
+  [ -n "$new_file" ]
+  grep -q "date: ${today}" "$new_file"
+}
+
+@test "AC-2 [BC-6.20.005]: subsystems validated against ARCH-INDEX registry" {
+  # SS-99 is not in the registry; driver must exit non-zero and name the bad ID.
+  _run_driver --title "New Decision" --subsystems "SS-99"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"SS-99"* ]] || [[ "$output" == *"invalid"* ]] || [[ "$output" == *"unknown"* ]]
+}
+
+@test "AC-2 [BC-6.20.006]: --supersedes ID validated to exist" {
+  # ADR-999 does not exist; driver must exit non-zero and mention the missing ID.
+  _run_driver --title "New Decision" --subsystems "SS-06" --supersedes "ADR-999"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"ADR-999"* ]] || [[ "$output" == *"not found"* ]] || [[ "$output" == *"does not exist"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# AC-3: Supersession bidirectional patch
+# ---------------------------------------------------------------------------
+
+@test "AC-3 [BC-6.20.007]: supersedes patches old ADR superseded_by" {
+  _run_driver --title "New Decision" --subsystems "SS-06" --supersedes "ADR-013"
+  [ "$status" -eq 0 ]
+  # ADR-013 must now have superseded_by: ADR-014
+  grep -q "superseded_by: ADR-014" "$DECISIONS_DIR/ADR-013-adversarial-review-structure.md"
+}
+
+@test "AC-3 [BC-6.20.007, BC-6.20.012]: atomic rollback when supersession patch fails" {
+  # Make ADR-013 read-only so the patch cannot be applied.
+  chmod 444 "$DECISIONS_DIR/ADR-013-adversarial-review-structure.md"
+  _run_driver --title "New Decision" --subsystems "SS-06" --supersedes "ADR-013"
+  [ "$status" -ne 0 ]
+  # No new ADR-014 file should have been left behind.
+  new_file=$(find "$DECISIONS_DIR" -name "ADR-014-*.md" 2>/dev/null | head -1)  # STDERR-EXEMPT: find on tmpdir; absence/presence is the assertion
+  [ -z "$new_file" ]
+  # Must report what it rolled back.
+  [[ "$output" == *"rollback"* ]] || [[ "$output" == *"revert"* ]] || [[ "$output" == *"failed"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# AC-4: ARCH-INDEX insertion
+# ---------------------------------------------------------------------------
+
+@test "AC-4 [BC-6.20.008]: row inserted in numeric order" {
+  _run_driver --title "New Decision" --subsystems "SS-06"
+  [ "$status" -eq 0 ]
+  # ADR-014 row must appear after the ADR-013 row in ARCH-INDEX.
+  adr013_line=$(grep -n "ADR-013" "$ARCH_INDEX" | head -1 | cut -d: -f1)
+  adr014_line=$(grep -n "ADR-014" "$ARCH_INDEX" | head -1 | cut -d: -f1)
+  [ -n "$adr013_line" ]
+  [ -n "$adr014_line" ]
+  [ "$adr014_line" -gt "$adr013_line" ]
+}
+
+@test "AC-4 [BC-6.20.008]: row is pipe-aligned with existing rows" {
+  _run_driver --title "New Decision" --subsystems "SS-06"
+  [ "$status" -eq 0 ]
+  # Each data row in the table must start with a pipe character.
+  # The inserted ADR-014 row must start with '|'.
+  grep -q "^| ADR-014" "$ARCH_INDEX"
+}
+
+@test "AC-4 [BC-6.20.008]: slug derivation strips special chars" {
+  # Title with special chars: slashes and angle brackets must be stripped from
+  # the filename slug.  The title in the ARCH-INDEX row uses the original title.
+  _run_driver --title "Decision <with/special> chars" --subsystems "SS-06"
+  [ "$status" -eq 0 ]
+  # Slug in the filename must not contain '<', '>', or '/'
+  new_file=$(find "$DECISIONS_DIR" -name "ADR-014-*.md" 2>/dev/null | head -1)  # STDERR-EXEMPT: find on tmpdir; absence/presence is the assertion
+  [ -n "$new_file" ]
+  basename "$new_file" | grep -qv '[<>/]'
+  # Original title preserved in ARCH-INDEX row
+  grep -q "Decision <with/special> chars" "$ARCH_INDEX"
+}
+
+@test "AC-4 [BC-6.20.008]: missing Architecture Decisions section blocks insert" {
+  # Remove the section header from ARCH-INDEX.
+  grep -v "## Architecture Decisions" "$ARCH_INDEX" > "${ARCH_INDEX}.tmp"
+  mv "${ARCH_INDEX}.tmp" "$ARCH_INDEX"
+  _run_driver --title "New Decision" --subsystems "SS-06"
+  [ "$status" -ne 0 ]
+  # No new file should be written.
+  new_file=$(find "$DECISIONS_DIR" -name "ADR-014-*.md" 2>/dev/null | head -1)  # STDERR-EXEMPT: find on tmpdir; absence/presence is the assertion
+  [ -z "$new_file" ]
+  # Must mention the missing section in the error output.
+  [[ "$output" == *"Architecture Decisions"* ]] || [[ "$output" == *"section"* ]] || [[ "$output" == *"ARCH-INDEX"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# AC-5: Hand-off pattern — no ghost-writing, guidance block on stdout
+# ---------------------------------------------------------------------------
+
+@test "AC-5 [BC-6.20.009]: scaffold preserves template placeholder text verbatim" {
+  _run_driver --title "New Decision" --subsystems "SS-06"
+  [ "$status" -eq 0 ]
+  new_file=$(find "$DECISIONS_DIR" -name "ADR-014-*.md" 2>/dev/null | head -1)  # STDERR-EXEMPT: find on tmpdir; absence/presence is the assertion
+  [ -n "$new_file" ]
+  # The template contains this exact placeholder; it must appear verbatim.
+  grep -q "\[2-5 paragraphs\] Background, forces driving the decision" "$new_file"
+}
+
+@test "AC-5 [BC-6.20.009]: stdout guidance block lists all sections to flesh out" {
+  _run_driver --title "New Decision" --subsystems "SS-06"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Sections to flesh out"* ]]
+  [[ "$output" == *"Context"* ]]
+  [[ "$output" == *"Decision"* ]]
+  [[ "$output" == *"Rationale"* ]]
+  [[ "$output" == *"Consequences"* ]]
+  [[ "$output" == *"Alternatives Considered"* ]]
+  [[ "$output" == *"Source / Origin"* ]]
+  # SKILL.md Step 11 also requires "Recommended next step:" guidance line
+  [[ "$output" == *"Recommended next step"* ]]
+}
+
+@test "AC-5 [BC-6.20.009, VP-059]: --dry-run prints proposed ID without writing files" {
+  # --dry-run must output proposed ID and write nothing (required by VP-059 harness)
+  _run_driver --title "New Decision" --subsystems "SS-06" --dry-run
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ADR-014"* ]]
+  [[ "$output" == *"Dry-run"* ]]
+  # No new ADR file must have been written
+  new_file=$(find "$DECISIONS_DIR" -name "ADR-014-*.md" 2>/dev/null | head -1)  # STDERR-EXEMPT: find on tmpdir; absence/presence is the assertion  # STDERR-EXEMPT: find on tmpdir; absence is the expected result
+  [ -z "$new_file" ]
+  # ARCH-INDEX must NOT have been modified
+  run grep -c "ADR-014" "$ARCH_INDEX"
+  [ "$output" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# AC-6: Brownfield mode annotation
+# ---------------------------------------------------------------------------
+
+@test "AC-6 [BC-6.20.010]: --brownfield flag injects Source/Origin annotation" {
+  _run_driver --title "New Decision" --subsystems "SS-06" --brownfield
+  [ "$status" -eq 0 ]
+  new_file=$(find "$DECISIONS_DIR" -name "ADR-014-*.md" 2>/dev/null | head -1)  # STDERR-EXEMPT: find on tmpdir; absence/presence is the assertion
+  [ -n "$new_file" ]
+  grep -q "BROWNFIELD" "$new_file"
+}
+
+@test "AC-6 [BC-6.20.010]: --supersedes implies brownfield annotation" {
+  _run_driver --title "New Decision" --subsystems "SS-06" --supersedes "ADR-012"
+  [ "$status" -eq 0 ]
+  new_file=$(find "$DECISIONS_DIR" -name "ADR-014-*.md" 2>/dev/null | head -1)  # STDERR-EXEMPT: find on tmpdir; absence/presence is the assertion
+  [ -n "$new_file" ]
+  grep -q "BROWNFIELD" "$new_file"
+}
+
+@test "AC-6 [BC-6.20.010]: no flag, no supersedes, no annotation" {
+  _run_driver --title "New Decision" --subsystems "SS-06"
+  [ "$status" -eq 0 ]
+  new_file=$(find "$DECISIONS_DIR" -name "ADR-014-*.md" 2>/dev/null | head -1)  # STDERR-EXEMPT: find on tmpdir; absence/presence is the assertion
+  [ -n "$new_file" ]
+  # Must NOT contain the brownfield annotation.
+  run grep -c "BROWNFIELD" "$new_file"
+  [ "$output" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# AC-7: Final validation gate
+# ---------------------------------------------------------------------------
+
+@test "AC-7 [BC-6.20.011]: validation pass exits 0 and registers ADR" {
+  export MOCK_VALIDATE_EXIT=0
+  _run_driver --title "New Decision" --subsystems "SS-06"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Template compliance: PASS"* ]]
+  # ARCH-INDEX must contain ADR-014 row.
+  grep -q "ADR-014" "$ARCH_INDEX"
+}
+
+@test "AC-7 [BC-6.20.011]: validation fail exits non-zero and skips index row" {
+  export MOCK_VALIDATE_EXIT=1
+  _run_driver --title "New Decision" --subsystems "SS-06"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Template compliance: FAIL"* ]] || [[ "$output" == *"not registered"* ]]
+  # ARCH-INDEX must NOT contain ADR-014 row.
+  run grep -c "ADR-014" "$ARCH_INDEX"
+  [ "$output" -eq 0 ]
+}
+
+@test "AC-7 [BC-6.20.011]: validation fail reverts supersession patch" {
+  export MOCK_VALIDATE_EXIT=1
+  _run_driver --title "New Decision" --subsystems "SS-06" --supersedes "ADR-013"
+  [ "$status" -ne 0 ]
+  # Driver must report the validation failure.
+  [[ "$output" == *"Template compliance: FAIL"* ]] || [[ "$output" == *"not registered"* ]] || [[ "$output" == *"FAIL"* ]]
+  # ADR-013 must NOT have been patched with superseded_by.
+  run grep -c "superseded_by: ADR-014" "$DECISIONS_DIR/ADR-013-adversarial-review-structure.md"
+  [ "$output" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# AC-8: Atomicity / no partial state
+# ---------------------------------------------------------------------------
+
+@test "AC-8 [BC-6.20.012]: file write fail leaves no index row" {
+  # Make DECISIONS_DIR read-only so the new file cannot be written.
+  chmod 555 "$DECISIONS_DIR"
+  _run_driver --title "New Decision" --subsystems "SS-06"
+  status_after="$status"
+  chmod 755 "$DECISIONS_DIR"
+  [ "$status_after" -ne 0 ]
+  # ARCH-INDEX must not contain ADR-014.
+  run grep -c "ADR-014" "$ARCH_INDEX"
+  [ "$output" -eq 0 ]
+}
+
+@test "AC-8 [BC-6.20.012]: index insert fail deletes the new file" {
+  # Make ARCH-INDEX read-only so the row cannot be inserted.
+  chmod 444 "$ARCH_INDEX"
+  _run_driver --title "New Decision" --subsystems "SS-06"
+  status_after="$status"
+  chmod 644 "$ARCH_INDEX"
+  [ "$status_after" -ne 0 ]
+  # New ADR file must have been cleaned up.
+  new_file=$(find "$DECISIONS_DIR" -name "ADR-014-*.md" 2>/dev/null | head -1)  # STDERR-EXEMPT: find on tmpdir; absence/presence is the assertion
+  [ -z "$new_file" ]
+}
+
+@test "AC-8 [BC-6.20.012]: supersession patch fail deletes new file (index never written)" {
+  # Make ADR-013 read-only so the supersession patch fails mid-flight.
+  chmod 444 "$DECISIONS_DIR/ADR-013-adversarial-review-structure.md"
+  _run_driver --title "New Decision" --subsystems "SS-06" --supersedes "ADR-013"
+  status_after="$status"
+  chmod 644 "$DECISIONS_DIR/ADR-013-adversarial-review-structure.md"
+  [ "$status_after" -ne 0 ]
+  # New file must not exist.
+  new_file=$(find "$DECISIONS_DIR" -name "ADR-014-*.md" 2>/dev/null | head -1)  # STDERR-EXEMPT: find on tmpdir; absence/presence is the assertion
+  [ -z "$new_file" ]
+  # ARCH-INDEX must not contain ADR-014.
+  run grep -c "ADR-014" "$ARCH_INDEX"
+  [ "$output" -eq 0 ]
+}
+
+@test "AC-8 [BC-6.20.012]: idempotent re-invocation succeeds after prior failure" {
+  # First invocation: fail by making DECISIONS_DIR unwritable.
+  chmod 555 "$DECISIONS_DIR"
+  _run_driver --title "New Decision" --subsystems "SS-06"
+  [ "$status" -ne 0 ]
+  chmod 755 "$DECISIONS_DIR"
+
+  # Second invocation with same arguments must succeed cleanly.
+  _run_driver --title "New Decision" --subsystems "SS-06"
+  [ "$status" -eq 0 ]
+  grep -q "ADR-014" "$ARCH_INDEX"
+}

--- a/plugins/vsdd-factory/tests/helpers/create-adr-driver.sh
+++ b/plugins/vsdd-factory/tests/helpers/create-adr-driver.sh
@@ -1,0 +1,492 @@
+#!/usr/bin/env bash
+# create-adr-driver.sh — Real implementation of the create-adr skill driver.
+#
+# Satisfies all 25 bats tests in create-adr.bats (S-6.01 GREEN phase).
+#
+# CLI surface:
+#   create-adr-driver.sh --title <text> --subsystems <SS-NN[,SS-NN...]>
+#                        [--supersedes <ADR-NNN>] [--brownfield] [--id <ADR-NNN>]
+#                        [--dry-run]
+#
+# Environment variables (wired by bats setup()):
+#   DECISIONS_DIR  — absolute path to decisions/ directory
+#   ARCH_INDEX     — absolute path to ARCH-INDEX.md
+#   ADR_TEMPLATE   — absolute path to adr-template.md
+#   VALIDATE_BIN   — absolute path to validate-template-compliance.sh
+#
+# Exit codes:
+#   0  — success
+#   1  — any error
+
+# Do NOT use set -e; we handle errors explicitly for atomic rollback.
+set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+TITLE=""
+SUBSYSTEMS=""
+SUPERSEDES=""
+BROWNFIELD=0
+EXPLICIT_ID=""
+DRY_RUN=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --title)       TITLE="$2";       shift 2 ;;
+    --subsystems)  SUBSYSTEMS="$2";  shift 2 ;;
+    --supersedes)  SUPERSEDES="$2";  shift 2 ;;
+    --brownfield)  BROWNFIELD=1;     shift   ;;
+    --id)          EXPLICIT_ID="$2"; shift 2 ;;
+    --dry-run)     DRY_RUN=1;        shift   ;;
+    *)             shift ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Resolve env defaults (fall back to real repo paths when not set by tests)
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+REPO_ROOT="$(cd "$PLUGIN_ROOT/../.." && pwd)"
+
+DECISIONS_DIR="${DECISIONS_DIR:-$REPO_ROOT/.factory/specs/architecture/decisions}"
+ARCH_INDEX="${ARCH_INDEX:-$REPO_ROOT/.factory/specs/architecture/ARCH-INDEX.md}"
+ADR_TEMPLATE="${ADR_TEMPLATE:-$PLUGIN_ROOT/templates/adr-template.md}"
+VALIDATE_BIN="${VALIDATE_BIN:-$PLUGIN_ROOT/bin/validate-template-compliance.sh}"
+
+# ---------------------------------------------------------------------------
+# No-args: print usage and exit 0
+# ---------------------------------------------------------------------------
+if [[ -z "$TITLE" && -z "$SUBSYSTEMS" && -z "$SUPERSEDES" && -z "$EXPLICIT_ID" \
+      && "$BROWNFIELD" -eq 0 && "$DRY_RUN" -eq 0 ]]; then
+  cat <<'USAGE'
+Usage: create-adr-driver.sh --title <text> --subsystems <SS-NN[,...]>
+                            [--supersedes <ADR-NNN>] [--brownfield]
+                            [--id <ADR-NNN>] [--dry-run]
+USAGE
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Argument validation order (BC-6.20.008 inv 5): --title first, subsystems
+# second, supersedes third, ID last
+# ---------------------------------------------------------------------------
+if [[ -z "$TITLE" ]]; then
+  echo "ERROR: --title is required." >&2
+  exit 1
+fi
+
+if [[ -z "$SUBSYSTEMS" ]]; then
+  echo "ERROR: --subsystems is required." >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Helper: derive slug from title
+# Lowercase; whitespace runs -> single '-'; strip non-[a-z0-9-]; collapse '--'; trim '-'
+# ---------------------------------------------------------------------------
+derive_slug() {
+  local title="$1"
+  local slug
+  slug="${title,,}"
+  # Replace whitespace runs with single '-'
+  slug=$(printf '%s' "$slug" | tr -s '[:space:]' '-')
+  # Strip all non-[a-z0-9-] characters (including non-ASCII)
+  slug=$(printf '%s' "$slug" | LC_ALL=C tr -cd 'a-z0-9-')
+  # Collapse consecutive hyphens
+  slug=$(printf '%s' "$slug" | tr -s '-')
+  # Trim leading/trailing hyphens
+  slug="${slug#-}"
+  slug="${slug%-}"
+  printf '%s' "$slug"
+}
+
+# ---------------------------------------------------------------------------
+# Validate ARCH-INDEX has Architecture Decisions section (checked early)
+# ---------------------------------------------------------------------------
+if [[ ! -f "$ARCH_INDEX" ]]; then
+  echo "ERROR: ARCH-INDEX not found at $ARCH_INDEX." >&2
+  exit 1
+fi
+
+if ! grep -q "^## Architecture Decisions" "$ARCH_INDEX"; then
+  echo "ERROR: ARCH-INDEX missing '## Architecture Decisions' section. Cannot insert row." >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Validate subsystems against ARCH-INDEX Subsystem Registry (BC-6.20.005)
+# ---------------------------------------------------------------------------
+validate_subsystems() {
+  local subsystems_str="$1"
+  local valid_ids
+  valid_ids=$(grep "^| SS-" "$ARCH_INDEX" | LC_ALL=C sed 's/^| \(SS-[0-9][0-9]\) .*/\1/')
+
+  IFS=',' read -ra SS_LIST <<< "$subsystems_str"
+  for ss in "${SS_LIST[@]}"; do
+    ss=$(printf '%s' "$ss" | tr -d ' ')
+    if ! printf '%s\n' "$valid_ids" | grep -qx "$ss"; then
+      echo "ERROR: Unknown or invalid subsystem '$ss'. Valid subsystems: $(printf '%s\n' "$valid_ids" | tr '\n' ' ')" >&2
+      exit 1
+    fi
+  done
+}
+
+validate_subsystems "$SUBSYSTEMS"
+
+# ---------------------------------------------------------------------------
+# Validate --supersedes exists (BC-6.20.006)
+# ---------------------------------------------------------------------------
+if [[ -n "$SUPERSEDES" ]]; then
+  supersedes_file=$(find "$DECISIONS_DIR" -maxdepth 1 -name "${SUPERSEDES}-*.md" 2>/dev/null | head -1)  # STDERR-EXEMPT: find warns on missing dir; absence is handled below
+  if [[ -z "$supersedes_file" ]]; then
+    echo "ERROR: --supersedes ${SUPERSEDES} does not exist in $DECISIONS_DIR." >&2
+    exit 1
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Ensure decisions directory exists
+# ---------------------------------------------------------------------------
+mkdir -p "$DECISIONS_DIR"
+
+# ---------------------------------------------------------------------------
+# ID allocation (BC-6.20.001/002/003)
+# ---------------------------------------------------------------------------
+
+fs_max=0
+fs_ids_str=""
+while IFS= read -r fname; do
+  base=$(basename "$fname")
+  num_str=$(printf '%s' "$base" | LC_ALL=C sed -n 's/^ADR-\([0-9][0-9][0-9]\)-.*/\1/p')
+  if [[ -n "$num_str" ]]; then
+    num=$((10#$num_str))
+    fs_ids_str="${fs_ids_str}${num},"
+    if (( num > fs_max )); then
+      fs_max=$num
+    fi
+  fi
+done < <(find "$DECISIONS_DIR" -maxdepth 1 -name "ADR-[0-9][0-9][0-9]-*.md" 2>/dev/null | sort)  # STDERR-EXEMPT: find warns on missing dir; mkdir -p above guards this
+
+idx_max=0
+idx_ids_str=""
+while IFS= read -r line; do
+  num_str=$(printf '%s' "$line" | LC_ALL=C sed -n 's/^| ADR-\([0-9][0-9][0-9]\) .*/\1/p')
+  if [[ -n "$num_str" ]]; then
+    num=$((10#$num_str))
+    idx_ids_str="${idx_ids_str}${num},"
+    if (( num > idx_max )); then
+      idx_max=$num
+    fi
+  fi
+done < "$ARCH_INDEX"
+
+# Normalize: sort comma-separated ID lists for comparison
+fs_sorted=$(printf '%s\n' ${fs_ids_str//,/ } | sort -n | tr '\n' ',' | sed 's/,$//')
+idx_sorted=$(printf '%s\n' ${idx_ids_str//,/ } | sort -n | tr '\n' ',' | sed 's/,$//')
+
+if [[ "$fs_sorted" != "$idx_sorted" ]]; then
+  echo "ERROR: Filesystem and ARCH-INDEX ADR IDs are inconsistent (mismatch). Filesystem: [$fs_sorted] Index: [$idx_sorted]. ADR-013 or another ADR may be missing from one source. Reconcile manually before proceeding." >&2
+  exit 1
+fi
+
+overall_max=$(( fs_max > idx_max ? fs_max : idx_max ))
+next_num=$(( overall_max + 1 ))
+proposed_id=$(printf "ADR-%03d" "$next_num")
+
+# Handle explicit --id override (BC-6.20.002)
+if [[ -n "$EXPLICIT_ID" ]]; then
+  existing=$(find "$DECISIONS_DIR" -maxdepth 1 -name "${EXPLICIT_ID}-*.md" 2>/dev/null | head -1)  # STDERR-EXEMPT: find warns on missing dir; absence handled below
+  if [[ -n "$existing" ]]; then
+    echo "ERROR: ${EXPLICIT_ID} already exists at decisions/$(basename "$existing"). Omit --id to auto-allocate or choose a free ID." >&2
+    exit 1
+  fi
+  if grep -q "^| ${EXPLICIT_ID} " "$ARCH_INDEX"; then
+    echo "ERROR: ${EXPLICIT_ID} already exists in ARCH-INDEX. Omit --id to auto-allocate or choose a free ID." >&2
+    exit 1
+  fi
+  proposed_id="$EXPLICIT_ID"
+fi
+
+SLUG=$(derive_slug "$TITLE")
+
+# ---------------------------------------------------------------------------
+# Dry-run: print and exit 0 without writing
+# ---------------------------------------------------------------------------
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  echo "Dry-run: proposed ADR ID = $proposed_id, slug = $SLUG"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Build ADR file content from template
+# ---------------------------------------------------------------------------
+if [[ ! -f "$ADR_TEMPLATE" ]]; then
+  echo "ERROR: ADR template not found at $ADR_TEMPLATE." >&2
+  exit 1
+fi
+
+TODAY=$(date +%Y-%m-%d)
+
+IFS=',' read -ra SS_ARRAY <<< "$SUBSYSTEMS"
+SS_TRIMMED=()
+for ss in "${SS_ARRAY[@]}"; do
+  SS_TRIMMED+=("$(printf '%s' "$ss" | tr -d ' ')")
+done
+SS_YAML=$(printf '[%s]' "$(printf '%s, ' "${SS_TRIMMED[@]}" | sed 's/, $//')")
+SS_JOINED=$(printf '%s, ' "${SS_TRIMMED[@]}" | sed 's/, $//')
+
+SUPERSEDES_VAL="${SUPERSEDES:-null}"
+
+# Extract template body (everything after the second closing ---)
+template_body=$(awk 'BEGIN{found=0; count=0} /^---/{count++; if(count==2){found=1; next}} found{print}' "$ADR_TEMPLATE")
+
+# Build initial ADR file content
+adr_file="${DECISIONS_DIR}/${proposed_id}-${SLUG}.md"
+FILE_PATH="decisions/${proposed_id}-${SLUG}.md"
+
+# ---------------------------------------------------------------------------
+# Write ADR file content via a temp file, then rename into place
+# (The write itself is to a temp file; this is the pre-validation staging)
+# ---------------------------------------------------------------------------
+WROTE_FILE=0
+INSERTED_INDEX=0
+PATCHED_OLD_ADR=""
+OLD_ADR_PREV_VALUE=""
+
+# Rollback function — called on any mid-flight failure except validation failure
+rollback() {
+  local reason="$1"
+  echo "ERROR: $reason" >&2
+  echo "ERROR: $reason"
+
+  if [[ -n "$PATCHED_OLD_ADR" ]]; then
+    if [[ -w "$PATCHED_OLD_ADR" ]]; then
+      restore_content=$(awk -v prev="$OLD_ADR_PREV_VALUE" '
+        /^superseded_by:/ { print "superseded_by: " prev; next }
+        { print }
+      ' "$PATCHED_OLD_ADR" 2>/dev/null)  # STDERR-EXEMPT: awk stderr on missing file; writeability already checked
+      if printf '%s\n' "$restore_content" > "$PATCHED_OLD_ADR" 2>/dev/null; then  # STDERR-EXEMPT: write permission already checked above
+        echo "Restored $(basename "$PATCHED_OLD_ADR") superseded_by to ${OLD_ADR_PREV_VALUE}." >&2
+      else
+        echo "WARNING: Could not restore $(basename "$PATCHED_OLD_ADR") superseded_by field." >&2
+      fi
+    else
+      echo "WARNING: Cannot restore $(basename "$PATCHED_OLD_ADR") — not writable." >&2
+    fi
+  fi
+
+  if [[ "$INSERTED_INDEX" -eq 1 ]]; then
+    if [[ -w "$ARCH_INDEX" ]]; then
+      local content_no_row
+      content_no_row=$(grep -v "^| ${proposed_id} " "$ARCH_INDEX" 2>/dev/null)  # STDERR-EXEMPT: writeability checked above
+      if printf '%s\n' "$content_no_row" > "$ARCH_INDEX" 2>/dev/null; then  # STDERR-EXEMPT: writeability checked above
+        echo "Reverted ARCH-INDEX row for ${proposed_id}." >&2
+      else
+        echo "WARNING: ARCH-INDEX revert failed — manual cleanup required." >&2
+      fi
+    else
+      echo "WARNING: ARCH-INDEX revert failed — manual cleanup required." >&2
+    fi
+    INSERTED_INDEX=0
+  fi
+
+  if [[ "$WROTE_FILE" -eq 1 ]]; then
+    rm -f "$adr_file" 2>/dev/null  # STDERR-EXEMPT: best-effort cleanup; missing file is acceptable
+    echo "Deleted ${proposed_id}-${SLUG}.md." >&2
+    WROTE_FILE=0
+  fi
+
+  exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Step 6: Write the ADR file
+# ---------------------------------------------------------------------------
+
+# Generate the frontmatter + body
+{
+  printf -- '---\n'
+  printf 'document_type: adr\n'
+  printf 'adr_id: %s\n' "$proposed_id"
+  printf 'status: proposed\n'
+  printf 'date: %s\n' "$TODAY"
+  printf 'subsystems_affected: %s\n' "$SS_YAML"
+  printf 'supersedes: %s\n' "$SUPERSEDES_VAL"
+  printf 'superseded_by: null\n'
+  printf -- '---\n'
+  printf '\n'
+  printf '# %s: %s\n' "$proposed_id" "$TITLE"
+  printf '%s\n' "$template_body"
+} > "$adr_file" 2>/dev/null || {  # STDERR-EXEMPT: write failure produces no useful stderr; error message below is explicit
+  echo "ERROR: Failed to write new ADR file at $adr_file." >&2
+  exit 1
+}
+WROTE_FILE=1
+
+# ---------------------------------------------------------------------------
+# Step 6b: Inject brownfield annotation if --brownfield or --supersedes set
+# ---------------------------------------------------------------------------
+if [[ "$BROWNFIELD" -eq 1 || -n "$SUPERSEDES" ]]; then
+  # Write a new version of the file with the annotation inserted after
+  # "## Source / Origin"
+  local_tmp=$(mktemp)
+  in_source_section=0
+  annotation_inserted=0
+  while IFS= read -r line; do
+    printf '%s\n' "$line" >> "$local_tmp"
+    if [[ "$line" == "## Source / Origin" && "$annotation_inserted" -eq 0 ]]; then
+      printf '%s\n' "<!-- BROWNFIELD: You MUST cite implementation evidence (file:line from crates/ or" >> "$local_tmp"
+      printf '%s\n' "     legacy-design-docs/) before this ADR can be accepted. Omitting evidence is a" >> "$local_tmp"
+      printf '%s\n' "     template-compliance failure. -->" >> "$local_tmp"
+      annotation_inserted=1
+    fi
+  done < "$adr_file"
+  mv "$local_tmp" "$adr_file" 2>/dev/null || {  # STDERR-EXEMPT: mv failure triggers rollback with explicit message
+    rollback "Failed to inject brownfield annotation into $adr_file."
+  }
+fi
+
+# ---------------------------------------------------------------------------
+# Step 7: Apply supersession patch (BC-6.20.007)
+# ---------------------------------------------------------------------------
+if [[ -n "$SUPERSEDES" ]]; then
+  old_adr_file=$(find "$DECISIONS_DIR" -maxdepth 1 -name "${SUPERSEDES}-*.md" 2>/dev/null | head -1)  # STDERR-EXEMPT: validated to exist at arg-parse time; absence triggers rollback below
+  if [[ -z "$old_adr_file" ]]; then
+    rollback "Old ADR ${SUPERSEDES} not found for supersession patch."
+  fi
+
+  OLD_ADR_PREV_VALUE=$(awk '/^superseded_by:/{print $2; exit}' "$old_adr_file")
+  [[ -z "$OLD_ADR_PREV_VALUE" ]] && OLD_ADR_PREV_VALUE="null"
+
+  PATCHED_OLD_ADR="$old_adr_file"
+
+  # Check writeability before attempting (direct write required — mv bypasses mode 444 on macOS)
+  if [[ ! -w "$old_adr_file" ]]; then
+    rollback "supersession patch failed for ${SUPERSEDES}: permission denied (read-only file). Rollback initiated."
+  fi
+
+  patch_content=$(awk -v new_id="$proposed_id" '
+    /^superseded_by:/ { print "superseded_by: " new_id; next }
+    { print }
+  ' "$old_adr_file" 2>/dev/null)  # STDERR-EXEMPT: awk stderr on unreadable file; writeability already checked above
+  if [[ -z "$patch_content" ]]; then
+    rollback "Failed to generate supersession patch content for ${SUPERSEDES}."
+  fi
+
+  if ! printf '%s\n' "$patch_content" > "$old_adr_file" 2>/dev/null; then  # STDERR-EXEMPT: writeability checked above; failure triggers rollback
+    rollback "Failed to write supersession patch to ${SUPERSEDES} (permission denied)."
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Step 8: Insert ARCH-INDEX row (BC-6.20.008)
+# Must write directly to the file (not via mv) so read-only fails correctly.
+# ---------------------------------------------------------------------------
+ROW="| ${proposed_id} | ${TITLE} | ${SS_JOINED} | ${FILE_PATH} |"
+
+# Build updated ARCH-INDEX content in memory
+updated_index=""
+last_adr_line_num=0
+line_num=0
+while IFS= read -r line; do
+  line_num=$(( line_num + 1 ))
+  if [[ "$line" =~ ^\|\ ADR-[0-9][0-9][0-9]\  ]]; then
+    last_adr_line_num="$line_num"
+  fi
+done < "$ARCH_INDEX"
+
+current_line=0
+while IFS= read -r line; do
+  current_line=$(( current_line + 1 ))
+  updated_index="${updated_index}${line}"$'\n'
+  if [[ "$current_line" -eq "$last_adr_line_num" ]]; then
+    updated_index="${updated_index}${ROW}"$'\n'
+  fi
+done < "$ARCH_INDEX"
+
+# Handle empty table (no data rows found): insert after separator row in Architecture Decisions section
+if [[ "$last_adr_line_num" -eq 0 ]]; then
+  in_section=0
+  sep_inserted=0
+  updated_index=""
+  while IFS= read -r line; do
+    updated_index="${updated_index}${line}"$'\n'
+    if [[ "$line" =~ ^##\ Architecture\ Decisions ]]; then
+      in_section=1
+    fi
+    if [[ "$in_section" -eq 1 && "$sep_inserted" -eq 0 && "$line" =~ ^\|[-|]+\| ]]; then
+      updated_index="${updated_index}${ROW}"$'\n'
+      sep_inserted=1
+    fi
+  done < "$ARCH_INDEX"
+fi
+
+# Write directly to ARCH_INDEX (not via mv) so read-only file permission fails
+if ! printf '%s' "$updated_index" > "$ARCH_INDEX" 2>/dev/null; then  # STDERR-EXEMPT: write failure triggers rollback with explicit message
+  rollback "Failed to write ARCH-INDEX (permission denied or read-only file)."
+fi
+INSERTED_INDEX=1
+
+# ---------------------------------------------------------------------------
+# Step 9: Run validate-template-compliance.sh as final gate (BC-6.20.011)
+# ---------------------------------------------------------------------------
+if [[ ! -x "$VALIDATE_BIN" ]]; then
+  rollback "validate-template-compliance.sh not found or not executable at $VALIDATE_BIN — cannot complete AC-7."
+fi
+
+validate_output=$("$VALIDATE_BIN" "$adr_file" 2>&1)
+validate_exit=$?
+
+if [[ "$validate_exit" -ne 0 ]]; then
+  [[ -n "$validate_output" ]] && echo "$validate_output"
+
+  # Validation failure: revert ARCH-INDEX and supersession, but LEAVE file on disk
+  if [[ -n "$PATCHED_OLD_ADR" && -w "$PATCHED_OLD_ADR" ]]; then
+    restore_content2=$(awk -v prev="$OLD_ADR_PREV_VALUE" '
+      /^superseded_by:/ { print "superseded_by: " prev; next }
+      { print }
+    ' "$PATCHED_OLD_ADR" 2>/dev/null)  # STDERR-EXEMPT: writeability checked by -w guard above
+    if printf '%s\n' "$restore_content2" > "$PATCHED_OLD_ADR" 2>/dev/null; then  # STDERR-EXEMPT: writeability checked by -w guard above
+      echo "Restored $(basename "$PATCHED_OLD_ADR") superseded_by to ${OLD_ADR_PREV_VALUE}." >&2
+    fi
+  fi
+
+  if [[ "$INSERTED_INDEX" -eq 1 && -w "$ARCH_INDEX" ]]; then
+    content_no_row=$(grep -v "^| ${proposed_id} " "$ARCH_INDEX" 2>/dev/null)  # STDERR-EXEMPT: writeability checked by -w guard above
+    printf '%s\n' "$content_no_row" > "$ARCH_INDEX" 2>/dev/null  # STDERR-EXEMPT: writeability checked by -w guard above
+    echo "Reverted ARCH-INDEX row for ${proposed_id}." >&2
+  fi
+
+  # File intentionally left on disk (BC-6.20.011 / BC-6.20.012)
+  echo "Template compliance: FAIL — ${proposed_id} not registered. Fix the issues above and re-run."
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Step 10: Emit structured event (AC-5 / BC-6.20.009)
+# ---------------------------------------------------------------------------
+EMIT_BIN="${PLUGIN_ROOT}/bin/emit-event"
+if [[ -x "$EMIT_BIN" ]]; then
+  "$EMIT_BIN" "type=adr.scaffolded" "adr_id=${proposed_id}" "slug=${SLUG}" \
+    "subsystems=${SS_JOINED}" "path=${FILE_PATH}" 2>/dev/null || true  # STDERR-EXEMPT: event emission is failure-tolerant per emit-event contract
+fi
+
+# ---------------------------------------------------------------------------
+# Step 11: Print guidance block to stdout (BC-6.20.009)
+# ---------------------------------------------------------------------------
+echo "Template compliance: PASS"
+echo ""
+echo "${proposed_id} scaffolded at: ${FILE_PATH}"
+echo ""
+echo "Sections to flesh out:"
+echo "  - Context      (2-5 paragraphs: background, forces, constraints)"
+echo "  - Decision     (1-3 paragraphs: the choice itself)"
+echo "  - Rationale    (2-5 paragraphs: why this, not alternatives)"
+echo "  - Consequences (Positive / Negative sub-headings)"
+echo "  - Alternatives Considered (top 2-3 options rejected)"
+echo "  - Source / Origin (MUST cite implementation evidence for brownfield ADRs)"
+echo ""
+echo "Recommended next step:"
+echo "  Spawn architect agent: \"Flesh out ${proposed_id} sections. File: .factory/specs/architecture/${FILE_PATH}\""


### PR DESCRIPTION
## Summary

Release **v1.0.0-beta.6** — bundles two CONVERGED feature deliveries (S-6.01 + E-7) plus substantial spec backfill. Self-referential dogfooding milestone: vsdd-factory used its own VSDD process to find and codify gaps in vsdd-factory.

## What's included

| Source | Tip | Description |
|--------|-----|-------------|
| PR #6 (E-7 codify-lessons) | a412700 → develop @ 33d7a06 | 8 lessons from S-6.01 codified into agent prompts + new hook + new rule |
| PR #7 (S-6.01 create-adr) | e1a2d42 → develop @ 9dcc52b | New `/vsdd-factory:create-adr` skill, 26 bats tests |
| factory-artifacts spec backfill | (separate worktree) | 10 ADRs, 27 BCs, 5 VPs, 2 FRs, 2 epics |

## Adversarial convergence (this release cycle)

- **s6.01-spec sub-cycle:** 8 passes, trajectory 19 → 4 → 2 → 1 → 1 → 0 → 0 → 0, **CONVERGENCE_REACHED** at pass-8
- **e7-spec sub-cycle:** 7 passes, trajectory 12 → 5 → 1 → 2 → 2 → 0 → 0, **CONVERGENCE_REACHED** at pass-7
- **PR-level review:** PR #7 cycle-1 (11 findings, all fixed), PR #6 cycle-1 (4 findings incl. 1 HIGH, all fixed) + cycle-2 (BC-5.36.007 brittleness fix)
- **Total findings closed across all reviews:** 42

## Test plan

- [ ] `bats plugins/vsdd-factory/tests/create-adr.bats` → 26/26 GREEN
- [ ] `bats plugins/vsdd-factory/tests/codify-lessons.bats` → 16/16 GREEN
- [ ] CI green on this PR
- [ ] After merge: tag `v1.0.0-beta.6` on main → release workflow builds dispatcher binaries + writes plugin.json:version atomically (per beta.4 cache-staleness fix)
- [ ] After tag: merge release branch back to develop to carry forward CHANGELOG entry

## Per beta.4 cache-staleness fix

This PR only modifies `CHANGELOG.md`. The release workflow bot will:
1. Build dispatcher binaries for all 5 platforms
2. Write `plugin.json:version = 1.0.0-beta.6`
3. Write `marketplace.json:plugins[0].version = 1.0.0-beta.6`
4. Commit binaries + JSON updates atomically as github-actions[bot]
5. Force-update the v1.0.0-beta.6 tag to the bot commit
6. Create the GH release

## Identifier counts post-release

| Type | Pre-beta.6 | Post-beta.6 |
|------|-----------|-------------|
| BCs (total) | 1,851 | 1,878 (+27) |
| VPs | 57 | 62 (+5) |
| FRs | 40 | 42 (+2) |
| Epics | 6 | 8 (+2) |
| Stories | 41 | 44 (+3) |
| ADRs | 3 | 13 (+10) |

See CHANGELOG.md diff for full release notes.