### PR TITLE
test: fix novelty-assessment fixture path after E-7 hook tightening

### DIFF
--- a/plugins/vsdd-factory/tests/workflow-validators-emission.bats
+++ b/plugins/vsdd-factory/tests/workflow-validators-emission.bats
@@ -104,7 +104,10 @@ EOF
 # ---------- validate-novelty-assessment.sh ----------
 
 @test "novelty-assessment: emits novelty_assessment_incomplete" {
-  local dir="$SCRATCH/.factory"
+  # Hook matcher (post-E-7 tightening) requires file under
+  # cycles/<key>/adversarial-reviews/ to avoid false-positives on ADRs
+  # whose filenames mention adversarial review (e.g., ADR-013).
+  local dir="$SCRATCH/.factory/cycles/test-cycle/adversarial-reviews"
   mkdir -p "$dir"
   local f="$dir/pass-01.md"
   cat > "$f" <<EOF


### PR DESCRIPTION
## Summary

Hotfix for the v1.0.0-beta.6 release workflow failure. The novelty-assessment test fixture path needs to match the tightened hook matcher introduced in PR #6 (E-7 codify-lessons).

## What broke

PR #6 tightened \`validate-novelty-assessment.sh\` matcher to anchor on \`cycles/<key>/adversarial-reviews/\` paths (correctly fixing the false-positive on ADR-013). This unblocked future ADRs whose filenames mention adversarial review.

Side-effect: the existing test fixture at \`\$SCRATCH/.factory/pass-01.md\` no longer matches the tightened pattern. The hook returns 0 (out-of-scope) instead of 2 (validation block), and the test asserts exit 2.

## Fix

Move test fixture to canonical hook-trigger path: \`\$SCRATCH/.factory/cycles/test-cycle/adversarial-reviews/pass-01.md\`.

## Verification

- 13/13 \`workflow-validators-emission.bats\` tests pass locally
- Single-line fixture path change; no logic change to the test or hook

## Release impact

This unblocks the v1.0.0-beta.6 release workflow which failed at pre-release validation. After merge, this fix needs to land on main as well (cherry-pick PR), then retag v1.0.0-beta.6.