### PR TITLE
hotfix: fix novelty-assessment test fixture path on main (unblocks v1.0.0-beta.6)

### DIFF
--- a/plugins/vsdd-factory/tests/workflow-validators-emission.bats
+++ b/plugins/vsdd-factory/tests/workflow-validators-emission.bats
@@ -104,7 +104,10 @@ EOF
 # ---------- validate-novelty-assessment.sh ----------
 
 @test "novelty-assessment: emits novelty_assessment_incomplete" {
-  local dir="$SCRATCH/.factory"
+  # Hook matcher (post-E-7 tightening) requires file under
+  # cycles/<key>/adversarial-reviews/ to avoid false-positives on ADRs
+  # whose filenames mention adversarial review (e.g., ADR-013).
+  local dir="$SCRATCH/.factory/cycles/test-cycle/adversarial-reviews"
   mkdir -p "$dir"
   local f="$dir/pass-01.md"
   cat > "$f" <<EOF


### PR DESCRIPTION
## Summary

Hotfix cherry-picked from PR #10 (already merged to develop). Fixes the test that broke the v1.0.0-beta.6 release workflow at pre-release validation.

## Root cause

PR #6 (E-7 codify-lessons) tightened \`validate-novelty-assessment.sh\` matcher to anchor on \`cycles/<key>/adversarial-reviews/\` directory paths — correctly fixing the false-positive on ADR-013-adversarial-review-structure.md.

Side-effect: existing test fixture at \`\$SCRATCH/.factory/pass-01.md\` no longer matches the tightened pattern. Hook returns 0 (out-of-scope) instead of 2 (validation block); test asserts exit 2.

The release workflow's pre-release validation step ran the test, it failed, and the entire release was blocked — preventing the bot bundle commit (per beta.4 cache-staleness fix). v1.0.0-beta.6 tag exists but release workflow didn't bundle binaries or update plugin.json.

## Fix

Move test fixture to canonical hook-trigger path: \`\$SCRATCH/.factory/cycles/test-cycle/adversarial-reviews/pass-01.md\`.

## Verification

- 13/13 \`workflow-validators-emission.bats\` tests pass locally
- Single-line fixture path change

## Release sequence

After this PR merges:
1. Delete v1.0.0-beta.6 tag (only the tag — no GH Release exists yet)
2. Re-create v1.0.0-beta.6 tag pointing at new main HEAD (which includes this fix)
3. Push tag → release workflow re-fires with all checks passing → bot bundles binaries atomically

This is a hotfix on main (parallel to PR #10 which already landed on develop). No content change to beta.6 release; only the test infrastructure that gates it.