### PR TITLE
chore: back-merge bot bundle commit (v1.0.0-beta.6) to develop

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "vsdd-factory",
-      "version": "1.0.0-beta.5",
+      "version": "1.0.0-beta.6",
       "source": "./plugins/vsdd-factory",
       "description": "Full VSDD pipeline: brownfield ingest, spec crystallization, decomposition, TDD delivery, adversarial review, holdout eval, formal verification, release.",
       "category": "sdlc",

--- a/plugins/vsdd-factory/.claude-plugin/plugin.json
+++ b/plugins/vsdd-factory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vsdd-factory",
   "description": "Verified Spec-Driven Development (VSDD) dark factory for software — full SDLC pipeline: brownfield ingest, spec crystallization, story decomposition, TDD delivery, adversarial review, holdout evaluation, formal verification, and release gating.",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "author": {
     "name": "drbothen"
   },


### PR DESCRIPTION
## Summary

Standard back-merge of the release workflow's bot bundle commit (\`ae426cd\` on main) into develop. Carries the v1.0.0-beta.6 plugin.json/marketplace.json bump + windows-x64 dispatcher binary refresh.

This is the second back-merge for beta.6:
- PR #9 brought the operator chore commit (\`5bdfeae\` CHANGELOG entry) into develop
- This PR brings the bot bundle commit (atomic plugin.json + binaries) into develop

After this lands, develop's plugin.json shows 1.0.0-beta.6 matching main.