### PR TITLE
fix(stub-architect): policy compliance for coding-profile agent

### DIFF
--- a/plugins/vsdd-factory/agents/stub-architect.md
+++ b/plugins/vsdd-factory/agents/stub-architect.md
@@ -15,7 +15,7 @@ Agent ID: `stub-architect`
 
 Generates compilable stubs for every function, method, and type in a story's file
 list. All non-trivial function bodies use `todo!()` or `unimplemented!()`. The
-resulting codebase must compile (`cargo check` passes) and all new tests must be
+resulting codebase must compile (cargo check passes) and all new tests must be
 red (fail against the stubs).
 
 ## Operating Procedure
@@ -36,8 +36,8 @@ red (fail against the stubs).
 - Stub commit report listing any GREEN-BY-DESIGN or WIRING-EXEMPT functions (see below)
 
 ### Success Criteria
-- `cargo check` passes inside the worktree — stubs compile
-- `cargo test` shows new tests as **red** (failing), not green — Red Gate holds
+- cargo check passes inside the worktree — stubs compile
+- cargo test shows new tests as **red** (failing), not green — Red Gate holds
 - No non-trivial function body contains real implementation logic
 
 ## Constraints
@@ -166,13 +166,13 @@ all non-trivial bodies.
 ## Tool Access
 
 - Profile: `coding`
-- Available: `read`, `write`, `edit`, `apply_patch`, `exec` (for `cargo check`)
+- Available: `read`, `write`, `edit`, `apply_patch`, `exec` (for cargo check)
 - Write only to the story's designated worktree paths
 - Do NOT write to `.factory/` — state-manager owns those paths
 
 ## Failure & Escalation
 
-- **Level 1 (self-correct):** If `cargo check` fails after stub generation, fix
+- **Level 1 (self-correct):** If cargo check fails after stub generation, fix
   compilation errors. Do NOT add real logic to fix type errors — add the correct
   type signatures with `todo!()` bodies.
 - **Level 2 (partial output):** If a subset of files cannot be stubbed (missing
@@ -184,4 +184,7 @@ all non-trivial bodies.
 ## Remember
 
 **Every non-trivial body is `todo!()`. The implementer writes real code; you write
-shapes. Your job is done when `cargo check` passes and every new test is red.**
+shapes. Your job is done when cargo check passes and every new test is red.**
+
+---
+_Engine-wide principles: see `../../docs/AGENT-SOUL.md`._


### PR DESCRIPTION
## Summary

Hotfix for two policy-test failures in `tests/permissions.bats` blocking the v1.0.0-beta.7 release-workflow Pre-release Validation step.

The new \`agents/stub-architect.md\` (introduced by S-7.03 / PR #13) violated two project policies:

1. **Test 36 — \`coding-profile agents have no inline backtick shell commands\`**
   stub-architect.md is \`Profile: coding\`. The helper \`_check_no_inline_shell\` flags inline backticked patterns like \`cargo \`, \`npx \`, \`npm run \`, \`git ...\`, \`bash -c\`. Five lines violated with \`cargo check\` references at lines 18, 39, 169, 175, 187.
   **Fix:** drop the backticks (plain prose \"cargo check\").

2. **Test 63 — \`all agents reference AGENT-SOUL.md\`**
   stub-architect.md was missing the canonical engine-wide-principles footer.
   **Fix:** add the standard footer block.

## Test plan

- ✅ \`bats plugins/vsdd-factory/tests/permissions.bats\` — 68/68 GREEN locally (was 66/68 with tests 36 and 63 failing)
- ✅ \`bats plugins/vsdd-factory/tests/tdd-discipline-gate.bats\` — 18/18 GREEN (unchanged; the 5 backtick-stripped strings don't affect bats grep targets, which look for \`todo!()\` and \`BC-5.38.001\` literals)

## Why PR #14 didn't catch this

The PR's \`ci.yml\` workflow does not run \`tests/permissions.bats\` with the same coverage as \`release.yml\`'s Pre-release Validation step. This is a separately-trackable gap (CI/release validation alignment) — out of scope for this hotfix; will track as follow-up.

## Release continuation plan

After merge:
1. Re-tag v1.0.0-beta.7 on the new main HEAD (with the hotfix included)
2. Push tag → release workflow re-fires
3. Bot bundles binaries + retag
4. Back-merge main → develop