### PR TITLE
feat(validate-consistency): add tautology + BC-TV consistency advisory checks

### DIFF
--- a/plugins/vsdd-factory/skills/validate-consistency/SKILL.md
+++ b/plugins/vsdd-factory/skills/validate-consistency/SKILL.md
@@ -58,6 +58,91 @@ Read and follow the output format in:
 - Entity names in stories match domain-spec/ubiquitous-language.md
 - Module names in architecture match story file lists
 
+---
+
+## Advisory Checks (non-blocking)
+
+The following checks emit advisory findings only — they appear under `## Advisories` in the report and never count toward `Failed`. They are heuristic by nature; treat them as code-smell signals rather than gates. Both were motivated by a real production cycle (Prism Wave 2 Pass 7 — TD-W2-FIXK-001 + TD-W2-FIXK-002) where the patterns slipped through 6 prior adversarial passes.
+
+### 8. Test Tautology Detector (advisory, severity: MEDIUM)
+
+**Goal:** flag tests that look like behavior tests but only assert on data they themselves constructed — the test would pass even if the production code under test were deleted.
+
+**Scope:**
+- Rust test functions whose names match `^test_BC_`, `^test_TV_`, `^test_.*_BC_`, or `^test_.*_TV_` (case-sensitive prefix; case-insensitive `_BC_` / `_TV_` segment).
+- Search root: `**/tests/**/*.rs`, `**/src/**/*.rs` files containing `#[cfg(test)]` modules, and `**/test_*.rs` / `**/*_test.rs`.
+
+**Tautology shape (FLAG when ALL three hold):**
+1. Body contains at least one struct literal construction (`let <ident> = <Path::>SomeStruct { ... };` or `Path::SomeStruct { ... }` returned/bound).
+2. Body contains one or more `assert_eq!(<ident>.<field>, ...)`, `assert!(<ident>.<field>...)`, or `assert_matches!(<ident>.<field>, ...)` calls where `<ident>` is the locally-constructed value.
+3. Body contains **zero calls** to any production-named function whose ident matches `(emit|process|apply|handle|execute|validate|compute|transform|render|serialize|encode|decode|parse|build|generate)_\w+`. Calls in `use` statements or comments don't count. Calls inside `assert_eq!(left, right)` where `right` is a production fn count as passing the gate.
+
+**Allowed exceptions (DO NOT flag):**
+- Tests named `test_BC_*_struct_shape` or `test_TV_*_fixture` are explicit data-shape pins; recognized only if the function has a doc-comment containing `// data-shape pin` or `/// data-shape pin`.
+- Tests where the constructed struct is passed as an argument to a production fn (e.g., `emit_event(&entry)`) — this is the non-tautological case.
+- Tests inside a `#[cfg(test)]` module where the file's top-level doc-comment contains `//! tautology-allowed: <reason>`.
+
+**Detection procedure:**
+1. `rg -nU --type rust 'fn (test_(?:[A-Za-z_0-9]*_)?(?:BC|TV)_[A-Za-z_0-9]+)\s*\([^)]*\)\s*\{' -o` to enumerate candidate functions. The non-capturing group ensures only the literal `BC` or `TV` segment matches — not `BV` or `TC`.
+2. For each match, extract the function body (balanced braces, simple line counter from `{` to matching `}`).
+3. Apply the three-condition predicate above. Production-fn regex: `\b(emit|process|apply|handle|execute|validate|compute|transform|render|serialize|encode|decode|parse|build|generate)_[a-z][a-z0-9_]*\s*\(`.
+4. Apply exception filters; emit one advisory per surviving match.
+
+**Advisory output (one row per finding):**
+```
+| File | Function | Evidence | Suggestion |
+|------|----------|----------|------------|
+| crates/foo/tests/bc.rs:42 | test_BC_3_02_001_emits_entry | Constructs `LogEntry { ts: 0, level: "info" }`, asserts on `entry.ts` and `entry.level`, no call to `emit_*`/`serialize_*`/`build_*` | Test exercises the assertion but not production code. Consider calling `emit_log_entry(&entry)` or invoking the actual emitter under test. If this is intentional (data-shape pin), add `/// data-shape pin` to the function. |
+```
+
+**Reference fixtures:** see `${CLAUDE_PLUGIN_ROOT}/skills/validate-consistency/fixtures/tautology/` for canonical positive (flagged) and negative (clean) examples.
+
+### 9. BC Canonical Test Vector ↔ Emitter Field Consistency (advisory, severity: HIGH)
+
+**Goal:** when a BC's "Canonical Test Vectors" section explicitly excludes a field from the emitted artifact, flag any production struct/emitter that unconditionally serializes that field. This catches the "spec says don't emit X but the code emits X anyway" class of drift — exactly the bug TD-W2-FIXK-002 hit in Prism.
+
+**Scope:**
+- BC files matching `.factory/specs/behavioral-contracts/ss-*/BC-*.md` (recursive) that contain a `## Canonical Test Vectors` (or `### Canonical Test Vectors`) section.
+- Any column header in those tables matching one of these shapes (case-insensitive):
+  - `<FieldName> in <Shape>?`
+  - `Field <FieldName> in <Shape>?`
+  - `Includes <FieldName>?`
+  - `Emits <FieldName>?`
+  - `Has <FieldName>?`
+- Treat answers `No`, `❌`, `false`, `excluded`, `omitted`, `n/a`, or `--` as "field-excluded for this row".
+
+**Detection procedure:**
+1. Parse each BC's frontmatter for `target_module:` or `architecture_module:` (if present) — this names the production crate/file. If absent, fall back to grepping the BC body for ` `crates/<name>` ` references.
+2. For each "field-excluded" row, identify the row's struct anchor — typically named in the row's first cell (e.g., `LogEntry`, `EmittedEvent`, `CommitMadeEvent`).
+3. In the production crate, locate the matching struct definition (`struct <Name> { ... }`). Use `rg -nU --type rust "(?m)^(pub )?struct $NAME\b"` plus N lines of context.
+4. Inspect the field declaration for the excluded field name:
+   - **CLEAN** if the field is missing entirely, OR is `Option<T>` with `#[serde(skip_serializing_if = "Option::is_none")]`, OR has `#[serde(skip_serializing)]`, OR is gated by a feature flag, OR has `#[serde(skip_serializing_if = ...)]` with any predicate.
+   - **FLAG** if the field is declared as a non-Option type with no `skip_serializing*` attribute, OR is `Option<T>` without `skip_serializing_if`, OR is plainly `pub <field>: T`.
+5. Cross-check by grepping the matching `impl Serialize` or `impl <Name>` block for hand-rolled serialization that emits the field unconditionally.
+
+**Why severity HIGH:** this represents a contract-implementation drift that adversarial review missed (Prism: 6 passes clean, defect surfaced in pass 7). The data shape doesn't match what the BC says is canonical, so any downstream consumer that trusts the BC will be wrong.
+
+**Allowed exceptions (DO NOT flag):**
+- BC frontmatter contains `tv_emitter_check: skip` or `tv_emitter_check: manual`.
+- The BC explicitly notes "field tolerated when present" in the row's notes column.
+- Rust struct has `#[serde(skip_serializing_if = ...)]` with ANY predicate, even a custom one.
+
+**Advisory output (one row per finding):**
+```
+| BC | Excluded Field | Struct | Location | Evidence | Suggestion |
+|----|----------------|--------|----------|----------|------------|
+| BC-3.02.013 | trace_id | LogEntry | crates/sink-core/src/entry.rs:24 | Field declared `pub trace_id: String,` with no `#[serde(skip_serializing_if)]`; BC TV row marks `trace_id in Entry? = No` for retry-exhaustion case | Either (a) make field `Option<String>` with `#[serde(skip_serializing_if = "Option::is_none")]`, (b) gate emission via a wrapper, or (c) update BC to mark field included if drift was intentional (and document the spec change). |
+```
+
+**Reference fixtures:** see `${CLAUDE_PLUGIN_ROOT}/skills/validate-consistency/fixtures/bc-tv-consistency/` for canonical positive (flagged) and negative (clean) examples.
+
+### Advisory check operating notes
+
+- These checks **never** flip the report's overall PASS/FAIL — only blocking checks (1-7) do. Advisories appear in their own section.
+- Advisories carry severity (MEDIUM/HIGH) for prioritization but are **not** policy gates by default. A project may promote them to blocking by adding the policy id to `.factory/policies.yaml` (`POLICY-VC-008`, `POLICY-VC-009`).
+- If a project has no Rust source (e.g., docs-only, TypeScript, Python), these checks are no-ops — emit one advisory line `Check 8/9: skipped (no Rust sources detected)` and move on.
+- Both checks are idempotent and side-effect free; they only read.
+
 ## Templates
 
 Use `${CLAUDE_PLUGIN_ROOT}/templates/consistency-validation-report-template.md` for the consistency validation report format.
@@ -72,6 +157,7 @@ Use `${CLAUDE_PLUGIN_ROOT}/templates/consistency-validation-report-template.md` 
 - Passed: <N>
 - Failed: <N>
 - Warnings: <N>
+- Advisories: <N>   <!-- Check 8 + Check 9 surfaced findings; non-blocking -->
 
 ## Failures
 | Check | Issue | Files Involved |
@@ -83,6 +169,20 @@ Use `${CLAUDE_PLUGIN_ROOT}/templates/consistency-validation-report-template.md` 
 |-------|-------|---------------|
 | Orphan BC | BC-2.01.001 not referenced by any story | BC-2.01.001.md |
 
+## Advisories
+
+### Check 8 — Test Tautologies (MEDIUM)
+| File | Function | Evidence | Suggestion |
+|------|----------|----------|------------|
+| <path>:<line> | <test fn name> | <what was constructed/asserted> | <how to convert to a real behavior test> |
+
+### Check 9 — BC Canonical TV vs Emitter Drift (HIGH)
+| BC | Excluded Field | Struct | Location | Evidence | Suggestion |
+|----|----------------|--------|----------|----------|------------|
+| BC-N.NN.NNN | <field> | <StructName> | <path>:<line> | <why it serializes anyway> | <fix or spec-update suggestion> |
+
 ## All Passed
 <List of checks that passed cleanly>
 ```
+
+**Reading the Advisories section:** entries are non-blocking by default. Promote to blocking by adding `POLICY-VC-008` (tautology) or `POLICY-VC-009` (BC-TV) to `.factory/policies.yaml` if the project wants the checks gating.

--- a/plugins/vsdd-factory/skills/validate-consistency/SKILL.md
+++ b/plugins/vsdd-factory/skills/validate-consistency/SKILL.md
@@ -69,7 +69,7 @@ The following checks emit advisory findings only — they appear under `## Advis
 **Goal:** flag tests that look like behavior tests but only assert on data they themselves constructed — the test would pass even if the production code under test were deleted.
 
 **Scope:**
-- Rust test functions whose names match `^test_BC_`, `^test_TV_`, `^test_.*_BC_`, or `^test_.*_TV_` (case-sensitive prefix; case-insensitive `_BC_` / `_TV_` segment).
+- Rust test functions whose names match `^test_BC_`, `^test_TV_`, `^test_.*_BC_`, or `^test_.*_TV_` (case-sensitive throughout; `BC` and `TV` must appear in upper-case exactly as written).
 - Search root: `**/tests/**/*.rs`, `**/src/**/*.rs` files containing `#[cfg(test)]` modules, and `**/test_*.rs` / `**/*_test.rs`.
 
 **Tautology shape (FLAG when ALL three hold):**
@@ -139,7 +139,7 @@ The following checks emit advisory findings only — they appear under `## Advis
 ### Advisory check operating notes
 
 - These checks **never** flip the report's overall PASS/FAIL — only blocking checks (1-7) do. Advisories appear in their own section.
-- Advisories carry severity (MEDIUM/HIGH) for prioritization but are **not** policy gates by default. A project may promote them to blocking by adding the policy id to `.factory/policies.yaml` (`POLICY-VC-008`, `POLICY-VC-009`).
+- Advisories carry severity (MEDIUM/HIGH) for prioritization but are **not** policy gates by default. A project may promote them to blocking by adding the policy to `.factory/policies.yaml` (`POLICY 11` — no_test_tautologies for Check 8; `POLICY 12` — bc_tv_emitter_consistency for Check 9).
 - If a project has no Rust source (e.g., docs-only, TypeScript, Python), these checks are no-ops — emit one advisory line `Check 8/9: skipped (no Rust sources detected)` and move on.
 - Both checks are idempotent and side-effect free; they only read.
 
@@ -185,4 +185,4 @@ Use `${CLAUDE_PLUGIN_ROOT}/templates/consistency-validation-report-template.md` 
 <List of checks that passed cleanly>
 ```
 
-**Reading the Advisories section:** entries are non-blocking by default. Promote to blocking by adding `POLICY-VC-008` (tautology) or `POLICY-VC-009` (BC-TV) to `.factory/policies.yaml` if the project wants the checks gating.
+**Reading the Advisories section:** entries are non-blocking by default. Promote to blocking by adding `POLICY 11` (no_test_tautologies, Check 8) or `POLICY 12` (bc_tv_emitter_consistency, Check 9) to `.factory/policies.yaml` if the project wants the checks gating.

--- a/plugins/vsdd-factory/skills/validate-consistency/fixtures/bc-tv-consistency/README.md
+++ b/plugins/vsdd-factory/skills/validate-consistency/fixtures/bc-tv-consistency/README.md
@@ -1,0 +1,43 @@
+---
+document_type: fixture-readme
+level: ops
+version: "1.0"
+status: stable
+producer: validate-consistency
+phase: skill-fixtures
+---
+
+# BC Canonical TV ↔ Emitter Consistency Fixtures
+
+These fixtures are reference inputs for **Check 9** (BC Canonical Test Vector
+↔ Emitter field consistency). They are NOT compiled or registered in any
+BC index — they exist purely to anchor the predicate's expected behavior
+on canonical positive/negative shapes.
+
+## Files
+
+| File | Expected Verdict | Why |
+|------|-----------------|-----|
+| `flagged_bc_excludes_field.md` | (BC source) | BC's Canonical Test Vectors table marks `trace_id in Entry? = No` for the retry-exhaustion case |
+| `flagged_emitter_serializes_field.rs` | FLAG | Production struct declares `pub trace_id: String,` with no `#[serde(skip_serializing_if)]` — emits the field unconditionally, contradicting the BC |
+| `clean_bc_excludes_field.md` | (BC source) | Same exclusion declared as in the flagged BC fixture |
+| `clean_emitter_uses_option_skip.rs` | CLEAN | Production struct declares `pub trace_id: Option<String>` with `#[serde(skip_serializing_if = "Option::is_none")]` — emission honors the BC |
+| `clean_bc_with_skip_directive.md` | (BC source) | Same shape but adds `tv_emitter_check: skip` to BC frontmatter — opts out of the check entirely |
+
+## How the predicate decides
+
+For each BC file with a `## Canonical Test Vectors` section:
+
+1. Parse table column headers for shapes like `<Field> in <Shape>?`, `Field <Field> in <Shape>?`, `Includes <Field>?`, `Emits <Field>?`, `Has <Field>?`.
+2. For each row whose answer is `No` / `❌` / `false` / `excluded` / `omitted` / `n/a` / `--`, identify the struct named in the row's first cell.
+3. Locate the matching `struct <Name> { ... }` in the production crate (named in BC frontmatter `target_module:` or grepped from the body).
+4. Inspect the field declaration:
+   - **CLEAN** if the field is missing, OR `Option<T>` with `#[serde(skip_serializing_if = "Option::is_none")]`, OR has `#[serde(skip_serializing)]`, OR is gated by feature flag, OR has any `#[serde(skip_serializing_if = ...)]` predicate.
+   - **FLAG** if the field is a non-Option type with no skip attribute, OR `Option<T>` without `skip_serializing_if`, OR `pub <field>: T` with no decoration.
+5. Skip BCs whose frontmatter contains `tv_emitter_check: skip` or `tv_emitter_check: manual`.
+
+## Adding new fixtures
+
+Follow the `flagged_` / `clean_` naming convention. Pair each new BC fixture
+(`.md`) with its corresponding emitter fixture (`.rs`) so the predicate can
+be exercised end-to-end against the pair.

--- a/plugins/vsdd-factory/skills/validate-consistency/fixtures/bc-tv-consistency/clean_bc_excludes_field.md
+++ b/plugins/vsdd-factory/skills/validate-consistency/fixtures/bc-tv-consistency/clean_bc_excludes_field.md
@@ -1,0 +1,38 @@
+---
+document_type: behavioral-contract
+level: ops
+bc_id: "BC-FIXTURE-CLEAN.001"
+version: "1.0"
+status: fixture
+producer: validate-consistency
+target_module: crates/sink-core/src/entry.rs
+phase: skill-fixtures
+---
+
+# BC-FIXTURE-CLEAN.001 — LogEntry omits trace_id on retry exhaustion (clean)
+
+> **Fixture only.** Not registered in BC-INDEX. Pairs with
+> `clean_emitter_uses_option_skip.rs` — same BC shape as the flagged
+> fixture, but the paired emitter honors the exclusion.
+
+## Description
+
+When a `LogEntry` is emitted as part of a retry-exhausted DLQ payload, the
+`trace_id` field is intentionally omitted.
+
+## Postconditions
+
+1. The serialized `LogEntry` JSON for retry-exhaustion entries does not contain a `trace_id` key.
+2. For non-DLQ entries, `trace_id` may be present.
+
+## Canonical Test Vectors
+
+| Struct | Scenario | trace_id in Entry? | level in Entry? | message in Entry? |
+|--------|----------|-------------------:|----------------:|------------------:|
+| LogEntry | normal info log | Yes | Yes | Yes |
+| LogEntry | retry-exhaustion DLQ entry | **No** | Yes | Yes |
+| LogEntry | queue-overflow DLQ entry | **No** | Yes | Yes |
+
+## Architecture Module
+
+`crates/sink-core/src/entry.rs`

--- a/plugins/vsdd-factory/skills/validate-consistency/fixtures/bc-tv-consistency/clean_bc_with_skip_directive.md
+++ b/plugins/vsdd-factory/skills/validate-consistency/fixtures/bc-tv-consistency/clean_bc_with_skip_directive.md
@@ -1,0 +1,39 @@
+---
+document_type: behavioral-contract
+level: ops
+bc_id: "BC-FIXTURE-SKIP.001"
+version: "1.0"
+status: fixture
+producer: validate-consistency
+target_module: crates/sink-core/src/entry.rs
+tv_emitter_check: skip
+phase: skill-fixtures
+---
+
+# BC-FIXTURE-SKIP.001 — Opt-out via tv_emitter_check directive
+
+> **Fixture only.** Not registered in BC-INDEX. Demonstrates the
+> `tv_emitter_check: skip` frontmatter directive that opts a BC out
+> of Check 9 entirely.
+
+## Why opt out?
+
+Some BCs intentionally describe field-set scenarios that the emitter is
+*allowed* to populate even when the canonical test vector marks them
+absent — for example, when a downstream consumer tolerates extra fields.
+In those cases the BC author records the intent in frontmatter so future
+audit passes don't surface false-positive findings.
+
+## Canonical Test Vectors
+
+| Struct | Scenario | trace_id in Entry? | level in Entry? |
+|--------|----------|-------------------:|----------------:|
+| LogEntry | tolerates-extra-fields scenario | **No** | Yes |
+
+Even though the row says `trace_id in Entry? = No`, the
+`tv_emitter_check: skip` frontmatter directive tells Check 9 to skip
+this BC entirely.
+
+## Architecture Module
+
+`crates/sink-core/src/entry.rs`

--- a/plugins/vsdd-factory/skills/validate-consistency/fixtures/bc-tv-consistency/clean_emitter_uses_option_skip.rs
+++ b/plugins/vsdd-factory/skills/validate-consistency/fixtures/bc-tv-consistency/clean_emitter_uses_option_skip.rs
@@ -1,0 +1,46 @@
+// FIXTURE: this file is NOT compiled. It pairs with
+// `clean_bc_excludes_field.md` to exercise Check 9's negative path.
+//
+// Expected detector verdict: CLEAN
+// Reason: same BC exclusion as the flagged fixture, but the struct below
+// declares `pub trace_id: Option<String>` with
+// `#[serde(skip_serializing_if = "Option::is_none")]`. When the DLQ
+// builder sets `trace_id: None`, serde drops the field from the emitted
+// JSON, satisfying the BC.
+
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub struct LogEntry {
+    pub ts: u64,
+    pub level: String,
+    pub message: String,
+
+    // CLEAN: Option<T> + skip_serializing_if. DLQ path sets this to None,
+    // serde omits the key entirely.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trace_id: Option<String>,
+}
+
+pub fn emit_log_entry(entry: &LogEntry) -> String {
+    serde_json::to_string(entry).expect("LogEntry is always serializable")
+}
+
+// Example call sites that satisfy the BC:
+pub fn build_normal_entry(ts: u64, msg: &str, trace: &str) -> LogEntry {
+    LogEntry {
+        ts,
+        level: "info".into(),
+        message: msg.into(),
+        trace_id: Some(trace.into()),
+    }
+}
+
+pub fn build_dlq_entry(ts: u64, msg: &str) -> LogEntry {
+    LogEntry {
+        ts,
+        level: "error".into(),
+        message: msg.into(),
+        trace_id: None, // BC mandates omission; skip_serializing_if drops the key.
+    }
+}

--- a/plugins/vsdd-factory/skills/validate-consistency/fixtures/bc-tv-consistency/flagged_bc_excludes_field.md
+++ b/plugins/vsdd-factory/skills/validate-consistency/fixtures/bc-tv-consistency/flagged_bc_excludes_field.md
@@ -1,0 +1,41 @@
+---
+document_type: behavioral-contract
+level: ops
+bc_id: "BC-FIXTURE-FLAGGED.001"
+version: "1.0"
+status: fixture
+producer: validate-consistency
+target_module: crates/sink-core/src/entry.rs
+phase: skill-fixtures
+---
+
+# BC-FIXTURE-FLAGGED.001 — LogEntry omits trace_id on retry exhaustion
+
+> **Fixture only.** Not registered in BC-INDEX. Pairs with
+> `flagged_emitter_serializes_field.rs` to exercise Check 9's positive path.
+
+## Description
+
+When a `LogEntry` is emitted as part of a retry-exhausted DLQ payload, the
+`trace_id` field is intentionally omitted because the upstream tracer is
+no longer available and the field would carry stale data.
+
+## Postconditions
+
+1. The serialized `LogEntry` JSON for retry-exhaustion entries does not contain a `trace_id` key.
+2. For non-DLQ entries, `trace_id` may be present.
+
+## Canonical Test Vectors
+
+| Struct | Scenario | trace_id in Entry? | level in Entry? | message in Entry? |
+|--------|----------|-------------------:|----------------:|------------------:|
+| LogEntry | normal info log | Yes | Yes | Yes |
+| LogEntry | retry-exhaustion DLQ entry | **No** | Yes | Yes |
+| LogEntry | queue-overflow DLQ entry | **No** | Yes | Yes |
+
+The `No` answers in the `trace_id in Entry?` column are what Check 9
+cross-references against `crates/sink-core/src/entry.rs::LogEntry`.
+
+## Architecture Module
+
+`crates/sink-core/src/entry.rs`

--- a/plugins/vsdd-factory/skills/validate-consistency/fixtures/bc-tv-consistency/flagged_emitter_serializes_field.rs
+++ b/plugins/vsdd-factory/skills/validate-consistency/fixtures/bc-tv-consistency/flagged_emitter_serializes_field.rs
@@ -1,0 +1,30 @@
+// FIXTURE: this file is NOT compiled. It pairs with
+// `flagged_bc_excludes_field.md` to exercise Check 9's positive path.
+//
+// Expected detector verdict: FLAG (severity HIGH)
+// Reason: BC-FIXTURE-FLAGGED.001's Canonical Test Vectors table marks
+// `trace_id in Entry? = No` for retry-exhaustion and queue-overflow
+// DLQ entries, but the struct below declares `pub trace_id: String,` —
+// non-Option, no `skip_serializing_if`, no feature gate. Default serde
+// derivation will emit `"trace_id": ""` for every entry, contradicting
+// the BC.
+
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub struct LogEntry {
+    pub ts: u64,
+    pub level: String,
+    pub message: String,
+
+    // VIOLATION: BC says this is excluded for retry-exhaustion / queue-overflow,
+    // but the field has no skip attribute and is non-Option, so serde will
+    // always emit it. Check 9 should flag this.
+    pub trace_id: String,
+}
+
+// Hand-rolled emitter that also serializes unconditionally — Check 9 should
+// also catch this branch by inspecting the struct definition above.
+pub fn emit_log_entry(entry: &LogEntry) -> String {
+    serde_json::to_string(entry).expect("LogEntry is always serializable")
+}

--- a/plugins/vsdd-factory/skills/validate-consistency/fixtures/tautology/README.md
+++ b/plugins/vsdd-factory/skills/validate-consistency/fixtures/tautology/README.md
@@ -1,0 +1,41 @@
+---
+document_type: fixture-readme
+level: ops
+version: "1.0"
+status: stable
+producer: validate-consistency
+phase: skill-fixtures
+---
+
+# Tautology Detector Fixtures
+
+These fixtures are reference inputs for **Check 8** (Test Tautology Detector).
+They are NOT compiled or executed — they exist so anyone implementing or
+auditing the check has canonical examples of what the predicate should
+flag and what it should leave alone.
+
+## Files
+
+| File | Expected Verdict | Why |
+|------|-----------------|-----|
+| `flagged_tautological_test.rs` | FLAG | Constructs a struct, asserts on its own fields, never calls the production emitter |
+| `clean_test_with_emitter_call.rs` | CLEAN | Same surface but actually calls `emit_log_entry(&entry)` — the assertion observes a real side effect |
+| `clean_data_shape_pin.rs` | CLEAN (exception) | Tautological in shape but carries the `/// data-shape pin` comment that opts out of the check |
+| `clean_test_with_emitter_arg.rs` | CLEAN | Constructs the struct then passes it to a production fn as an argument; assertions follow the call |
+
+## How the predicate decides
+
+The check fires when ALL of these hold:
+
+1. Function name matches `test_BC_*`, `test_TV_*`, `test_*_BC_*`, or `test_*_TV_*`.
+2. Body constructs a struct literal and binds it (e.g., `let entry = LogEntry { ... };`).
+3. Body asserts on that struct's fields via `assert_eq!`/`assert!`/`assert_matches!`.
+4. Body contains zero calls to functions whose names match the production-fn regex (`emit_*`, `process_*`, `apply_*`, `handle_*`, `execute_*`, `validate_*`, `compute_*`, `transform_*`, `render_*`, `serialize_*`, `encode_*`, `decode_*`, `parse_*`, `build_*`, `generate_*`).
+
+If conditions 1–3 hold but condition 4 fails (i.e., a production fn IS called),
+the test is exercising production code and is **not** a tautology.
+
+## Adding new fixtures
+
+When a real-world false-positive or false-negative is found, add a new file
+prefixed `flagged_` or `clean_` with a short suffix. Update this README's table.

--- a/plugins/vsdd-factory/skills/validate-consistency/fixtures/tautology/clean_data_shape_pin.rs
+++ b/plugins/vsdd-factory/skills/validate-consistency/fixtures/tautology/clean_data_shape_pin.rs
@@ -1,0 +1,35 @@
+// FIXTURE: this file is NOT compiled. It documents a tautology-shaped
+// test that opts out via the `data-shape pin` doc-comment.
+//
+// Expected detector verdict: CLEAN (exception)
+// Reason: the test IS structurally a tautology, but its doc-comment
+// explicitly declares it a data-shape pin — the test exists to lock
+// the struct's field set so additions/removals fail the build, not
+// to exercise production behavior. The check honors this opt-out.
+
+#[cfg(test)]
+mod tests {
+    use crate::entry::LogEntry;
+
+    /// data-shape pin
+    ///
+    /// This test pins LogEntry's public field set. If a field is added
+    /// or removed, this test breaks at compile time and forces a BC
+    /// review. It is intentionally tautological.
+    #[test]
+    fn test_BC_3_02_001_log_entry_field_set_pin() {
+        let entry = LogEntry {
+            ts: 0,
+            level: String::new(),
+            message: String::new(),
+            trace_id: None,
+        };
+
+        // Pure shape assertion — no production fn called. The opt-out
+        // comment above is what keeps this off the advisory list.
+        assert_eq!(entry.ts, 0);
+        assert_eq!(entry.level, "");
+        assert_eq!(entry.message, "");
+        assert!(entry.trace_id.is_none());
+    }
+}

--- a/plugins/vsdd-factory/skills/validate-consistency/fixtures/tautology/clean_test_with_emitter_arg.rs
+++ b/plugins/vsdd-factory/skills/validate-consistency/fixtures/tautology/clean_test_with_emitter_arg.rs
@@ -1,0 +1,30 @@
+// FIXTURE: this file is NOT compiled. It documents a CLEAN shape where
+// the constructed struct is passed directly to a production fn as an
+// argument — the most common and idiomatic non-tautological form.
+//
+// Expected detector verdict: CLEAN
+// Reason: `emit_event(&event)` and `validate_event(&event)` both match
+// the production-fn regex; the `assert_*` calls observe the result.
+
+#[cfg(test)]
+mod tests {
+    use crate::events::Event;
+    use crate::emitter::emit_event;
+    use crate::validator::validate_event;
+
+    #[test]
+    fn test_BC_4_03_001_commit_made_event_round_trip() {
+        let event = Event::CommitMade {
+            sha: "abc123".into(),
+            branch: "main".into(),
+            message: "fix: typo".into(),
+        };
+
+        // Production fn invoked with the constructed value — non-tautological.
+        let bytes = emit_event(&event);
+        let valid = validate_event(&bytes);
+
+        assert!(valid.is_ok(), "validator rejected canonical commit.made");
+        assert!(bytes.starts_with(b"{"), "emitted as JSON");
+    }
+}

--- a/plugins/vsdd-factory/skills/validate-consistency/fixtures/tautology/clean_test_with_emitter_call.rs
+++ b/plugins/vsdd-factory/skills/validate-consistency/fixtures/tautology/clean_test_with_emitter_call.rs
@@ -1,0 +1,63 @@
+// FIXTURE: this file is NOT compiled. It documents a NON-tautological
+// test shape that Check 8 must NOT flag.
+//
+// Expected detector verdict: CLEAN
+// Reason: the test still constructs a struct and asserts on results, but
+// it routes the struct through `emit_log_entry`, exercising production
+// code. The `emit_log_entry(...)` call satisfies condition 4 (production
+// fn invoked) and breaks the tautology.
+
+#[cfg(test)]
+mod tests {
+    use crate::entry::LogEntry;
+    use crate::emitter::emit_log_entry;
+
+    #[test]
+    fn test_BC_3_02_001_log_entry_emits_canonical_payload() {
+        let entry = LogEntry {
+            ts: 1_700_000_000,
+            level: "info".to_string(),
+            message: "ok".to_string(),
+            trace_id: None,
+        };
+
+        // emit_log_entry matches the production-fn regex (`emit_*`),
+        // so condition 4 is satisfied — this is a real behavior test.
+        let json = emit_log_entry(&entry);
+
+        assert!(json.contains("\"ts\":1700000000"));
+        assert!(json.contains("\"level\":\"info\""));
+        assert!(!json.contains("trace_id"), "trace_id is absent when None");
+    }
+
+    #[test]
+    fn test_TV_dlq_round_trip_through_serialize() {
+        let envelope = DlqEnvelope {
+            sink: "datadog".into(),
+            reason: "5xx".into(),
+            payload: vec![1, 2, 3],
+        };
+
+        // serialize_dlq_envelope matches `serialize_*` — non-tautological.
+        let bytes = serialize_dlq_envelope(&envelope);
+        let decoded = decode_dlq_envelope(&bytes);
+
+        assert_eq!(decoded.sink, "datadog");
+        assert_eq!(decoded.payload, vec![1, 2, 3]);
+    }
+}
+
+// Stand-ins for production fns and types.
+struct DlqEnvelope {
+    sink: String,
+    reason: String,
+    payload: Vec<u8>,
+}
+
+fn serialize_dlq_envelope(_e: &DlqEnvelope) -> Vec<u8> {
+    unimplemented!("fixture only")
+}
+
+fn decode_dlq_envelope(_b: &[u8]) -> DlqEnvelope {
+    unimplemented!("fixture only")
+}

--- a/plugins/vsdd-factory/skills/validate-consistency/fixtures/tautology/flagged_tautological_test.rs
+++ b/plugins/vsdd-factory/skills/validate-consistency/fixtures/tautology/flagged_tautological_test.rs
@@ -1,0 +1,55 @@
+// FIXTURE: this file is NOT compiled. It documents a tautological test
+// shape that Check 8 of the validate-consistency skill must flag.
+//
+// Expected detector verdict: FLAG (severity MEDIUM)
+// Reason: constructs `LogEntry` and asserts on its own fields without
+// ever invoking the production emitter (`emit_log_entry`, `serialize_log_entry`,
+// `build_log_entry`, etc.). The test would pass even if the production
+// crate were emptied.
+
+#[cfg(test)]
+mod tests {
+    // Imagine LogEntry lives in `crate::entry` and is serialized by
+    // `crate::emitter::emit_log_entry(&entry) -> String`.
+    use crate::entry::LogEntry;
+
+    #[test]
+    fn test_BC_3_02_001_log_entry_has_canonical_fields() {
+        // Body matches the tautology shape:
+        //   1. struct literal binding
+        //   2. assertions on its own fields
+        //   3. zero calls to `emit_*` / `serialize_*` / `build_*` / etc.
+        let entry = LogEntry {
+            ts: 1_700_000_000,
+            level: "info".to_string(),
+            message: "ok".to_string(),
+            trace_id: None,
+        };
+
+        assert_eq!(entry.ts, 1_700_000_000);
+        assert_eq!(entry.level, "info");
+        assert_eq!(entry.message, "ok");
+        assert!(entry.trace_id.is_none());
+    }
+
+    #[test]
+    fn test_TV_dlq_envelope_includes_sink_name() {
+        // Same shape, different domain — also a tautology.
+        let envelope = DlqEnvelope {
+            sink: "datadog".into(),
+            reason: "5xx".into(),
+            payload: vec![],
+        };
+
+        assert_eq!(envelope.sink, "datadog");
+        assert_eq!(envelope.reason, "5xx");
+        assert!(envelope.payload.is_empty());
+    }
+}
+
+// Dummy types to keep this fixture readable in isolation.
+struct DlqEnvelope {
+    sink: String,
+    reason: String,
+    payload: Vec<u8>,
+}


### PR DESCRIPTION
## Summary

Extends `plugins/vsdd-factory/skills/validate-consistency/SKILL.md` with two new advisory checks motivated by the Prism project Wave 2 Pass 7 finding (TD-W2-FIXK-001 + TD-W2-FIXK-002) — patterns that slipped through 6 prior adversarial passes.

- **Check 8 — Test Tautology Detector** (MEDIUM, advisory): flags `test_BC_*`/`test_TV_*` Rust tests that construct a struct and assert on its own fields without ever calling a production fn matching `(emit|process|apply|handle|execute|validate|compute|transform|render|serialize|encode|decode|parse|build|generate)_*`.
- **Check 9 — BC Canonical TV ↔ Emitter Field Consistency** (HIGH, advisory): parses BC `## Canonical Test Vectors` tables for column headers like `<Field> in <Shape>?` with answers `No`/`❌`/`excluded`/`omitted`, then cross-references the named struct in the production crate (via BC `target_module:` frontmatter) and flags fields serialized unconditionally without `#[serde(skip_serializing_if)]` or `Option<T>` gating.

Both checks are advisory by default and never flip overall PASS/FAIL. Output gains a `## Advisories` section with separate Check 8 (4-col) and Check 9 (6-col) tables.

Recognized opt-outs:
- Check 8: `/// data-shape pin` doc-comment, `//! tautology-allowed: <reason>` file declaration.
- Check 9: BC frontmatter `tv_emitter_check: skip|manual`, row-notes column says \"field tolerated when present\".

Projects can promote either check to gating via the policy registry — `POLICY 11` (`no_test_tautologies`, MEDIUM) and `POLICY 12` (`bc_tv_emitter_consistency`, HIGH) are pre-registered as opt-in policies. (Policy registry edits live on `factory-artifacts`, not in this PR.)

## Files changed

- **`SKILL.md`** — 89 → 188 lines. Adds Check 8 + Check 9 sections, output-format extension, and operating notes.
- **`fixtures/tautology/`** (NEW) — 5 files: README + 1 flagged tautology + 3 clean variants (emitter-call, emitter-arg, data-shape-pin opt-out).
- **`fixtures/bc-tv-consistency/`** (NEW) — 6 files: README + flagged BC↔emitter pair + clean Option-skip pair + `tv_emitter_check: skip` opt-out BC.

## Known limitations (tracked as TD-006)

This PR ships the procedural specification + reference fixtures. It does **not** ship:

1. An executable runner (`bin/check-tautology` / `bin/check-bc-tv-consistency`). The check fires only if a human or LLM follows the SKILL.md procedure manually.
2. Bats/Rust tests asserting that the predicate flags `flagged_*` fixtures and ignores `clean_*` ones.
3. Any non-Rust language support — TS/Python/Go projects emit a \"skipped\" advisory and provide zero value.

The deliverable also bypassed proper TDD (no test-writer/implementer dispatch) and was originally authored directly on `main` (Git Flow violation; remediated by this branch). All four gaps are recorded as **TD-006** in `.factory/tech-debt-register.md` (P1, due v1.0.1).

## Test plan

- [ ] Manual: read SKILL.md Check 8 procedure, run the regex against `fixtures/tautology/flagged_tautological_test.rs` — should identify both `test_BC_3_02_001_log_entry_has_canonical_fields` and `test_TV_dlq_envelope_includes_sink_name`.
- [ ] Manual: read SKILL.md Check 8 procedure, run against `fixtures/tautology/clean_test_with_emitter_call.rs` — should produce zero flags (call to `emit_log_entry` and `serialize_dlq_envelope` satisfies the production-fn condition).
- [ ] Manual: read SKILL.md Check 9 procedure, parse `fixtures/bc-tv-consistency/flagged_bc_excludes_field.md` — `trace_id in Entry? = No` rows should match against `flagged_emitter_serializes_field.rs::LogEntry` declaring `pub trace_id: String,` (no skip attribute) and yield 1 finding.
- [ ] Manual: same procedure against `clean_bc_excludes_field.md` + `clean_emitter_uses_option_skip.rs` — should produce zero findings (Option + skip_serializing_if honored).
- [ ] Manual: confirm `clean_bc_with_skip_directive.md` is skipped entirely due to `tv_emitter_check: skip` frontmatter.
- [ ] Follow-up story (TD-006 plan): build the executable runner + bats tests; this manual checklist becomes automated.

## Process notes

- Branch is **off `develop`** per Git Flow established in Task #33.
- No AI-attribution lines in the commit message.
- This is a remediation of a process slip — the original Task #114 deliverable was authored directly on `main`. See TD-006 for the full retrospective.