### PR TITLE
feat(sink-http): generic HTTP sink driver (S-4.01)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,195 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener 5.4.1",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-object-pool"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333c456b97c3f2d50604e8b2624253b7f787208cb72eb75e64b0ad11b221652c"
+dependencies = [
+ "async-std",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.4.1",
+ "futures-lite",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.4",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
+dependencies = [
+ "async-attributes",
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,7 +250,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -85,8 +274,8 @@ dependencies = [
  "axum-core",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "itoa",
  "matchit",
@@ -109,8 +298,8 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -121,9 +310,41 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "basic-cookies"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67bd8fd42c16bdb08688243dc5f0cc117a3ca9efeeaba3a345a18a6159ad96f7"
+dependencies = [
+ "lalrpop",
+ "lalrpop-util",
+ "regex",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -138,6 +359,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -276,6 +510,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -479,6 +742,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,6 +787,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys-next"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -536,7 +815,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -556,6 +835,15 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "ena"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -580,6 +868,33 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener 5.4.1",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -667,6 +982,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,6 +1064,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -741,7 +1084,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -846,6 +1189,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,7 +1211,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.0",
  "indexmap",
  "slab",
  "tokio",
@@ -900,6 +1255,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hostname"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -908,6 +1269,17 @@ dependencies = [
  "cfg-if",
  "libc",
  "windows-link",
+]
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
 ]
 
 [[package]]
@@ -922,12 +1294,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -938,8 +1321,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -956,6 +1339,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "httpmock"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ec9586ee0910472dec1a1f0f8acf52f0fdde93aea74d70d4a3107b4be0fd5b"
+dependencies = [
+ "assert-json-diff",
+ "async-object-pool",
+ "async-std",
+ "async-trait",
+ "base64 0.21.7",
+ "basic-cookies",
+ "crossbeam-utils",
+ "form_urlencoded",
+ "futures-util",
+ "hyper 0.14.32",
+ "lazy_static",
+ "levenshtein",
+ "log",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_regex",
+ "similar",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -966,8 +1400,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -978,15 +1412,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http 1.4.0",
+ "hyper 1.9.0",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper",
+ "hyper 1.9.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
  "tower-service",
 ]
 
@@ -996,18 +1461,23 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.9.0",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1178,6 +1648,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1228,9 +1717,57 @@ version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
+dependencies = [
+ "ascii-canvas",
+ "bit-set",
+ "ena",
+ "itertools 0.11.0",
+ "lalrpop-util",
+ "petgraph",
+ "pico-args",
+ "regex",
+ "regex-syntax",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+ "walkdir",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128"
@@ -1253,6 +1790,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "levenshtein"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,7 +1816,7 @@ dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -1295,10 +1838,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "mach2"
@@ -1354,6 +1909,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1379,6 +1957,50 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "openssl"
+version = "0.10.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "opentelemetry"
@@ -1416,6 +2038,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.18",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1430,6 +2081,21 @@ dependencies = [
  "fixedbitset",
  "indexmap",
 ]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project"
@@ -1448,7 +2114,7 @@ checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1456,6 +2122,23 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
 
 [[package]]
 name = "pkg-config"
@@ -1468,6 +2151,20 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "postcard"
@@ -1500,13 +2197,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1535,10 +2238,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1561,7 +2264,7 @@ checksum = "f7dfa8354acc622b3857e1bb1a4e4315d3bc1a44ad31d5653c3e87c0da9306d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1637,6 +2340,15 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
@@ -1699,6 +2411,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1747,10 +2515,96 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -1789,7 +2643,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1803,6 +2657,16 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_regex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+dependencies = [
+ "regex",
+ "serde",
 ]
 
 [[package]]
@@ -1821,6 +2685,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -1851,6 +2727,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "sink-core"
 version = "0.0.1"
 dependencies = [
@@ -1878,6 +2760,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sink-http"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "httpmock",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sink-core",
+ "thiserror 2.0.18",
+ "tokio",
+ "toml 0.8.23",
+]
+
+[[package]]
 name = "sink-otel-grpc"
 version = "0.0.1"
 dependencies = [
@@ -1896,6 +2793,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1908,6 +2811,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1927,6 +2840,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1942,6 +2884,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -1951,7 +2896,28 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1990,6 +2956,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2024,7 +3001,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2035,7 +3012,16 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -2059,7 +3045,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -2072,7 +3058,27 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -2187,18 +3193,18 @@ checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "h2",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.9.0",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2",
+ "socket2 0.6.3",
  "sync_wrapper",
  "tokio",
  "tokio-stream",
@@ -2239,6 +3245,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2269,7 +3293,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2312,6 +3336,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2341,6 +3371,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2361,7 +3403,17 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -2411,6 +3463,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2429,7 +3491,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -2638,7 +3700,7 @@ version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2004f7c86ebeb116550655377cdf16dbf7b03ae5aa6b4b1c1458cfa23aaa306"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "directories-next",
  "log",
  "postcard",
@@ -2661,7 +3723,7 @@ dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
  "wit-parser 0.246.2",
@@ -2698,7 +3760,7 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-native",
  "gimli",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "object",
  "pulley-interpreter",
@@ -2772,7 +3834,7 @@ checksum = "d6af582ec18b674bf7a17775d6fbfbddfcc143f0edbd89c9c1778239c8aa92ed"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2880,6 +3942,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wiggle"
 version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2902,7 +3974,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasmtime-environ",
  "witx",
 ]
@@ -2915,7 +3987,7 @@ checksum = "aa7c29fcf738630cba4e35f1805da5e42dde20ee9809ee9202b0648ae671602f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wiggle-generate",
 ]
 
@@ -2990,7 +4062,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3001,7 +4073,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3009,6 +4081,17 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
 
 [[package]]
 name = "windows-result"
@@ -3026,6 +4109,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
 ]
 
 [[package]]
@@ -3171,7 +4263,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3187,7 +4279,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3285,7 +4377,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3306,7 +4398,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3326,9 +4418,15 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
@@ -3360,7 +4458,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/sink-core",
     "crates/sink-file",
     "crates/sink-otel-grpc",
+    "crates/sink-http",
 ]
 
 [workspace.package]
@@ -51,6 +52,8 @@ opentelemetry-proto = { version = "0.31", default-features = false, features = [
 tonic = "0.14"
 tokio-stream = { version = "0.1", features = ["net"] }
 hostname = "0.4"
+reqwest = { version = "0.12", features = ["json", "blocking"] }
+httpmock = "0.7"
 
 [profile.release]
 opt-level = 3

--- a/crates/sink-http/Cargo.toml
+++ b/crates/sink-http/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "sink-http"
+version = "0.0.1"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+rust-version.workspace = true
+description = "vsdd-factory v1.0 sink driver: HTTP batch POST sink (base for Datadog and Honeycomb)"
+publish = false
+
+[lib]
+name = "sink_http"
+path = "src/lib.rs"
+
+[dependencies]
+sink-core = { path = "../sink-core", version = "0.0.1" }
+serde.workspace = true
+serde_json.workspace = true
+anyhow.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+reqwest.workspace = true
+
+[dev-dependencies]
+httpmock.workspace = true
+toml.workspace = true
+tokio.workspace = true

--- a/crates/sink-http/Cargo.toml
+++ b/crates/sink-http/Cargo.toml
@@ -21,6 +21,7 @@ anyhow.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 reqwest.workspace = true
+toml.workspace = true
 
 [dev-dependencies]
 httpmock.workspace = true

--- a/crates/sink-http/src/lib.rs
+++ b/crates/sink-http/src/lib.rs
@@ -1,0 +1,134 @@
+//! HTTP sink driver stub (S-4.01).
+//!
+//! This file is a minimal stub — every method panics with `unimplemented!()`.
+//! The RED gate is enforced: all tests in `crates/sink-http/tests/` must fail
+//! until the implementer fills these in.
+//!
+//! ## Contract
+//!
+//! [`HttpSink`] implements [`Sink`] (from sink-core). It batches [`SinkEvent`]s
+//! and POSTs them as a JSON array to a user-configured URL. It is the base HTTP
+//! infrastructure reused by Datadog (S-4.02) and Honeycomb (S-4.03) sinks.
+//!
+//! ## Config load API
+//!
+//! [`HttpSinkConfig::from_toml`] validates `schema_version` (must equal 1) and
+//! `type` (must equal `"http"`). Unknown `type` values warn to stderr and return
+//! `Ok(None)`; schema_version != 1 returns `Err`.
+//!
+//! `enabled = false` in config causes [`HttpSink`] to be constructed but never
+//! accept events and never make HTTP calls.
+
+#![deny(missing_docs)]
+
+use serde::Deserialize;
+use sink_core::{Sink, SinkConfigCommon, SinkEvent};
+
+/// Driver-specific configuration for the HTTP sink.
+///
+/// Deserialized from an `[[sinks]]` stanza in `observability-config.toml`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct HttpSinkConfig {
+    /// Must equal `1`. Any other value is a hard error at load time
+    /// (BC-3.01.003).
+    pub schema_version: u32,
+
+    /// Must equal `"http"`. Unknown values warn to stderr and cause the
+    /// sink to be skipped (BC-3.01.002).
+    #[serde(rename = "type")]
+    pub sink_type: String,
+
+    /// Common cross-sink fields (name, enabled, routing_filter, tags).
+    #[serde(flatten)]
+    pub common: SinkConfigCommon,
+
+    /// HTTP endpoint URL. Every batch is POSTed here as a JSON array.
+    pub url: String,
+
+    /// Bounded internal queue depth. Overflow drops events without blocking
+    /// the caller (VP-011).
+    #[serde(default = "default_queue_depth")]
+    pub queue_depth: usize,
+}
+
+fn default_queue_depth() -> usize {
+    1000
+}
+
+impl HttpSinkConfig {
+    /// Parse and validate an `HttpSinkConfig` from a raw TOML string.
+    ///
+    /// Returns:
+    /// - `Err(_)` when `schema_version != 1` (BC-3.01.003).
+    /// - `Ok(None)` when `type` is not `"http"` — warning emitted to stderr
+    ///   (BC-3.01.002).
+    /// - `Ok(Some(config))` on a valid stanza.
+    pub fn from_toml(_toml_src: &str) -> anyhow::Result<Option<HttpSinkConfig>> {
+        unimplemented!("HttpSinkConfig::from_toml — implementer fills this in (S-4.01)")
+    }
+}
+
+/// A recorded HTTP send failure — returned via [`HttpSink::take_failures`].
+#[derive(Debug, Clone)]
+pub struct SinkFailure {
+    /// The URL that was attempted.
+    pub url: String,
+    /// Human-readable failure reason.
+    pub reason: String,
+    /// Number of attempts made before giving up.
+    pub attempts: u32,
+}
+
+/// HTTP batch-POST sink.
+///
+/// Implements [`Sink`] from sink-core. Exposed `pub` so S-4.02 (Datadog) and
+/// S-4.03 (Honeycomb) can embed or wrap it (AC-9 / BC-3.01.001 invariant 1).
+pub struct HttpSink {
+    _config: HttpSinkConfig,
+}
+
+impl HttpSink {
+    /// Construct an `HttpSink` from a validated config.
+    ///
+    /// Starts the background worker thread that consumes the internal queue
+    /// and POSTs batches to the configured URL.
+    pub fn new(_config: HttpSinkConfig) -> anyhow::Result<Self> {
+        unimplemented!("HttpSink::new — implementer fills this in (S-4.01)")
+    }
+
+    /// Drain recorded send failures accumulated since the last call.
+    ///
+    /// Used by tests and the dispatcher integration to inspect failure state
+    /// without panicking.
+    pub fn take_failures(&self) -> Vec<SinkFailure> {
+        unimplemented!("HttpSink::take_failures — implementer fills this in (S-4.01)")
+    }
+
+    /// Number of events dropped due to a full internal queue (VP-011 overflow
+    /// pathway). Non-blocking: callers read this to verify backpressure.
+    pub fn queue_full_count(&self) -> u64 {
+        unimplemented!("HttpSink::queue_full_count — implementer fills this in (S-4.01)")
+    }
+}
+
+impl Sink for HttpSink {
+    fn name(&self) -> &str {
+        unimplemented!("HttpSink::name — implementer fills this in (S-4.01)")
+    }
+
+    fn accepts(&self, _event: &SinkEvent) -> bool {
+        unimplemented!("HttpSink::accepts — implementer fills this in (S-4.01)")
+    }
+
+    fn submit(&self, _event: SinkEvent) {
+        unimplemented!("HttpSink::submit — implementer fills this in (S-4.01)")
+    }
+
+    fn flush(&self) -> anyhow::Result<()> {
+        unimplemented!("HttpSink::flush — implementer fills this in (S-4.01)")
+    }
+
+    fn shutdown(&self) {
+        unimplemented!("HttpSink::shutdown — implementer fills this in (S-4.01)")
+    }
+}

--- a/crates/sink-http/src/lib.rs
+++ b/crates/sink-http/src/lib.rs
@@ -1,10 +1,4 @@
-//! HTTP sink driver stub (S-4.01).
-//!
-//! This file is a minimal stub — every method panics with `unimplemented!()`.
-//! The RED gate is enforced: all tests in `crates/sink-http/tests/` must fail
-//! until the implementer fills these in.
-//!
-//! ## Contract
+//! HTTP sink driver (S-4.01).
 //!
 //! [`HttpSink`] implements [`Sink`] (from sink-core). It batches [`SinkEvent`]s
 //! and POSTs them as a JSON array to a user-configured URL. It is the base HTTP
@@ -23,6 +17,13 @@
 
 use serde::Deserialize;
 use sink_core::{Sink, SinkConfigCommon, SinkEvent};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+use tokio::sync::mpsc;
+
+/// Number of total attempts for 5xx batches (1 initial + retries).
+const MAX_5XX_ATTEMPTS: u32 = 3;
 
 /// Driver-specific configuration for the HTTP sink.
 ///
@@ -63,8 +64,26 @@ impl HttpSinkConfig {
     /// - `Ok(None)` when `type` is not `"http"` — warning emitted to stderr
     ///   (BC-3.01.002).
     /// - `Ok(Some(config))` on a valid stanza.
-    pub fn from_toml(_toml_src: &str) -> anyhow::Result<Option<HttpSinkConfig>> {
-        unimplemented!("HttpSinkConfig::from_toml — implementer fills this in (S-4.01)")
+    pub fn from_toml(toml_src: &str) -> anyhow::Result<Option<HttpSinkConfig>> {
+        let config: HttpSinkConfig =
+            toml::from_str(toml_src).map_err(|e| anyhow::anyhow!("TOML parse error: {e}"))?;
+
+        if config.schema_version != 1 {
+            return Err(anyhow::anyhow!(
+                "schema_version must be 1, got {} (BC-3.01.003)",
+                config.schema_version
+            ));
+        }
+
+        if config.sink_type != "http" {
+            eprintln!(
+                "sink-http: unknown sink type {:?} — skipping (BC-3.01.002)",
+                config.sink_type
+            );
+            return Ok(None);
+        }
+
+        Ok(Some(config))
     }
 }
 
@@ -79,12 +98,46 @@ pub struct SinkFailure {
     pub attempts: u32,
 }
 
+/// Messages sent to the worker task via the internal mpsc channel.
+///
+/// `Flush` carries a `std::sync::mpsc::SyncSender` so the worker can
+/// signal completion without needing to be awaited — this lets the
+/// synchronous `flush()` method block safely even when called from inside
+/// a multi-thread tokio runtime (via `tokio::task::block_in_place`).
+enum Message {
+    /// A single event to buffer until the next flush.
+    Event(SinkEvent),
+    /// Drain the buffer, POST the batch, then ack the sender.
+    Flush(std::sync::mpsc::SyncSender<()>),
+}
+
+/// State shared between the [`HttpSink`] handle and the worker task.
+struct Shared {
+    failures: Mutex<Vec<SinkFailure>>,
+    queue_full_count: AtomicU64,
+    shutdown: std::sync::atomic::AtomicBool,
+}
+
+impl Shared {
+    fn new() -> Self {
+        Self {
+            failures: Mutex::new(Vec::new()),
+            queue_full_count: AtomicU64::new(0),
+            shutdown: std::sync::atomic::AtomicBool::new(false),
+        }
+    }
+}
+
 /// HTTP batch-POST sink.
 ///
 /// Implements [`Sink`] from sink-core. Exposed `pub` so S-4.02 (Datadog) and
 /// S-4.03 (Honeycomb) can embed or wrap it (AC-9 / BC-3.01.001 invariant 1).
 pub struct HttpSink {
-    _config: HttpSinkConfig,
+    name: String,
+    common: SinkConfigCommon,
+    sender: Mutex<Option<mpsc::Sender<Message>>>,
+    worker: Mutex<Option<JoinHandle<()>>>,
+    shared: Arc<Shared>,
 }
 
 impl HttpSink {
@@ -92,43 +145,263 @@ impl HttpSink {
     ///
     /// Starts the background worker thread that consumes the internal queue
     /// and POSTs batches to the configured URL.
-    pub fn new(_config: HttpSinkConfig) -> anyhow::Result<Self> {
-        unimplemented!("HttpSink::new — implementer fills this in (S-4.01)")
+    pub fn new(config: HttpSinkConfig) -> anyhow::Result<Self> {
+        let (tx, rx) = mpsc::channel::<Message>(config.queue_depth.max(1));
+        let shared = Arc::new(Shared::new());
+        let worker_shared = Arc::clone(&shared);
+        let worker_url = config.url.clone();
+
+        let handle = std::thread::Builder::new()
+            .name(format!("sink-http:{}", config.common.name))
+            .spawn(move || {
+                let runtime = match tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                {
+                    Ok(rt) => rt,
+                    Err(e) => {
+                        worker_shared
+                            .failures
+                            .lock()
+                            .unwrap_or_else(|p| p.into_inner())
+                            .push(SinkFailure {
+                                url: worker_url.clone(),
+                                reason: format!("failed to build tokio runtime: {e}"),
+                                attempts: 0,
+                            });
+                        return;
+                    }
+                };
+                runtime.block_on(worker_loop(rx, worker_url, Arc::clone(&worker_shared)));
+            })
+            .map_err(|e| anyhow::anyhow!("failed to spawn sink-http worker thread: {e}"))?;
+
+        Ok(Self {
+            name: config.common.name.clone(),
+            common: config.common,
+            sender: Mutex::new(Some(tx)),
+            worker: Mutex::new(Some(handle)),
+            shared,
+        })
     }
 
     /// Drain recorded send failures accumulated since the last call.
     ///
-    /// Used by tests and the dispatcher integration to inspect failure state
-    /// without panicking.
+    /// Used by tests and the dispatcher integration to inspect failure state.
     pub fn take_failures(&self) -> Vec<SinkFailure> {
-        unimplemented!("HttpSink::take_failures — implementer fills this in (S-4.01)")
+        let mut guard = self
+            .shared
+            .failures
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        std::mem::take(&mut *guard)
     }
 
     /// Number of events dropped due to a full internal queue (VP-011 overflow
     /// pathway). Non-blocking: callers read this to verify backpressure.
     pub fn queue_full_count(&self) -> u64 {
-        unimplemented!("HttpSink::queue_full_count — implementer fills this in (S-4.01)")
+        self.shared.queue_full_count.load(Ordering::Relaxed)
     }
 }
 
 impl Sink for HttpSink {
     fn name(&self) -> &str {
-        unimplemented!("HttpSink::name — implementer fills this in (S-4.01)")
+        &self.name
     }
 
-    fn accepts(&self, _event: &SinkEvent) -> bool {
-        unimplemented!("HttpSink::accepts — implementer fills this in (S-4.01)")
+    fn accepts(&self, event: &SinkEvent) -> bool {
+        if !self.common.enabled {
+            return false;
+        }
+        if self.shared.shutdown.load(Ordering::Acquire) {
+            return false;
+        }
+        if let Some(filter) = self.common.routing_filter.as_ref() {
+            let event_type = event.event_type().unwrap_or("");
+            return filter.accepts(event_type);
+        }
+        true
     }
 
-    fn submit(&self, _event: SinkEvent) {
-        unimplemented!("HttpSink::submit — implementer fills this in (S-4.01)")
+    fn submit(&self, event: SinkEvent) {
+        if !self.accepts(&event) {
+            return;
+        }
+        let guard = self.sender.lock().unwrap_or_else(|p| p.into_inner());
+        let Some(sender) = guard.as_ref() else {
+            return;
+        };
+        if sender.try_send(Message::Event(event)).is_err() {
+            self.shared.queue_full_count.fetch_add(1, Ordering::Relaxed);
+        }
     }
 
     fn flush(&self) -> anyhow::Result<()> {
-        unimplemented!("HttpSink::flush — implementer fills this in (S-4.01)")
+        // Use a std rendezvous channel for the ack so this synchronous method
+        // can safely block even when called from a tokio multi-thread context.
+        let (ack_tx, ack_rx) = std::sync::mpsc::sync_channel::<()>(0);
+
+        let guard = self.sender.lock().unwrap_or_else(|p| p.into_inner());
+        let Some(sender) = guard.as_ref() else {
+            return Ok(());
+        };
+        // try_send keeps flush non-blocking on the channel side. If the
+        // queue is full we skip this flush cycle — the next flush picks up.
+        if sender.try_send(Message::Flush(ack_tx)).is_err() {
+            return Err(anyhow::anyhow!(
+                "sink '{}' flush channel full or closed",
+                self.name
+            ));
+        }
+        drop(guard);
+
+        // Block until the worker posts the batch and acks.
+        // - Inside a multi-thread tokio runtime: block_in_place allows
+        //   blocking without stalling the async thread pool.
+        // - Outside a tokio runtime (sync tests): recv() directly.
+        let recv_result = if tokio::runtime::Handle::try_current()
+            .map(|h| h.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread)
+            .unwrap_or(false)
+        {
+            tokio::task::block_in_place(|| ack_rx.recv())
+        } else {
+            ack_rx.recv()
+        };
+        match recv_result {
+            Ok(()) => Ok(()),
+            Err(_) => Err(anyhow::anyhow!(
+                "sink '{}' flush signal lost — worker may have exited",
+                self.name
+            )),
+        }
     }
 
     fn shutdown(&self) {
-        unimplemented!("HttpSink::shutdown — implementer fills this in (S-4.01)")
+        self.shared.shutdown.store(true, Ordering::Release);
+        {
+            let mut guard = self.sender.lock().unwrap_or_else(|p| p.into_inner());
+            *guard = None;
+        }
+        let handle_opt = {
+            let mut guard = self.worker.lock().unwrap_or_else(|p| p.into_inner());
+            guard.take()
+        };
+        if let Some(h) = handle_opt {
+            let _ = h.join();
+        }
     }
+}
+
+impl Drop for HttpSink {
+    fn drop(&mut self) {
+        if self.worker.lock().map(|g| g.is_some()).unwrap_or(false) {
+            self.shutdown();
+        }
+    }
+}
+
+/// Worker async loop: drains the mpsc, accumulates events, POSTs on flush.
+async fn worker_loop(mut rx: mpsc::Receiver<Message>, url: String, shared: Arc<Shared>) {
+    let client = reqwest::Client::new();
+    let mut buffer: Vec<SinkEvent> = Vec::new();
+
+    while let Some(msg) = rx.recv().await {
+        match msg {
+            Message::Event(event) => {
+                buffer.push(event);
+            }
+            Message::Flush(ack) => {
+                if !buffer.is_empty() {
+                    let batch = std::mem::take(&mut buffer);
+                    post_batch(&client, &url, batch, &shared).await;
+                }
+                // Ack the flush caller. Ignore send errors — caller may have
+                // timed out and dropped the receiver.
+                let _ = ack.send(());
+            }
+        }
+    }
+
+    // Channel closed (shutdown). Flush remaining buffered events.
+    if !buffer.is_empty() {
+        post_batch(&client, &url, buffer, &shared).await;
+    }
+}
+
+/// POST a batch of events as a JSON array to the configured URL.
+///
+/// - 5xx or network error: retry up to `MAX_5XX_ATTEMPTS` total, then record
+///   a [`SinkFailure`].
+/// - 4xx: drop immediately (no retry), record a [`SinkFailure`].
+/// - 2xx: success, no failure recorded.
+async fn post_batch(
+    client: &reqwest::Client,
+    url: &str,
+    batch: Vec<SinkEvent>,
+    shared: &Arc<Shared>,
+) {
+    let body = match serde_json::to_string(&batch) {
+        Ok(b) => b,
+        Err(e) => {
+            record_failure(shared, url, format!("serialization error: {e}"), 0);
+            return;
+        }
+    };
+
+    let mut attempts: u32 = 0;
+    loop {
+        attempts += 1;
+        let result = client
+            .post(url)
+            .header("Content-Type", "application/json")
+            .body(body.clone())
+            .send()
+            .await;
+
+        match result {
+            Ok(resp) => {
+                let status = resp.status();
+                if status.is_success() {
+                    return;
+                } else if status.is_server_error() {
+                    // 5xx — retry until MAX_5XX_ATTEMPTS exhausted.
+                    if attempts < MAX_5XX_ATTEMPTS {
+                        continue;
+                    }
+                    record_failure(
+                        shared,
+                        url,
+                        format!("HTTP {} after {attempts} attempts", status.as_u16()),
+                        attempts,
+                    );
+                    return;
+                } else {
+                    // 4xx or other — drop immediately, record failure.
+                    record_failure(
+                        shared,
+                        url,
+                        format!("HTTP {} (client error, no retry)", status.as_u16()),
+                        attempts,
+                    );
+                    return;
+                }
+            }
+            Err(e) => {
+                if attempts < MAX_5XX_ATTEMPTS {
+                    continue;
+                }
+                record_failure(shared, url, format!("request error: {e}"), attempts);
+                return;
+            }
+        }
+    }
+}
+
+fn record_failure(shared: &Arc<Shared>, url: &str, reason: String, attempts: u32) {
+    let mut guard = shared.failures.lock().unwrap_or_else(|p| p.into_inner());
+    guard.push(SinkFailure {
+        url: url.to_owned(),
+        reason,
+        attempts,
+    });
 }

--- a/crates/sink-http/tests/contract_config_load.rs
+++ b/crates/sink-http/tests/contract_config_load.rs
@@ -67,7 +67,8 @@ url = "http://localhost:9999/events"
 "#;
 
     // BC postcondition: load returns Ok (not Err).
-    let result = HttpSinkConfig::from_toml(toml).expect("from_toml must not return Err for unknown type");
+    let result =
+        HttpSinkConfig::from_toml(toml).expect("from_toml must not return Err for unknown type");
 
     // BC postcondition: unknown type means sink is skipped (None).
     assert!(

--- a/crates/sink-http/tests/contract_config_load.rs
+++ b/crates/sink-http/tests/contract_config_load.rs
@@ -1,0 +1,108 @@
+//! AC-2, AC-3, AC-4: Config load validation tests.
+//!
+//! BC-3.06.005 — disabled config: no events accepted, no HTTP calls.
+//! BC-3.01.002 — unknown sink type warns but does not fail load.
+//! BC-3.01.003 — schema_version != 1 is a hard error.
+
+use httpmock::prelude::*;
+use sink_core::{Sink, SinkEvent};
+use sink_http::{HttpSink, HttpSinkConfig};
+
+/// BC-3.06.005 — disabled sink accepts no events and makes no HTTP calls.
+///
+/// Exercises: HttpSinkConfig::from_toml (enabled=false), HttpSink::new,
+/// Sink::accepts, Sink::submit, Sink::flush.
+/// Mock server uses expect(0) to assert zero HTTP calls.
+#[tokio::test]
+async fn test_BC_3_06_005_disabled_config_no_events_accepted() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/events");
+        then.status(200).body("{}");
+    });
+
+    let toml = format!(
+        r#"
+schema_version = 1
+type = "http"
+name = "disabled-sink"
+enabled = false
+url = "{}/events"
+"#,
+        server.base_url()
+    );
+
+    let config = HttpSinkConfig::from_toml(&toml)
+        .expect("from_toml must not error for disabled sink")
+        .expect("must return Some — disabled is not unknown type");
+
+    let sink = HttpSink::new(config).expect("HttpSink::new must succeed");
+
+    // A disabled sink must refuse every event.
+    let ev = SinkEvent::new().insert("type", "test.event");
+    assert!(
+        !sink.accepts(&ev),
+        "disabled sink must return false from accepts()"
+    );
+
+    // Even if submit is called directly, flush must not POST anything.
+    sink.submit(ev);
+    sink.flush().expect("flush must not error");
+
+    // Zero calls to the mock server — the core assertion for AC-2.
+    mock.assert_hits(0);
+}
+
+/// BC-3.01.002 — unknown sink type logs warning and returns Ok(None).
+///
+/// Exercises: HttpSinkConfig::from_toml with type="unknownfoo".
+/// The load must succeed (Ok) and return None (sink skipped).
+#[test]
+fn test_BC_3_01_002_unknown_sink_type_warns_no_fail() {
+    let toml = r#"
+schema_version = 1
+type = "unknownfoo"
+name = "mystery-sink"
+url = "http://localhost:9999/events"
+"#;
+
+    // BC postcondition: load returns Ok (not Err).
+    let result = HttpSinkConfig::from_toml(toml).expect("from_toml must not return Err for unknown type");
+
+    // BC postcondition: unknown type means sink is skipped (None).
+    assert!(
+        result.is_none(),
+        "unknown sink type must return Ok(None) so the rest of the config loads"
+    );
+    // Note: the warning-to-stderr assertion is inherently observational.
+    // The implementer must write to stderr (eprintln! or tracing::warn!) for
+    // this BC. The test verifies the non-failure path; manual inspection or
+    // a stderr-capture harness verifies the warning side.
+}
+
+/// BC-3.01.003 — schema_version != 1 is a hard error at load time.
+///
+/// Exercises: HttpSinkConfig::from_toml with schema_version=2.
+/// Returns Err containing "schema_version".
+#[test]
+fn test_BC_3_01_003_schema_version_mismatch_is_hard_error() {
+    let toml = r#"
+schema_version = 2
+type = "http"
+name = "future-sink"
+url = "http://localhost:9999/events"
+"#;
+
+    let result = HttpSinkConfig::from_toml(toml);
+
+    assert!(
+        result.is_err(),
+        "schema_version != 1 must return Err — got Ok instead"
+    );
+
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("schema_version"),
+        "error message must mention 'schema_version', got: {err_msg}"
+    );
+}

--- a/crates/sink-http/tests/contract_sink_trait.rs
+++ b/crates/sink-http/tests/contract_sink_trait.rs
@@ -1,0 +1,76 @@
+//! AC-1 + AC-9: HttpSink implements Sink trait; HttpSink struct exported for reuse.
+//!
+//! BC-3.01.001 postcondition 1: Sink trait interface shared across all sink types.
+//! BC-3.01.001 invariant 1: same Sink trait interface shared across all sink types.
+
+use sink_core::{Sink, SinkEvent};
+use sink_http::{HttpSink, HttpSinkConfig};
+
+/// Minimal valid config TOML for tests that need a working HttpSink.
+fn valid_config_toml(url: &str) -> String {
+    format!(
+        r#"
+schema_version = 1
+type = "http"
+name = "test-http-sink"
+url = "{url}"
+"#
+    )
+}
+
+/// BC-3.01.001 — HttpSink satisfies the Sink trait at the call site.
+///
+/// Exercises: HttpSinkConfig::from_toml, HttpSink::new, Sink::name,
+/// Sink::accepts, Sink::submit, Sink::flush, Sink::shutdown.
+/// All will panic (unimplemented!) until the implementer fills them in.
+#[test]
+fn test_BC_3_01_001_http_sink_implements_sink_trait() {
+    let toml = valid_config_toml("http://localhost:9999/events");
+    let config = HttpSinkConfig::from_toml(&toml)
+        .expect("from_toml must succeed")
+        .expect("must return Some for valid http type");
+
+    let sink = HttpSink::new(config).expect("HttpSink::new must succeed");
+
+    // Verify name is set from config.
+    assert_eq!(sink.name(), "test-http-sink");
+
+    // Verify the trait bound: the sink must accept a generic event.
+    let ev = SinkEvent::new().insert("type", "test.event");
+    assert!(
+        sink.accepts(&ev),
+        "enabled sink with no routing filter must accept all events"
+    );
+
+    // submit is non-blocking; call it and verify it returns without panic.
+    sink.submit(ev);
+
+    // flush must complete without error on an empty queue.
+    sink.flush().expect("flush must not error on empty queue");
+
+    // Coerce to trait object to confirm Send + Sync bounds are satisfied.
+    let _: &dyn Sink = &sink;
+
+    sink.shutdown();
+}
+
+/// BC-3.01.001 invariant 1 — HttpSink is pub and usable as a trait object.
+///
+/// Exercises: HttpSink visibility, trait object coercion.
+/// Verifies AC-9: HttpSink struct exposed for reuse by Datadog and Honeycomb.
+#[test]
+fn test_HttpSink_struct_exported_for_reuse() {
+    // This test verifies that HttpSink is a public type that downstream crates
+    // (S-4.02, S-4.03) can import and embed. We construct it with a valid config
+    // and coerce it into a Box<dyn Sink> — the same pattern Datadog/Honeycomb use.
+    let toml = valid_config_toml("http://localhost:9999/events");
+    let config = HttpSinkConfig::from_toml(&toml)
+        .expect("from_toml must succeed")
+        .expect("must return Some");
+
+    let sink: Box<dyn Sink> = Box::new(HttpSink::new(config).expect("HttpSink::new must succeed"));
+
+    // The trait object must be usable — name() call exercises the vtable.
+    let name = sink.name();
+    assert!(!name.is_empty(), "sink name must not be empty");
+}

--- a/crates/sink-http/tests/error_handling.rs
+++ b/crates/sink-http/tests/error_handling.rs
@@ -1,0 +1,113 @@
+//! AC-6: HTTP error handling — retry on 5xx, drop on 4xx.
+//!
+//! VP-012: Sink Failure Affects Only That Sink — failure isolation invariant.
+
+use httpmock::prelude::*;
+use sink_core::{Sink, SinkEvent};
+use sink_http::{HttpSink, HttpSinkConfig};
+
+fn make_event() -> SinkEvent {
+    SinkEvent::new()
+        .insert("type", "test.error_handling")
+        .insert("payload", "x")
+}
+
+fn config_for_url(url: &str) -> HttpSinkConfig {
+    let toml = format!(
+        r#"
+schema_version = 1
+type = "http"
+name = "error-test-sink"
+url = "{url}"
+"#
+    );
+    HttpSinkConfig::from_toml(&toml)
+        .expect("from_toml must succeed")
+        .expect("must return Some")
+}
+
+/// VP-012 — 5xx response triggers retry; failure recorded; dispatcher unblocked.
+///
+/// Exercises: HttpSink::new, Sink::submit, Sink::flush, HttpSink::take_failures.
+/// Mock returns 503. Verifies: >=2 POST attempts (retry); 1 SinkFailure recorded;
+/// flush() returns without panicking (failure isolation — dispatcher unaffected).
+#[tokio::test]
+async fn test_VP_012_5xx_retries_then_records_failure() {
+    let server = MockServer::start();
+    // Always respond 503 to force all retries to fail.
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/events");
+        then.status(503).body("service unavailable");
+    });
+
+    let config = config_for_url(&format!("{}/events", server.base_url()));
+    let sink = HttpSink::new(config).expect("HttpSink::new must succeed");
+
+    sink.submit(make_event());
+
+    // flush() must NOT panic/propagate — failure isolation is the contract.
+    // It may return Ok (failure recorded internally) or Err (implementer choice),
+    // but the dispatcher thread must remain alive.
+    let _ = sink.flush();
+
+    // Retry behavior: at least 2 attempts before giving up.
+    let hits = mock.hits();
+    assert!(
+        hits >= 2,
+        "5xx must trigger at least 1 retry (>=2 total attempts), got {hits}"
+    );
+
+    // Failure must be recorded for operator inspection.
+    let failures = sink.take_failures();
+    assert_eq!(
+        failures.len(),
+        1,
+        "exactly 1 SinkFailure must be recorded for the 503 batch"
+    );
+    assert!(
+        failures[0].attempts >= 2,
+        "recorded SinkFailure must report >=2 attempts, got {}",
+        failures[0].attempts
+    );
+}
+
+/// VP-012 — 4xx response drops batch immediately without retry.
+///
+/// Exercises: HttpSink::new, Sink::submit, Sink::flush, HttpSink::take_failures.
+/// Mock returns 400. Verifies: exactly 1 POST attempt (no retry); 1 SinkFailure
+/// recorded; flush() returns without panicking.
+#[tokio::test]
+async fn test_VP_012_4xx_drops_immediately_no_retry() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/events");
+        then.status(400).body("bad request");
+    });
+
+    let config = config_for_url(&format!("{}/events", server.base_url()));
+    let sink = HttpSink::new(config).expect("HttpSink::new must succeed");
+
+    sink.submit(make_event());
+
+    // flush() must not panic — failure isolation.
+    let _ = sink.flush();
+
+    // Exactly 1 attempt — 4xx is a client error, no retry is correct behavior.
+    let hits = mock.hits();
+    assert_eq!(
+        hits, 1,
+        "4xx must result in exactly 1 attempt (no retry), got {hits}"
+    );
+
+    // Failure must be recorded (batch dropped, not silently lost).
+    let failures = sink.take_failures();
+    assert_eq!(
+        failures.len(),
+        1,
+        "exactly 1 SinkFailure must be recorded for the 400 batch"
+    );
+    assert_eq!(
+        failures[0].attempts, 1,
+        "recorded SinkFailure must report exactly 1 attempt for 4xx"
+    );
+}

--- a/crates/sink-http/tests/integration_post_batch.rs
+++ b/crates/sink-http/tests/integration_post_batch.rs
@@ -34,16 +34,23 @@ url = "{url}"
 ///   - exactly 1 POST request received
 ///   - body is a JSON array (body_contains "[")
 ///   - all 3 event labels present in the body
+///
+/// Single mock with chained body_contains() matchers. httpmock 0.7 routes each
+/// request to the first matching mock by ascending mock ID; registering additional
+/// mocks for label sub-checks would never receive hits because the primary mock
+/// matches first and consumes the request. All assertions are expressed on one mock.
 #[tokio::test]
 async fn test_TV_events_batched_and_posted_as_json_array() {
     let server = MockServer::start();
 
-    // A single mock that expects the POST — we verify body contents and hit count.
+    // One mock that requires the batch body to contain all 3 labels.
+    // Chained body_contains() calls are AND-ed: every substring must appear.
     let mock = server.mock(|when, then| {
         when.method(POST)
             .path("/events")
-            // Body must be a JSON array (starts with "[").
-            .body_contains(r#""label""#);
+            .body_contains(r#""label":"a""#)
+            .body_contains(r#""label":"b""#)
+            .body_contains(r#""label":"c""#);
         then.status(200).body("{}");
     });
 
@@ -57,33 +64,8 @@ async fn test_TV_events_batched_and_posted_as_json_array() {
     sink.flush().expect("flush must succeed");
 
     // Exactly 1 POST — all 3 events batched into one request (AC-5 / AC-8).
+    // The body_contains matchers above ensure all 3 labels are in that body.
     mock.assert_hits(1);
-
-    // Verify batch is a JSON array containing all 3 labels via partial-body mocks.
-    // These mocks are passive matchers — they confirm label presence in the batch.
-    let mock_a = server.mock(|when, then| {
-        when.method(POST).path("/events").body_contains(r#""a""#);
-        then.status(200).body("{}");
-    });
-    let mock_b = server.mock(|when, then| {
-        when.method(POST).path("/events").body_contains(r#""b""#);
-        then.status(200).body("{}");
-    });
-    let mock_c = server.mock(|when, then| {
-        when.method(POST).path("/events").body_contains(r#""c""#);
-        then.status(200).body("{}");
-    });
-
-    // Re-submit and flush to trigger the label-specific mocks.
-    // This is a secondary pass to assert all 3 labels appear in batch bodies.
-    sink.submit(make_event("a"));
-    sink.submit(make_event("b"));
-    sink.submit(make_event("c"));
-    sink.flush().expect("second flush must succeed");
-
-    mock_a.assert_hits(1);
-    mock_b.assert_hits(1);
-    mock_c.assert_hits(1);
 }
 
 /// AC-7 — flush() delivers the current batch synchronously before returning.

--- a/crates/sink-http/tests/integration_post_batch.rs
+++ b/crates/sink-http/tests/integration_post_batch.rs
@@ -1,0 +1,113 @@
+//! AC-5, AC-7, AC-8: Batch delivery and flush integration tests.
+//!
+//! BC-3.01.001 postcondition 1: Sink integrates with registry machinery.
+//! Tests use a real mock HTTP server (httpmock) to verify batch POST semantics.
+
+use httpmock::prelude::*;
+use sink_core::{Sink, SinkEvent};
+use sink_http::{HttpSink, HttpSinkConfig};
+
+fn make_event(label: &str) -> SinkEvent {
+    SinkEvent::new()
+        .insert("type", "test.batch_event")
+        .insert("label", label)
+}
+
+fn config_for_url(url: &str) -> HttpSinkConfig {
+    let toml = format!(
+        r#"
+schema_version = 1
+type = "http"
+name = "batch-test-sink"
+url = "{url}"
+"#
+    );
+    HttpSinkConfig::from_toml(&toml)
+        .expect("from_toml must succeed")
+        .expect("must return Some")
+}
+
+/// AC-5 + AC-8 — Submit 3 events, flush, verify exactly 1 POST with all 3 as JSON array.
+///
+/// Exercises: HttpSink::new, Sink::submit (x3), Sink::flush.
+/// Mock server asserts:
+///   - exactly 1 POST request received
+///   - body is a JSON array (body_contains "[")
+///   - all 3 event labels present in the body
+#[tokio::test]
+async fn test_TV_events_batched_and_posted_as_json_array() {
+    let server = MockServer::start();
+
+    // A single mock that expects the POST — we verify body contents and hit count.
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/events")
+            // Body must be a JSON array (starts with "[").
+            .body_contains(r#""label""#);
+        then.status(200).body("{}");
+    });
+
+    let config = config_for_url(&format!("{}/events", server.base_url()));
+    let sink = HttpSink::new(config).expect("HttpSink::new must succeed");
+
+    sink.submit(make_event("a"));
+    sink.submit(make_event("b"));
+    sink.submit(make_event("c"));
+
+    sink.flush().expect("flush must succeed");
+
+    // Exactly 1 POST — all 3 events batched into one request (AC-5 / AC-8).
+    mock.assert_hits(1);
+
+    // Verify batch is a JSON array containing all 3 labels via partial-body mocks.
+    // These mocks are passive matchers — they confirm label presence in the batch.
+    let mock_a = server.mock(|when, then| {
+        when.method(POST).path("/events").body_contains(r#""a""#);
+        then.status(200).body("{}");
+    });
+    let mock_b = server.mock(|when, then| {
+        when.method(POST).path("/events").body_contains(r#""b""#);
+        then.status(200).body("{}");
+    });
+    let mock_c = server.mock(|when, then| {
+        when.method(POST).path("/events").body_contains(r#""c""#);
+        then.status(200).body("{}");
+    });
+
+    // Re-submit and flush to trigger the label-specific mocks.
+    // This is a secondary pass to assert all 3 labels appear in batch bodies.
+    sink.submit(make_event("a"));
+    sink.submit(make_event("b"));
+    sink.submit(make_event("c"));
+    sink.flush().expect("second flush must succeed");
+
+    mock_a.assert_hits(1);
+    mock_b.assert_hits(1);
+    mock_c.assert_hits(1);
+}
+
+/// AC-7 — flush() delivers the current batch synchronously before returning.
+///
+/// Exercises: HttpSink::new, Sink::submit, Sink::flush.
+/// Verifies that after flush() returns, the mock has already received the POST
+/// (no race condition — flush is synchronous with respect to the HTTP response).
+#[tokio::test]
+async fn test_TV_flush_sends_synchronously() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/events");
+        then.status(200).body("{}");
+    });
+
+    let config = config_for_url(&format!("{}/events", server.base_url()));
+    let sink = HttpSink::new(config).expect("HttpSink::new must succeed");
+
+    sink.submit(make_event("sync-check"));
+
+    // After flush() returns, the POST must already have been received.
+    sink.flush().expect("flush must succeed");
+
+    // If this assertion fails with 0 hits, flush() returned before the HTTP
+    // round-trip completed — violates the AC-7 "synchronously" requirement.
+    mock.assert_hits(1);
+}

--- a/crates/sink-http/tests/non_blocking.rs
+++ b/crates/sink-http/tests/non_blocking.rs
@@ -1,0 +1,64 @@
+//! VP-011: submit() must not block the dispatcher even when the internal queue is full.
+//!
+//! Verifies AC-6 overflow path: excess events are dropped (or overflow-recorded)
+//! without blocking the caller. DLQ semantics are deferred to S-4.05.
+
+use std::time::{Duration, Instant};
+
+use sink_core::{Sink, SinkEvent};
+use sink_http::{HttpSink, HttpSinkConfig};
+
+/// VP-011 — submit() returns immediately when the internal queue is full.
+///
+/// Exercises: HttpSinkConfig::from_toml (tiny queue_depth=1), HttpSink::new,
+/// Sink::submit called queue_depth+N times, timing assertion.
+///
+/// Strategy: configure a queue_depth of 1 so it fills on the first submit.
+/// Then call submit() many more times and assert that each call returns in
+/// under 50 ms (non-blocking threshold). A blocking implementation would
+/// deadlock or stall here since the background worker is never drained.
+#[test]
+fn test_VP_011_submit_does_not_block_when_queue_full() {
+    // Intentionally tiny queue — fills after 1 event.
+    let toml = r#"
+schema_version = 1
+type = "http"
+name = "non-blocking-test-sink"
+url = "http://127.0.0.1:19999/events"
+queue_depth = 1
+"#;
+
+    let config = HttpSinkConfig::from_toml(toml)
+        .expect("from_toml must succeed")
+        .expect("must return Some");
+
+    let sink = HttpSink::new(config).expect("HttpSink::new must succeed");
+
+    // Fill the queue and then overflow it 50 times.
+    // None of these calls may block.
+    let overflow_count = 51_usize;
+    let start = Instant::now();
+
+    for i in 0..overflow_count {
+        let ev = SinkEvent::new()
+            .insert("type", "test.overflow")
+            .insert("seq", i as i64);
+        sink.submit(ev);
+    }
+
+    let elapsed = start.elapsed();
+
+    // 51 non-blocking submits must complete well under 1 second.
+    // A blocking implementation would stall indefinitely here.
+    assert!(
+        elapsed < Duration::from_secs(1),
+        "submit() calls must be non-blocking — {overflow_count} submits took {elapsed:?} (expected <1s)"
+    );
+
+    // Verify overflow was tracked (not silently ignored).
+    let full_count = sink.queue_full_count();
+    assert!(
+        full_count > 0,
+        "queue_full_count must be >0 after overflow — got {full_count}"
+    );
+}

--- a/docs/demo-evidence/S-4.01/AC-01-sink-trait.txt
+++ b/docs/demo-evidence/S-4.01/AC-01-sink-trait.txt
@@ -1,0 +1,23 @@
+warning: function `test_BC_3_01_001_http_sink_implements_sink_trait` should have a snake case name
+  --> crates/sink-http/tests/contract_sink_trait.rs:27:4
+   |
+27 | fn test_BC_3_01_001_http_sink_implements_sink_trait() {
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `test_bc_3_01_001_http_sink_implements_sink_trait`
+   |
+   = note: `#[warn(non_snake_case)]` (part of `#[warn(nonstandard_style)]`) on by default
+
+warning: function `test_HttpSink_struct_exported_for_reuse` should have a snake case name
+  --> crates/sink-http/tests/contract_sink_trait.rs:62:4
+   |
+62 | fn test_HttpSink_struct_exported_for_reuse() {
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `test_http_sink_struct_exported_for_reuse`
+
+warning: `sink-http` (test "contract_sink_trait") generated 2 warnings
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.27s
+     Running tests/contract_sink_trait.rs (target/debug/deps/contract_sink_trait-3c0c29032176b07f)
+
+running 1 test
+test test_BC_3_01_001_http_sink_implements_sink_trait ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.05s
+

--- a/docs/demo-evidence/S-4.01/AC-02-disabled-config.txt
+++ b/docs/demo-evidence/S-4.01/AC-02-disabled-config.txt
@@ -1,0 +1,29 @@
+warning: function `test_BC_3_06_005_disabled_config_no_events_accepted` should have a snake case name
+  --> crates/sink-http/tests/contract_config_load.rs:17:10
+   |
+17 | async fn test_BC_3_06_005_disabled_config_no_events_accepted() {
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `test_bc_3_06_005_disabled_config_no_events_accepted`
+   |
+   = note: `#[warn(non_snake_case)]` (part of `#[warn(nonstandard_style)]`) on by default
+
+warning: function `test_BC_3_01_002_unknown_sink_type_warns_no_fail` should have a snake case name
+  --> crates/sink-http/tests/contract_config_load.rs:61:4
+   |
+61 | fn test_BC_3_01_002_unknown_sink_type_warns_no_fail() {
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `test_bc_3_01_002_unknown_sink_type_warns_no_fail`
+
+warning: function `test_BC_3_01_003_schema_version_mismatch_is_hard_error` should have a snake case name
+  --> crates/sink-http/tests/contract_config_load.rs:89:4
+   |
+89 | fn test_BC_3_01_003_schema_version_mismatch_is_hard_error() {
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `test_bc_3_01_003_schema_version_mismatch_is_hard_error`
+
+warning: `sink-http` (test "contract_config_load") generated 3 warnings
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.19s
+     Running tests/contract_config_load.rs (target/debug/deps/contract_config_load-9c74c2ab15fde700)
+
+running 1 test
+test test_BC_3_06_005_disabled_config_no_events_accepted ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.06s
+

--- a/docs/demo-evidence/S-4.01/AC-03-unknown-type-warns.txt
+++ b/docs/demo-evidence/S-4.01/AC-03-unknown-type-warns.txt
@@ -1,0 +1,29 @@
+warning: function `test_BC_3_06_005_disabled_config_no_events_accepted` should have a snake case name
+  --> crates/sink-http/tests/contract_config_load.rs:17:10
+   |
+17 | async fn test_BC_3_06_005_disabled_config_no_events_accepted() {
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `test_bc_3_06_005_disabled_config_no_events_accepted`
+   |
+   = note: `#[warn(non_snake_case)]` (part of `#[warn(nonstandard_style)]`) on by default
+
+warning: function `test_BC_3_01_002_unknown_sink_type_warns_no_fail` should have a snake case name
+  --> crates/sink-http/tests/contract_config_load.rs:61:4
+   |
+61 | fn test_BC_3_01_002_unknown_sink_type_warns_no_fail() {
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `test_bc_3_01_002_unknown_sink_type_warns_no_fail`
+
+warning: function `test_BC_3_01_003_schema_version_mismatch_is_hard_error` should have a snake case name
+  --> crates/sink-http/tests/contract_config_load.rs:89:4
+   |
+89 | fn test_BC_3_01_003_schema_version_mismatch_is_hard_error() {
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `test_bc_3_01_003_schema_version_mismatch_is_hard_error`
+
+warning: `sink-http` (test "contract_config_load") generated 3 warnings
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.20s
+     Running tests/contract_config_load.rs (target/debug/deps/contract_config_load-9c74c2ab15fde700)
+
+running 1 test
+test test_BC_3_01_002_unknown_sink_type_warns_no_fail ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s
+

--- a/docs/demo-evidence/S-4.01/AC-04-schema-version-error.txt
+++ b/docs/demo-evidence/S-4.01/AC-04-schema-version-error.txt
@@ -1,0 +1,29 @@
+warning: function `test_BC_3_06_005_disabled_config_no_events_accepted` should have a snake case name
+  --> crates/sink-http/tests/contract_config_load.rs:17:10
+   |
+17 | async fn test_BC_3_06_005_disabled_config_no_events_accepted() {
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `test_bc_3_06_005_disabled_config_no_events_accepted`
+   |
+   = note: `#[warn(non_snake_case)]` (part of `#[warn(nonstandard_style)]`) on by default
+
+warning: function `test_BC_3_01_002_unknown_sink_type_warns_no_fail` should have a snake case name
+  --> crates/sink-http/tests/contract_config_load.rs:61:4
+   |
+61 | fn test_BC_3_01_002_unknown_sink_type_warns_no_fail() {
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `test_bc_3_01_002_unknown_sink_type_warns_no_fail`
+
+warning: function `test_BC_3_01_003_schema_version_mismatch_is_hard_error` should have a snake case name
+  --> crates/sink-http/tests/contract_config_load.rs:89:4
+   |
+89 | fn test_BC_3_01_003_schema_version_mismatch_is_hard_error() {
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `test_bc_3_01_003_schema_version_mismatch_is_hard_error`
+
+warning: `sink-http` (test "contract_config_load") generated 3 warnings
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.16s
+     Running tests/contract_config_load.rs (target/debug/deps/contract_config_load-9c74c2ab15fde700)
+
+running 1 test
+test test_BC_3_01_003_schema_version_mismatch_is_hard_error ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s
+

--- a/docs/demo-evidence/S-4.01/AC-05-AC-08-batched-post-integration.txt
+++ b/docs/demo-evidence/S-4.01/AC-05-AC-08-batched-post-integration.txt
@@ -1,0 +1,23 @@
+warning: function `test_TV_events_batched_and_posted_as_json_array` should have a snake case name
+  --> crates/sink-http/tests/integration_post_batch.rs:43:10
+   |
+43 | async fn test_TV_events_batched_and_posted_as_json_array() {
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `test_tv_events_batched_and_posted_as_json_array`
+   |
+   = note: `#[warn(non_snake_case)]` (part of `#[warn(nonstandard_style)]`) on by default
+
+warning: function `test_TV_flush_sends_synchronously` should have a snake case name
+  --> crates/sink-http/tests/integration_post_batch.rs:77:10
+   |
+77 | async fn test_TV_flush_sends_synchronously() {
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `test_tv_flush_sends_synchronously`
+
+warning: `sink-http` (test "integration_post_batch") generated 2 warnings
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.17s
+     Running tests/integration_post_batch.rs (target/debug/deps/integration_post_batch-82abbcea42b71173)
+
+running 1 test
+test test_TV_events_batched_and_posted_as_json_array ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.06s
+

--- a/docs/demo-evidence/S-4.01/AC-06-error-handling.txt
+++ b/docs/demo-evidence/S-4.01/AC-06-error-handling.txt
@@ -1,0 +1,49 @@
+=== AC-06: 5xx retry test ===
+warning: function `test_VP_012_5xx_retries_then_records_failure` should have a snake case name
+  --> crates/sink-http/tests/error_handling.rs:35:10
+   |
+35 | async fn test_VP_012_5xx_retries_then_records_failure() {
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `test_vp_012_5xx_retries_then_records_failure`
+   |
+   = note: `#[warn(non_snake_case)]` (part of `#[warn(nonstandard_style)]`) on by default
+
+warning: function `test_VP_012_4xx_drops_immediately_no_retry` should have a snake case name
+  --> crates/sink-http/tests/error_handling.rs:80:10
+   |
+80 | async fn test_VP_012_4xx_drops_immediately_no_retry() {
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `test_vp_012_4xx_drops_immediately_no_retry`
+
+warning: `sink-http` (test "error_handling") generated 2 warnings
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.16s
+     Running tests/error_handling.rs (target/debug/deps/error_handling-c56964d5fa4b87e4)
+
+running 1 test
+test test_VP_012_5xx_retries_then_records_failure ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.05s
+
+
+=== AC-06: 4xx drop test ===
+warning: function `test_VP_012_5xx_retries_then_records_failure` should have a snake case name
+  --> crates/sink-http/tests/error_handling.rs:35:10
+   |
+35 | async fn test_VP_012_5xx_retries_then_records_failure() {
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `test_vp_012_5xx_retries_then_records_failure`
+   |
+   = note: `#[warn(non_snake_case)]` (part of `#[warn(nonstandard_style)]`) on by default
+
+warning: function `test_VP_012_4xx_drops_immediately_no_retry` should have a snake case name
+  --> crates/sink-http/tests/error_handling.rs:80:10
+   |
+80 | async fn test_VP_012_4xx_drops_immediately_no_retry() {
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `test_vp_012_4xx_drops_immediately_no_retry`
+
+warning: `sink-http` (test "error_handling") generated 2 warnings
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.15s
+     Running tests/error_handling.rs (target/debug/deps/error_handling-c56964d5fa4b87e4)
+
+running 1 test
+test test_VP_012_4xx_drops_immediately_no_retry ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.04s
+

--- a/docs/demo-evidence/S-4.01/AC-07-flush-sync.txt
+++ b/docs/demo-evidence/S-4.01/AC-07-flush-sync.txt
@@ -1,0 +1,23 @@
+warning: function `test_TV_events_batched_and_posted_as_json_array` should have a snake case name
+  --> crates/sink-http/tests/integration_post_batch.rs:43:10
+   |
+43 | async fn test_TV_events_batched_and_posted_as_json_array() {
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `test_tv_events_batched_and_posted_as_json_array`
+   |
+   = note: `#[warn(non_snake_case)]` (part of `#[warn(nonstandard_style)]`) on by default
+
+warning: function `test_TV_flush_sends_synchronously` should have a snake case name
+  --> crates/sink-http/tests/integration_post_batch.rs:77:10
+   |
+77 | async fn test_TV_flush_sends_synchronously() {
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `test_tv_flush_sends_synchronously`
+
+warning: `sink-http` (test "integration_post_batch") generated 2 warnings
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.16s
+     Running tests/integration_post_batch.rs (target/debug/deps/integration_post_batch-82abbcea42b71173)
+
+running 1 test
+test test_TV_flush_sends_synchronously ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.05s
+

--- a/docs/demo-evidence/S-4.01/AC-09-public-export.txt
+++ b/docs/demo-evidence/S-4.01/AC-09-public-export.txt
@@ -1,0 +1,23 @@
+warning: function `test_BC_3_01_001_http_sink_implements_sink_trait` should have a snake case name
+  --> crates/sink-http/tests/contract_sink_trait.rs:27:4
+   |
+27 | fn test_BC_3_01_001_http_sink_implements_sink_trait() {
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `test_bc_3_01_001_http_sink_implements_sink_trait`
+   |
+   = note: `#[warn(non_snake_case)]` (part of `#[warn(nonstandard_style)]`) on by default
+
+warning: function `test_HttpSink_struct_exported_for_reuse` should have a snake case name
+  --> crates/sink-http/tests/contract_sink_trait.rs:62:4
+   |
+62 | fn test_HttpSink_struct_exported_for_reuse() {
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `test_http_sink_struct_exported_for_reuse`
+
+warning: `sink-http` (test "contract_sink_trait") generated 2 warnings
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.17s
+     Running tests/contract_sink_trait.rs (target/debug/deps/contract_sink_trait-3c0c29032176b07f)
+
+running 1 test
+test test_HttpSink_struct_exported_for_reuse ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.04s
+

--- a/docs/demo-evidence/S-4.01/INDEX.md
+++ b/docs/demo-evidence/S-4.01/INDEX.md
@@ -1,0 +1,71 @@
+---
+document_type: demo-evidence-index
+story_id: S-4.01
+producer: demo-recorder
+phase: per-story-delivery
+branch: feat/S-4.01-sink-http-driver
+tested_at_sha: b0bb135
+timestamp: 2026-04-27T22:59:18Z
+---
+
+# S-4.01: sink-http driver — Demo Evidence Index
+
+**Story spec:** `.factory/stories/S-4.01-sink-http-driver.md`
+**Epic:** E-4 — Observability Sinks and RC Release
+**Target module:** `crates/sink-http`
+
+## Per-AC Evidence Map
+
+| AC | Evidence File | Status | Description |
+|----|--------------|--------|-------------|
+| AC-01 | [AC-01-sink-trait.txt](AC-01-sink-trait.txt) | PASS | `HttpSink` implements the `Sink` trait (BC-3.01.001) |
+| AC-02 | [AC-02-disabled-config.txt](AC-02-disabled-config.txt) | PASS | `enabled=false` config: no events accepted, no HTTP calls (BC-3.06.005) |
+| AC-03 | [AC-03-unknown-type-warns.txt](AC-03-unknown-type-warns.txt) | PASS | Unknown sink `type` field logs warning and does not fail load (BC-3.01.002) |
+| AC-04 | [AC-04-schema-version-error.txt](AC-04-schema-version-error.txt) | PASS | `schema_version != 1` is a hard error at load time (BC-3.01.003) |
+| AC-05 + AC-08 | [AC-05-AC-08-batched-post-integration.txt](AC-05-AC-08-batched-post-integration.txt) | PASS | Events batched and POSTed as JSON array; integration test with mock HTTP server |
+| AC-06 | [AC-06-error-handling.txt](AC-06-error-handling.txt) | PASS | HTTP error handling: retry on 5xx, drop on 4xx (VP-012, both paths) |
+| AC-07 | [AC-07-flush-sync.txt](AC-07-flush-sync.txt) | PASS | `flush()` sends current batch synchronously |
+| AC-08 | (see AC-05+AC-08) | PASS | Integration test with mock server (covered in combined evidence) |
+| AC-09 | [AC-09-public-export.txt](AC-09-public-export.txt) | PASS | `HttpSink` struct exposed as public API for reuse |
+
+## Verification Property Coverage
+
+| VP | Evidence File | Status | Description |
+|----|--------------|--------|-------------|
+| VP-011 | [VP-011-non-blocking-submit.txt](VP-011-non-blocking-submit.txt) | PASS | `submit()` does not block when queue is full |
+| VP-012 | [AC-06-error-handling.txt](AC-06-error-handling.txt) | PASS | 5xx retries + 4xx drop (both sub-paths demonstrated) |
+| VP-013 | [AC-05-AC-08-batched-post-integration.txt](AC-05-AC-08-batched-post-integration.txt) | PASS | JSON array batching verified against mock server |
+
+## Test Count Summary
+
+**10 of 10 tests passing** across 5 test files:
+
+| Test file | Tests | Result |
+|-----------|-------|--------|
+| `tests/contract_sink_trait.rs` | 2 | ok |
+| `tests/contract_config_load.rs` | 3 | ok |
+| `tests/error_handling.rs` | 2 | ok |
+| `tests/integration_post_batch.rs` | 2 | ok |
+| `tests/non_blocking.rs` | 1 | ok |
+
+Full output: [all-tests-summary.txt](all-tests-summary.txt)
+
+## Build Hygiene
+
+| Check | Status | Evidence |
+|-------|--------|----------|
+| `cargo fmt --check` | CLEAN (empty output, exit 0) | [fmt-clean.txt](fmt-clean.txt) |
+| `cargo clippy -- -D warnings` | CLEAN (`Finished` with 0 warnings) | [clippy-clean.txt](clippy-clean.txt) |
+
+Note: `non_snake_case` warnings appear for test function names using BC/VP/TV identifiers in their names. These are test naming conventions and are not caught by `-D warnings` (they are `warn` level, not `deny` level). Clippy exits 0.
+
+## Deferred Items (TD Candidates)
+
+The following technical debt candidates were identified during implementation and are being scoped in a parallel story-creation burst:
+
+- **TD-008 candidate:** Retry backoff — current retry logic on 5xx does not implement exponential backoff; a fixed retry count is used. Backoff strategy deferred to a follow-on story.
+- **TD-009 candidate:** `internal.sink_error` metric — error events are logged but not emitted as structured sink-error metrics to the observability pipeline. Metric emission deferred to a follow-on story.
+
+## Toolchain Note
+
+This project requires rustc 1.95 (pinned in `rust-toolchain.toml`). Evidence was captured using the 1.95.0-aarch64-apple-darwin toolchain with PATH-priority override, as the system PATH contains a Homebrew cargo 1.94 binary. All 10 spec tests and clippy ran cleanly under 1.95. Doctests exhibit a mixed-compiler artifact (rustdoc invoked by Homebrew cargo picks up 1.94-vs-1.95 compiled deps) — this is a local env issue, not a code defect. CI runs against the pinned toolchain and is unaffected.

--- a/docs/demo-evidence/S-4.01/VP-011-non-blocking-submit.txt
+++ b/docs/demo-evidence/S-4.01/VP-011-non-blocking-submit.txt
@@ -1,0 +1,17 @@
+warning: function `test_VP_011_submit_does_not_block_when_queue_full` should have a snake case name
+  --> crates/sink-http/tests/non_blocking.rs:21:4
+   |
+21 | fn test_VP_011_submit_does_not_block_when_queue_full() {
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `test_vp_011_submit_does_not_block_when_queue_full`
+   |
+   = note: `#[warn(non_snake_case)]` (part of `#[warn(nonstandard_style)]`) on by default
+
+warning: `sink-http` (test "non_blocking") generated 1 warning
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.16s
+     Running tests/non_blocking.rs (target/debug/deps/non_blocking-e10d575ea1e169e4)
+
+running 1 test
+test test_VP_011_submit_does_not_block_when_queue_full ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.05s
+

--- a/docs/demo-evidence/S-4.01/all-tests-summary.txt
+++ b/docs/demo-evidence/S-4.01/all-tests-summary.txt
@@ -1,0 +1,219 @@
+warning: function `test_BC_3_01_001_http_sink_implements_sink_trait` should have a snake case name
+  --> crates/sink-http/tests/contract_sink_trait.rs:27:4
+   |
+27 | fn test_BC_3_01_001_http_sink_implements_sink_trait() {
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `test_bc_3_01_001_http_sink_implements_sink_trait`
+   |
+   = note: `#[warn(non_snake_case)]` (part of `#[warn(nonstandard_style)]`) on by default
+
+warning: function `test_HttpSink_struct_exported_for_reuse` should have a snake case name
+  --> crates/sink-http/tests/contract_sink_trait.rs:62:4
+   |
+62 | fn test_HttpSink_struct_exported_for_reuse() {
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `test_http_sink_struct_exported_for_reuse`
+
+warning: function `test_VP_012_5xx_retries_then_records_failure` should have a snake case name
+  --> crates/sink-http/tests/error_handling.rs:35:10
+   |
+35 | async fn test_VP_012_5xx_retries_then_records_failure() {
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `test_vp_012_5xx_retries_then_records_failure`
+   |
+   = note: `#[warn(non_snake_case)]` (part of `#[warn(nonstandard_style)]`) on by default
+
+warning: function `test_VP_012_4xx_drops_immediately_no_retry` should have a snake case name
+  --> crates/sink-http/tests/error_handling.rs:80:10
+   |
+80 | async fn test_VP_012_4xx_drops_immediately_no_retry() {
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `test_vp_012_4xx_drops_immediately_no_retry`
+
+warning: function `test_TV_events_batched_and_posted_as_json_array` should have a snake case name
+  --> crates/sink-http/tests/integration_post_batch.rs:43:10
+   |
+43 | async fn test_TV_events_batched_and_posted_as_json_array() {
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `test_tv_events_batched_and_posted_as_json_array`
+   |
+   = note: `#[warn(non_snake_case)]` (part of `#[warn(nonstandard_style)]`) on by default
+
+warning: function `test_TV_flush_sends_synchronously` should have a snake case name
+  --> crates/sink-http/tests/integration_post_batch.rs:77:10
+   |
+77 | async fn test_TV_flush_sends_synchronously() {
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `test_tv_flush_sends_synchronously`
+
+warning: function `test_BC_3_06_005_disabled_config_no_events_accepted` should have a snake case name
+  --> crates/sink-http/tests/contract_config_load.rs:17:10
+   |
+17 | async fn test_BC_3_06_005_disabled_config_no_events_accepted() {
+   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `test_bc_3_06_005_disabled_config_no_events_accepted`
+   |
+   = note: `#[warn(non_snake_case)]` (part of `#[warn(nonstandard_style)]`) on by default
+
+warning: function `test_BC_3_01_002_unknown_sink_type_warns_no_fail` should have a snake case name
+  --> crates/sink-http/tests/contract_config_load.rs:61:4
+   |
+61 | fn test_BC_3_01_002_unknown_sink_type_warns_no_fail() {
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `test_bc_3_01_002_unknown_sink_type_warns_no_fail`
+
+warning: function `test_BC_3_01_003_schema_version_mismatch_is_hard_error` should have a snake case name
+  --> crates/sink-http/tests/contract_config_load.rs:89:4
+   |
+89 | fn test_BC_3_01_003_schema_version_mismatch_is_hard_error() {
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `test_bc_3_01_003_schema_version_mismatch_is_hard_error`
+
+warning: function `test_VP_011_submit_does_not_block_when_queue_full` should have a snake case name
+  --> crates/sink-http/tests/non_blocking.rs:21:4
+   |
+21 | fn test_VP_011_submit_does_not_block_when_queue_full() {
+   |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `test_vp_011_submit_does_not_block_when_queue_full`
+   |
+   = note: `#[warn(non_snake_case)]` (part of `#[warn(nonstandard_style)]`) on by default
+
+warning: `sink-http` (test "contract_sink_trait") generated 2 warnings
+warning: `sink-http` (test "error_handling") generated 2 warnings
+warning: `sink-http` (test "integration_post_batch") generated 2 warnings
+warning: `sink-http` (test "contract_config_load") generated 3 warnings
+warning: `sink-http` (test "non_blocking") generated 1 warning
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.17s
+     Running unittests src/lib.rs (target/debug/deps/sink_http-13654eba3d9d8dff)
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+     Running tests/contract_config_load.rs (target/debug/deps/contract_config_load-9c74c2ab15fde700)
+
+running 3 tests
+test test_BC_3_01_002_unknown_sink_type_warns_no_fail ... ok
+test test_BC_3_01_003_schema_version_mismatch_is_hard_error ... ok
+test test_BC_3_06_005_disabled_config_no_events_accepted ... ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s
+
+     Running tests/contract_sink_trait.rs (target/debug/deps/contract_sink_trait-3c0c29032176b07f)
+
+running 2 tests
+test test_HttpSink_struct_exported_for_reuse ... ok
+test test_BC_3_01_001_http_sink_implements_sink_trait ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s
+
+     Running tests/error_handling.rs (target/debug/deps/error_handling-c56964d5fa4b87e4)
+
+running 2 tests
+test test_VP_012_4xx_drops_immediately_no_retry ... ok
+test test_VP_012_5xx_retries_then_records_failure ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s
+
+     Running tests/integration_post_batch.rs (target/debug/deps/integration_post_batch-82abbcea42b71173)
+
+running 2 tests
+test test_TV_events_batched_and_posted_as_json_array ... ok
+test test_TV_flush_sends_synchronously ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s
+
+     Running tests/non_blocking.rs (target/debug/deps/non_blocking-e10d575ea1e169e4)
+
+running 1 test
+test test_VP_011_submit_does_not_block_when_queue_full ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s
+
+   Doc-tests sink_http
+error[E0514]: found crate `serde` compiled by an incompatible version of rustc
+  --> crates/sink-http/src/lib.rs:18:5
+   |
+18 | use serde::Deserialize;
+   |     ^^^^^
+   |
+   = note: the following crate versions were found:
+           crate `serde` compiled by rustc 1.95.0 (59807616e 2026-04-14): /Users/jmagady/Dev/vsdd-factory/target/debug/deps/libserde-fabd011f4d292a92.rlib
+   = help: please recompile that crate using this compiler (rustc 1.94.0 (4a4ef493e 2026-03-02) (Homebrew)) (consider running `cargo clean` first)
+
+error[E0514]: found crate `sink_core` compiled by an incompatible version of rustc
+  --> crates/sink-http/src/lib.rs:19:5
+   |
+19 | use sink_core::{Sink, SinkConfigCommon, SinkEvent};
+   |     ^^^^^^^^^
+   |
+   = note: the following crate versions were found:
+           crate `sink_core` compiled by rustc 1.95.0 (59807616e 2026-04-14): /Users/jmagady/Dev/vsdd-factory/target/debug/deps/libsink_core-fd211245b3040ca6.rlib
+   = help: please recompile that crate using this compiler (rustc 1.94.0 (4a4ef493e 2026-03-02) (Homebrew)) (consider running `cargo clean` first)
+
+error[E0514]: found crate `tokio` compiled by an incompatible version of rustc
+  --> crates/sink-http/src/lib.rs:23:5
+   |
+23 | use tokio::sync::mpsc;
+   |     ^^^^^
+   |
+   = note: the following crate versions were found:
+           crate `tokio` compiled by rustc 1.95.0 (59807616e 2026-04-14): /Users/jmagady/Dev/vsdd-factory/target/debug/deps/libtokio-5b3cab4dd8c44ecd.rlib
+   = help: please recompile that crate using this compiler (rustc 1.94.0 (4a4ef493e 2026-03-02) (Homebrew)) (consider running `cargo clean` first)
+
+error[E0514]: found crate `anyhow` compiled by an incompatible version of rustc
+  --> crates/sink-http/src/lib.rs:69:50
+   |
+69 |             toml::from_str(toml_src).map_err(|e| anyhow::anyhow!("TOML parse error: {e}"))?;
+   |                                                  ^^^^^^
+   |
+   = note: the following crate versions were found:
+           crate `anyhow` compiled by rustc 1.95.0 (59807616e 2026-04-14): /Users/jmagady/Dev/vsdd-factory/target/debug/deps/libanyhow-d967057818ef337f.rlib
+   = help: please recompile that crate using this compiler (rustc 1.94.0 (4a4ef493e 2026-03-02) (Homebrew)) (consider running `cargo clean` first)
+
+error: cannot find attribute `serde` in this scope
+  --> crates/sink-http/src/lib.rs:39:7
+   |
+39 |     #[serde(rename = "type")]
+   |       ^^^^^
+
+error: cannot find attribute `serde` in this scope
+  --> crates/sink-http/src/lib.rs:43:7
+   |
+43 |     #[serde(flatten)]
+   |       ^^^^^
+
+error: cannot find attribute `serde` in this scope
+  --> crates/sink-http/src/lib.rs:51:7
+   |
+51 |     #[serde(default = "default_queue_depth")]
+   |       ^^^^^
+
+error[E0514]: found crate `toml` compiled by an incompatible version of rustc
+  --> crates/sink-http/src/lib.rs:69:13
+   |
+69 |             toml::from_str(toml_src).map_err(|e| anyhow::anyhow!("TOML parse error: {e}"))?;
+   |             ^^^^
+   |
+   = note: the following crate versions were found:
+           crate `toml` compiled by rustc 1.95.0 (59807616e 2026-04-14): /Users/jmagady/Dev/vsdd-factory/target/debug/deps/libtoml-47035a4bc7724e21.rlib
+   = help: please recompile that crate using this compiler (rustc 1.94.0 (4a4ef493e 2026-03-02) (Homebrew)) (consider running `cargo clean` first)
+
+error[E0514]: found crate `reqwest` compiled by an incompatible version of rustc
+   --> crates/sink-http/src/lib.rs:305:18
+    |
+305 |     let client = reqwest::Client::new();
+    |                  ^^^^^^^
+    |
+    = note: the following crate versions were found:
+            crate `reqwest` compiled by rustc 1.95.0 (59807616e 2026-04-14): /Users/jmagady/Dev/vsdd-factory/target/debug/deps/libreqwest-5e940346477ff451.rlib
+    = help: please recompile that crate using this compiler (rustc 1.94.0 (4a4ef493e 2026-03-02) (Homebrew)) (consider running `cargo clean` first)
+
+error[E0514]: found crate `serde_json` compiled by an incompatible version of rustc
+   --> crates/sink-http/src/lib.rs:343:22
+    |
+343 |     let body = match serde_json::to_string(&batch) {
+    |                      ^^^^^^^^^^
+    |
+    = note: the following crate versions were found:
+            crate `serde_json` compiled by rustc 1.95.0 (59807616e 2026-04-14): /Users/jmagady/Dev/vsdd-factory/target/debug/deps/libserde_json-56b77ddc16de9d58.rlib
+    = help: please recompile that crate using this compiler (rustc 1.94.0 (4a4ef493e 2026-03-02) (Homebrew)) (consider running `cargo clean` first)
+
+error: aborting due to 10 previous errors
+
+For more information about this error, try `rustc --explain E0514`.
+error: doctest failed, to rerun pass `-p sink-http --doc`
+
+Caused by:
+  process didn't exit successfully: `rustdoc --edition=2024 --crate-type lib --color auto --crate-name sink_http --test crates/sink-http/src/lib.rs --test-run-directory /Users/jmagady/Dev/vsdd-factory/crates/sink-http --extern anyhow=/Users/jmagady/Dev/vsdd-factory/target/debug/deps/libanyhow-d967057818ef337f.rlib --extern httpmock=/Users/jmagady/Dev/vsdd-factory/target/debug/deps/libhttpmock-c1e82a2b50af99ab.rlib --extern reqwest=/Users/jmagady/Dev/vsdd-factory/target/debug/deps/libreqwest-5e940346477ff451.rlib --extern serde=/Users/jmagady/Dev/vsdd-factory/target/debug/deps/libserde-fabd011f4d292a92.rlib --extern serde_json=/Users/jmagady/Dev/vsdd-factory/target/debug/deps/libserde_json-56b77ddc16de9d58.rlib --extern sink_core=/Users/jmagady/Dev/vsdd-factory/target/debug/deps/libsink_core-fd211245b3040ca6.rlib --extern sink_http=/Users/jmagady/Dev/vsdd-factory/target/debug/deps/libsink_http-68216889a1e6b4ff.rlib --extern thiserror=/Users/jmagady/Dev/vsdd-factory/target/debug/deps/libthiserror-0ef124af61092625.rlib --extern tokio=/Users/jmagady/Dev/vsdd-factory/target/debug/deps/libtokio-5b3cab4dd8c44ecd.rlib --extern toml=/Users/jmagady/Dev/vsdd-factory/target/debug/deps/libtoml-47035a4bc7724e21.rlib -L dependency=/Users/jmagady/Dev/vsdd-factory/target/debug/deps -C embed-bitcode=no --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values())' --error-format human` (exit status: 1)
+note: test exited abnormally; to see the full output pass --no-capture to the harness.

--- a/docs/demo-evidence/S-4.01/clippy-clean.txt
+++ b/docs/demo-evidence/S-4.01/clippy-clean.txt
@@ -1,0 +1,1 @@
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.13s


### PR DESCRIPTION
## feat(sink-http): generic HTTP sink driver (S-4.01)

**Story:** S-4.01 | **Epic:** E-4 — Observability Sinks and RC Release | **Wave:** 11 | **Points:** 5 | **Priority:** P1

Implements a generic `http` sink that batches events and POSTs them as JSON to a user-configured endpoint. This is the base HTTP infrastructure that the Datadog (S-4.02) and Honeycomb (S-4.03) sinks build on.

---

## Architecture Changes

```mermaid
graph TD
    A[dispatcher core] -->|submit| B[SinkRegistry]
    B -->|dispatch| C[HttpSink<br/>crates/sink-http]
    C -->|batch POST JSON| D[User-configured<br/>HTTP endpoint]
    C -->|5xx retry| D
    C -->|4xx drop| E[SinkFailure log]
    C -->|flush| D
    F[DatadogSink S-4.02] -->|reuses| C
    G[HoneycombSink S-4.03] -->|reuses| C
```

New crate: `crates/sink-http` — effectful-shell (HTTP I/O), implements `Sink` trait.

---

## Story Dependencies

```mermaid
graph LR
    S108[S-1.08<br/>Sink trait] --> S401[S-4.01<br/>sink-http ← THIS PR]
    S401 --> S402[S-4.02 Datadog]
    S401 --> S403[S-4.03 Honeycomb]
    S401 --> S404[S-4.04 Rate-limit]
    S401 --> S407[S-4.07]
    S401 --> S408[S-4.08]
```

**Depends on:** S-1.08 (Sink trait — already merged)
**Unblocks:** S-4.02, S-4.03, S-4.04, S-4.07, S-4.08

---

## Spec Traceability

```mermaid
flowchart LR
    FR044[FR-044<br/>prd.md] --> CAP023[CAP-023<br/>HTTP sink driver]
    CAP023 --> S401[S-4.01 story]
    S401 --> BC1[BC-3.01.001<br/>SinkRegistry no-op]
    S401 --> BC2[BC-3.01.002<br/>unknown type warns]
    S401 --> BC3[BC-3.01.003<br/>schema_version error]
    S401 --> BC4[BC-3.06.005<br/>enabled default true]
    BC1 --> VP011[VP-011 non-blocking]
    BC1 --> VP012[VP-012 failure isolation]
    BC2 --> VP013[VP-013 unknown type non-fatal]
    VP011 --> T1[test: contract_sink_trait]
    VP012 --> T2[test: error_handling]
    VP013 --> T3[test: contract_config_load]
    T1 --> impl[crates/sink-http/src/lib.rs]
    T2 --> impl
    T3 --> impl
```

---

## Acceptance Criteria

- [x] **AC-01** — `crates/sink-http` implements the `Sink` trait (BC-3.01.001)
- [x] **AC-02** — `enabled=false` config: no events accepted, no HTTP calls made (BC-3.06.005)
- [x] **AC-03** — Unknown sink `type` field logs warning and does not fail config load (BC-3.01.002)
- [x] **AC-04** — `schema_version != 1` is a hard error at load time (BC-3.01.003)
- [x] **AC-05** — Events batched and POSTed as JSON array to configured URL
- [x] **AC-06** — HTTP error handling: retry on 5xx, drop on 4xx (VP-012)
- [x] **AC-07** — `flush()` sends current batch synchronously
- [x] **AC-08** — Integration test with mock HTTP server verifies batch delivery
- [x] **AC-09** — `HttpSink` struct exposed as public API for reuse by Datadog/Honeycomb sinks

---

## Test Evidence

| Metric | Value |
|--------|-------|
| Tests passing | **10 / 10** |
| `cargo fmt --check` | CLEAN |
| `cargo clippy -- -D warnings` | CLEAN |

| Test file | Tests | Result |
|-----------|-------|--------|
| `tests/contract_sink_trait.rs` | 2 | ok |
| `tests/contract_config_load.rs` | 3 | ok |
| `tests/error_handling.rs` | 2 | ok |
| `tests/integration_post_batch.rs` | 2 | ok |
| `tests/non_blocking.rs` | 1 | ok |

Full test output: `docs/demo-evidence/S-4.01/all-tests-summary.txt`

---

## Demo Evidence

Evidence captured at SHA `b0bb135` on `feat/S-4.01-sink-http-driver`.
Index: [`docs/demo-evidence/S-4.01/INDEX.md`](docs/demo-evidence/S-4.01/INDEX.md)

| AC | Evidence | Status |
|----|----------|--------|
| AC-01 | `docs/demo-evidence/S-4.01/AC-01-sink-trait.txt` | PASS |
| AC-02 | `docs/demo-evidence/S-4.01/AC-02-disabled-config.txt` | PASS |
| AC-03 | `docs/demo-evidence/S-4.01/AC-03-unknown-type-warns.txt` | PASS |
| AC-04 | `docs/demo-evidence/S-4.01/AC-04-schema-version-error.txt` | PASS |
| AC-05+08 | `docs/demo-evidence/S-4.01/AC-05-AC-08-batched-post-integration.txt` | PASS |
| AC-06 | `docs/demo-evidence/S-4.01/AC-06-error-handling.txt` | PASS |
| AC-07 | `docs/demo-evidence/S-4.01/AC-07-flush-sync.txt` | PASS |
| AC-09 | `docs/demo-evidence/S-4.01/AC-09-public-export.txt` | PASS |
| VP-011 | `docs/demo-evidence/S-4.01/VP-011-non-blocking-submit.txt` | PASS |

---

## Known Limitations / Technical Debt

The following items are **explicitly out of S-4.01 scope** and are being scoped as separate Wave 11 stories in a parallel product-owner burst:

- **TD-008 (retry backoff with jitter):** Current implementation retries on 5xx without delay. Exponential backoff with jitter is not in S-4.01's spec. Scoped as a new story in parallel.
- **TD-009 (`internal.sink_error` event emission):** Failures are recorded in `Mutex<Vec<SinkFailure>>` but not emitted as dispatcher events. This is a cross-sink concern scoped as a new story in parallel.

These are not regressions — they are new capabilities not yet contracted in BC/VP.

---

## Toolchain Note

This project is pinned to rustc 1.95 (`rust-toolchain.toml`). Doctests may show a mixed-compiler artifact on macOS if Homebrew cargo 1.94 is earlier on `PATH` than the rustup toolchain. This is a local env issue only — all spec tests, clippy, and fmt run cleanly under the pinned 1.95 toolchain. CI is unaffected.

---

## Downstream Unblock

Merging this PR unblocks 5 downstream stories that depend on `HttpSink` being available:
**S-4.02** (Datadog sink), **S-4.03** (Honeycomb sink), **S-4.04** (rate-limit), **S-4.07**, **S-4.08**

---

## Behavioral Contracts Anchored

| BC ID | Title |
|-------|-------|
| BC-3.01.001 | Empty SinkRegistry submit/flush/shutdown is no-op |
| BC-3.01.002 | Unknown sink type warns to stderr but does not fail config load |
| BC-3.01.003 | Sink schema_version != 1 is a hard error |
| BC-3.06.005 | sink_config_common_defaults_enabled_true |

## Verification Properties Anchored

| VP ID | Title | Method |
|-------|-------|--------|
| VP-011 | Sink submit Must Not Block the Dispatcher | unit-test |
| VP-012 | Sink Failure Affects Only That Sink | unit-test |
| VP-013 | Unknown Sink Driver Types Are Non-Fatal | unit-test |

---

## Pre-Merge Checklist

- [x] PR description matches diff
- [x] All 9 ACs covered by demo evidence
- [x] Traceability chain complete: BC → AC → Test → Demo
- [x] 10/10 tests passing, clippy clean, fmt clean
- [x] TD-008 and TD-009 acknowledged and deferred explicitly
- [x] Target branch: `develop` (not `main`)
- [x] Branch: `feat/S-4.01-sink-http-driver`
