### PR TITLE
feat(ci): add Semgrep SAST workflow + config

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,41 @@
+name: semgrep
+
+on:
+  pull_request:
+    branches: [develop, main]
+  push:
+    branches: [develop, main]
+  schedule:
+    - cron: '0 12 * * 1'  # Weekly Monday noon UTC for full repo scan
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  semgrep:
+    name: SAST (Semgrep)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    container:
+      image: returntocorp/semgrep
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run Semgrep SAST
+        # `semgrep ci` is the CI-aware command: on pull_request triggers it
+        # diffs only the changed files; on push/schedule it scans the full
+        # repo. Rule packs: security-audit (general), secrets (credential
+        # leakage), owasp-top-ten, cwe-top-25. All four languages in scope
+        # (Rust, Python, TypeScript, Go — per TD-006) are covered natively.
+        #
+        # Custom org rules will live in .semgrep.yml once TD-006 POLICY 11
+        # (tautology) and POLICY 12 (BC-TV consistency) are authored as
+        # executable Semgrep rules.
+        run: semgrep ci --config=auto
+        env:
+          SEMGREP_RULES: >-
+            p/security-audit
+            p/secrets
+            p/owasp-top-ten
+            p/cwe-top-25

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -1,0 +1,14 @@
+# .semgrep.yml — Semgrep configuration for vsdd-factory
+#
+# Default rule selection is in .github/workflows/semgrep.yml's
+# SEMGREP_RULES env var (p/security-audit, p/secrets, p/owasp-top-ten,
+# p/cwe-top-25). This file holds future custom organizational rules.
+#
+# TD-006 follow-up will register two policy rules here:
+#   POLICY 11 — tautology detection (Check 8)
+#   POLICY 12 — BC-TV consistency enforcement (Check 9)
+#
+# To add a custom rule, append to the `rules:` list below following
+# the Semgrep rule schema: https://semgrep.dev/docs/writing-rules/rule-syntax/
+
+rules: []

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,94 @@
+# Contributing to vsdd-factory
+
+## Development workflow
+
+### Prerequisites
+
+- Rust toolchain (see `rust-toolchain.toml` — currently 1.95.0)
+- `bats` (Bash test runner) for hook tests
+- `jq` and `yq` for JSON/YAML validation steps
+- `semgrep` for local security scanning (`pip install semgrep` or `brew install semgrep`)
+
+### Running tests locally
+
+```bash
+# Rust workspace
+cargo test --workspace --all-targets
+
+# Hook and bin tests
+bats plugins/vsdd-factory/tests/hooks.bats
+bats plugins/vsdd-factory/tests/bin.bats
+```
+
+### Branch model
+
+All feature work targets `develop`. PRs from `feature/STORY-NNN` branches are
+opened against `develop` and squash-merged after CI passes. Releases merge
+`develop` to `main` and tag from `main`.
+
+---
+
+## Security scanning
+
+Semgrep is the project's SAST (Static Application Security Testing) tool.
+It covers all four languages in the project footprint: Rust, Python,
+TypeScript, and Go (per TD-006 scoping).
+
+### When it runs
+
+- On every PR to `develop` or `main` (diff-scoped scan via `semgrep ci`)
+- On every push to `develop` or `main` (full scan)
+- Weekly on Monday at noon UTC (scheduled full-repo scan)
+
+Workflow definition: `.github/workflows/semgrep.yml`
+
+### Severity policy
+
+Findings at severity **ERROR** or **WARNING** block merge. Findings at
+INFO are advisory and do not gate.
+
+### Running locally
+
+```bash
+semgrep --config=auto .
+```
+
+Or to match the exact CI rule packs:
+
+```bash
+semgrep --config=p/security-audit \
+        --config=p/secrets \
+        --config=p/owasp-top-ten \
+        --config=p/cwe-top-25 \
+        .
+```
+
+### Triaging a finding
+
+Three options, in preference order:
+
+1. **Remediate** — fix the underlying issue (preferred).
+2. **Suppress inline** — add a `# nosemgrep: <rule-id>` comment on the
+   offending line with a justification comment above it explaining why the
+   finding is a false positive.
+3. **Override in `.semgrep.yml`** — add a `paths.exclude` or rule-level
+   `filter` for systematic false-positive patterns. Document the rationale
+   in a comment.
+
+### Custom rules
+
+Custom organizational rules live in `.semgrep.yml` (currently a stub).
+TD-006 follow-up will register two policy rules:
+
+- **POLICY 11** — tautology detection (Check 8 of the TD-006 adversarial
+  review checklist): flags spec assertions that are vacuously true.
+- **POLICY 12** — BC-TV consistency enforcement (Check 9): flags
+  test-vector mismatches against behavioral contracts.
+
+To add a rule, append to the `rules:` list in `.semgrep.yml` following
+the Semgrep rule schema at https://semgrep.dev/docs/writing-rules/rule-syntax/
+
+### Baseline
+
+Initial adoption scan (Semgrep 1.156.0, 2026-04-27): **0 findings** across
+308 files, 320 rules, covering Python + TypeScript + multilang rule packs.


### PR DESCRIPTION
## Why Semgrep

Security mandates SAST coverage before the v1.0.0-rc.1 release gate (S-4.08). Semgrep was selected because it handles all four languages in scope — Rust, Python, TypeScript, and Go (per TD-006 scoping) — out-of-the-box with no per-language plugin configuration. It integrates cleanly with GitHub Actions via `semgrep ci` (diff-scoped on PRs, full scan on push/schedule) and aligns with VSDD Phase 5 adversarial implementation review.

## What's added (3 files)

| File | Purpose |
|------|---------|
| `.github/workflows/semgrep.yml` | CI workflow — PR, push, weekly schedule triggers |
| `.semgrep.yml` | Stub config for future custom rules (TD-006 follow-up) |
| `CONTRIBUTING.md` | Security Scanning section: local dev instructions, triage path, custom rule registration |

## Rule pack selection

- `p/security-audit` — broad security pattern coverage across all languages
- `p/secrets` — credential and API key leakage detection
- `p/owasp-top-ten` — OWASP Top 10 vulnerability patterns
- `p/cwe-top-25` — CWE Top 25 most dangerous software weaknesses

All four packs are free Semgrep Registry packs; no login or token required for CI.

## Local smoke test

Run: Semgrep 1.156.0, 2026-04-27, `--config=p/security-audit --config=p/secrets --config=p/owasp-top-ten --config=p/cwe-top-25`
Result: **0 findings** across 308 files, 320 rules, covering Python + TypeScript + multilang packs. Clean baseline — no triage backlog on adoption.

## Triage path (for future findings)

1. Remediate the underlying issue (preferred).
2. `# nosemgrep: <rule-id>` inline suppression with a justification comment.
3. Rule override in `.semgrep.yml` for systematic false positives.

## Future expansion

TD-006 follow-up will register two custom Semgrep rules in `.semgrep.yml`:
- **POLICY 11** — tautology detection (Check 8 of TD-006 adversarial checklist)
- **POLICY 12** — BC-TV consistency enforcement (Check 9)

These will be authored as part of the executable-runner story in the TD-006 scope.