### PR TITLE
chore: delete stale loads_legacy_registry tests (post-migration cleanup)

### DIFF
--- a/crates/factory-dispatcher/tests/loads_legacy_registry.rs
+++ b/crates/factory-dispatcher/tests/loads_legacy_registry.rs
@@ -1,16 +1,18 @@
-//! Validates that the auto-generated `plugins/vsdd-factory/hooks-registry.toml`
-//! parses cleanly through the production `Registry::load` codepath. The
-//! registry is produced by `scripts/generate-registry-from-hooks-json.sh`
-//! (S-2.2); this test is the schema-side gate that the generator
-//! output is structurally sound.
+//! Validates that `plugins/vsdd-factory/hooks-registry.toml` parses cleanly
+//! through the production `Registry::load` codepath.
+//!
+//! The registry is now a permanent, human-edited file that contains both
+//! native WASM hook entries (capture-commit-activity, capture-pr-activity,
+//! block-ai-attribution — ported in S-3.01/S-3.02/S-3.03) and legacy-bash-
+//! adapter entries for hooks that have not yet been ported. The v0.79.x →
+//! v1.0 migration that required all entries to route through the bash adapter
+//! is complete; the generator script is retired.
 //!
 //! What this test does NOT cover (deliberate scope cut):
-//!   * Whether each entry's `script_path` resolves to an extant `.sh` —
-//!     the bats suite at `plugins/vsdd-factory/tests/generate-registry.bats`
-//!     owns that check, since it's a filesystem invariant tied to the
-//!     plugin layout, not the registry schema.
-//!   * Whether the legacy-bash-adapter actually runs the script — that's
-//!     the adapter's own integration suite (S-2.1).
+//!   * Whether each bash-adapter entry's `script_path` resolves to an extant
+//!     `.sh` — the bats suite at `plugins/vsdd-factory/tests/` owns that.
+//!   * Whether the legacy-bash-adapter actually runs the script — that's the
+//!     adapter's own integration suite (S-2.1).
 
 use factory_dispatcher::registry::{REGISTRY_SCHEMA_VERSION, Registry};
 use std::path::PathBuf;
@@ -55,51 +57,4 @@ fn loads_generated_registry_from_disk() {
          generator for a duplicated emit",
         registry.hooks.len()
     );
-}
-
-#[test]
-fn every_entry_routes_through_legacy_bash_adapter() {
-    let registry = Registry::load(&registry_path()).unwrap();
-    for entry in &registry.hooks {
-        let plugin = entry
-            .plugin
-            .file_name()
-            .and_then(|s| s.to_str())
-            .unwrap_or("");
-        assert_eq!(
-            plugin, "legacy-bash-adapter.wasm",
-            "entry {:?} routes through {} — every v0.79.x hook should \
-             go through the bash adapter at this point in the migration",
-            entry.name, plugin
-        );
-    }
-}
-
-#[test]
-fn every_entry_carries_a_script_path() {
-    // legacy-bash-adapter (S-2.1) demands `plugin_config.script_path`;
-    // the generator must emit it for every entry or the adapter will
-    // refuse the payload at runtime. Catch that at registry-load time
-    // rather than waiting for the first hook fire.
-    let registry = Registry::load(&registry_path()).unwrap();
-    for entry in &registry.hooks {
-        let cfg_json = entry.config_as_json();
-        let script_path = cfg_json
-            .get("script_path")
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
-        assert!(
-            !script_path.is_empty(),
-            "entry {:?} has empty config.script_path — \
-             legacy-bash-adapter will refuse this entry",
-            entry.name
-        );
-        assert!(
-            script_path.starts_with("hooks/") && script_path.ends_with(".sh"),
-            "entry {:?} script_path={:?} should be `hooks/<name>.sh` \
-             (relative to ${{CLAUDE_PLUGIN_ROOT}})",
-            entry.name,
-            script_path
-        );
-    }
 }


### PR DESCRIPTION
## Summary
- Deletes 2 stale tests that encoded a transitional v0.79.x→v1.0 migration invariant
- Tests assumed all hooks route through `legacy-bash-adapter.wasm`, which is no longer true post-S-3.01/S-3.02/S-3.03 native ports
- Workspace now passes on the removed tests; the one surviving test (`loads_generated_registry_from_disk`) continues to pass

## Background
The deleted tests asserted:
1. `every_entry_routes_through_legacy_bash_adapter` — every hook in `hooks-registry.toml` must point to `legacy-bash-adapter.wasm`
2. `every_entry_carries_a_script_path` — every entry must have `[hooks.config]` with a `script_path` for the bash adapter

These invariants were correct during the migration period (v0.79.x). They are no longer correct — native WASM hooks (S-3.01 capture-commit-activity, S-3.02 capture-pr-activity, S-3.03 block-ai-attribution) intentionally bypass the bash adapter and route directly to their own compiled WASM plugins.

The third test in the file (`loads_generated_registry_from_disk`) remains valid and is kept — it verifies the file parses cleanly and has a sane entry count.

The module docstring has been updated to reflect that the registry is now a permanent human-edited file containing both native WASM and legacy-bash-adapter entries, and that the generator script is retired.

## Why now
These failures have been carried as "pre-existing, unrelated" through Wave 12 PRs (#29, #30, #31, #32). With Wave 12 now closed and the frontier empty, this is the natural time to clean up.

Note: `sinks_file_integration::registry_fans_events_to_file_sinks_with_filter_and_tags` is a separate pre-existing failure on `develop` and is not in scope for this PR.

## Test plan
- [x] cargo test --workspace: `loads_legacy_registry` module now shows 1 passed; 0 failed (was 1 passed; 2 failed)
- [x] cargo build --workspace --all-features clean
- [x] cargo clippy clean
- [x] `loads_generated_registry_from_disk` (the still-valid test) continues to pass