### PR TITLE
fix(test): sinks_file_integration uses splunk instead of datadog (S-4.07 drift)

### DIFF
--- a/crates/factory-dispatcher/tests/sinks_file_integration.rs
+++ b/crates/factory-dispatcher/tests/sinks_file_integration.rs
@@ -53,9 +53,8 @@ path_template = "{audit}"
 routing_filter = {{ event_types_deny = ["internal.sink_error", "plugin.timeout"] }}
 
 [[sinks]]
-type = "datadog"
-name = "dd-prod"
-api_key = "stub"
+type = "splunk"
+name = "splunk-prod"
 "#,
         local = local_path.display().to_string().replace('\\', "/"),
         audit = audit_path.display().to_string().replace('\\', "/"),
@@ -74,7 +73,7 @@ fn registry_fans_events_to_file_sinks_with_filter_and_tags() {
     assert_eq!(
         registry.sinks().len(),
         2,
-        "expected 2 file sinks (datadog should be skipped)"
+        "expected 2 file sinks (splunk is unknown — should be skipped per from_config warn-and-skip; datadog/honeycomb were promoted to known types in S-4.07)"
     );
 
     let router = Router::new(registry);


### PR DESCRIPTION
## Summary
- Fixes a drift regression introduced by **S-4.07 (PR #31)** that promoted `datadog`/`honeycomb` to known sink types in `SinkRegistry::from_config`
- Existing test `registry_fans_events_to_file_sinks_with_filter_and_tags` at `sinks_file_integration.rs:69` used `type = "datadog"` as its "unknown sink type that should be skipped" fixture
- Post-S-4.07, datadog is no longer skipped — test fails with `left: 3, right: 2`
- Same drift pattern S-4.07 fixed for the sibling unit test `load_warns_on_unknown_sink_type_but_still_succeeds`; this is sibling-fix completion

## Fix
- Swap fixture stanza type `"datadog"` → `"splunk"` (truly unknown post-S-4.07)
- Update assertion message to clarify rationale

## Test plan
- [x] `cargo test --test sinks_file_integration registry_fans_events_to_file_sinks_with_filter_and_tags` — PASS
- [x] No production code changes
- [x] No other test affected

## Why now
This test failure was hidden in the "pre-existing failures" bucket of Wave 12 PRs. After Wave 12 closure, code-reviewer triage identified it as a real S-4.07 drift regression rather than a pre-existing failure. Fixed in this small PR to bring develop fully green.
