### PR TITLE
[W-15-gate-3] docs: HOST_ABI.md alignment before rc.3

### DIFF
--- a/crates/hook-plugins/update-wave-state-on-merge/src/lib.rs
+++ b/crates/hook-plugins/update-wave-state-on-merge/src/lib.rs
@@ -1217,10 +1217,7 @@ waves:
             tool_name: String::new(),
             session_id: "s".to_string(),
             dispatcher_trace_id: "t".to_string(),
-            tool_input: json!({
-                "agent_type": "pr-manager",
-                "result": "STEP_COMPLETE: step=8 status=ok — no story id here",
-            }),
+            tool_input: serde_json::Value::Null,
             tool_response: None,
             plugin_config: serde_json::Value::Null,
             agent_type: Some("pr-manager".to_string()),

--- a/crates/hook-sdk/HOST_ABI.md
+++ b/crates/hook-sdk/HOST_ABI.md
@@ -156,13 +156,14 @@ The dispatcher checks for this line BEFORE returning to the parent agent. If
 `outcome=block`, the dispatcher exits with a non-zero status and propagates the
 reason.
 
-The `on_error` field in `hooks-registry.toml` controls **crash** behavior only:
-
-- `on_error = "continue"` (default): plugin crashes are non-fatal; execution
-  proceeds.
-- `on_error = "block"` reserved for future first-class hard-block at the
-  dispatcher boundary; current implementation treats this identically to
-  "continue" because plugins use the stdout outcome line for advisory blocks.
+The `on_error` field in `hooks-registry.toml` controls how the dispatcher reacts
+to a plugin that *crashes* (returns a non-zero exit code, panics, or otherwise
+fails). The advisory-block mechanism is independent of `on_error` — any plugin
+that writes `{"outcome":"block","reason":"..."}` to stdout records a
+dispatcher-level block intent regardless of `on_error`. As of v1.0,
+`on_error="block"` and `on_error="continue"` produce identical behavior for
+block_intent aggregation; the field is preserved for forward-compatibility with
+potential future crash-to-block escalation policies (W-16+).
 
 The SDK's `HookResult::Block(reason)` variant is reserved for future hard-block
 semantics (planned W-16 / v1.1). All v1.0 plugins use `HookResult::Continue` +
@@ -170,12 +171,16 @@ stdout outcome line.
 
 **Affected plugins (canonical v1.0 advisory-block-mode users):**
 
-- `handoff-validator` — emits `hook.block` event + returns `HookResult::Continue`
+- `handoff-validator` — emits `hook.block` event + writes
+  `{"outcome":"block","reason":"handoff_empty_result"}` (empty path) or
+  `{"outcome":"block","reason":"handoff_truncated_result"}` (truncated path) to
+  stdout + returns `HookResult::Continue`
 - `pr-manager-completion-guard` — emits `hook.block` event + writes
   `{"outcome":"block","reason":"pr_manager_incomplete_lifecycle"}` to stdout +
   returns `HookResult::Continue`
-- `validate-pr-review-posted` — emits `hook.block` event + returns
-  `HookResult::Continue`
+- `validate-pr-review-posted` — emits `hook.block` event + writes
+  `{"outcome":"block","reason":"pr_review_invalid"}` to stdout when any
+  pre-merge check fails + returns `HookResult::Continue`
 
 **Decision record:** D-W15-gate-003 — W-15 gate fix: canonical advisory-block-mode
 pattern chosen (stdout emit, not HookResult::Block); HookResult::Block SDK


### PR DESCRIPTION
## Summary

Tiny docs-only PR closing residual HOST_ABI.md drift surfaced during the W-15 wave-gate re-run #2 (against develop @ c4dc842). With this merged, the wave gate is fully CONVERGED and `v1.0.0-rc.3` is clear to cut.

## Findings addressed

- **NEW-CONS-001 (Major):** `crates/hook-sdk/HOST_ABI.md:171-178` enumerated the three canonical advisory-block plugins but only described stdout `outcome:block` emission for `pr-manager-completion-guard`. After PR #60 added stdout writes to `handoff-validator` (empty + truncated paths) and `validate-pr-review-posted` (any failed pre-merge check), the bullet table was stale. Both bullets now describe the exact reason strings emitted.
- **NEW-CONS-002 (Minor):** `crates/hook-sdk/HOST_ABI.md:159-165` explained `on_error="block"` as "reserved for future first-class hard-block ... treats this identically to continue because plugins use the stdout outcome line." This was misleading after PR #60 — `executor.rs` does not consult `on_error` AT ALL when computing `block_intent`. Paragraph rewritten to mirror `executor.rs:14-19` module-doc-comment language: advisory-block via stdout is independent of `on_error`; `on_error` governs only crash semantics.
- **Dead fixture cleanup:** `crates/hook-plugins/update-wave-state-on-merge/src/lib.rs:~1220` legacy EC-002 test fixture still populated `tool_input` with `agent_type` + `result` keys alongside the canonical typed top-level fields. The implementation hasn't read `tool_input` since PR #60 (CRIT-CONS-001 fix). Set to `serde_json::Value::Null` to match production semantics and avoid misleading future maintainers.

## Verification

- `cargo test -p update-wave-state-on-merge --features standalone`: 45/45 passed
- `cargo test --workspace`: clean
- No code paths changed; behavior unchanged

## Source

- Wave-gate re-run #2 (post PR #60): adversary verdict CONVERGED with non-blocking advisory; consistency-validator verdict FINDINGS (doc-only). Both explicitly described as "no code defect — executor and all three plugins behaviorally consistent."

## Test plan

- [x] HOST_ABI.md handoff-validator + validate-pr-review-posted bullets match plugin code
- [x] HOST_ABI.md `on_error` paragraph matches executor.rs module doc-comment
- [x] update-wave-state-on-merge EC-002 fixture mirrors production (tool_input=null)
- [x] 45/45 plugin tests pass
- [ ] CI green
- [ ] Post-merge: cut v1.0.0-rc.3 from develop

## Out of scope (deferred to backlog)

- LOW-1 (adversary): end-to-end integration test against `execute_tiers` (helper-only test in PR #60 already prove the fix; structural lock for future)
- TD-013 (main branch protection bot bypass)
- TD-014 (Tier 2/3 adapter retirement)
- HookResult::Block SDK first-class hard-block (W-16)
- WASI preopen tightening to read-only (v1.1)