### PR TITLE
[hotfix] remove deleted bats files from run-all.sh (rc.3 release fix #2)

### DIFF
--- a/plugins/vsdd-factory/tests/run-all.sh
+++ b/plugins/vsdd-factory/tests/run-all.sh
@@ -94,10 +94,6 @@ echo "== Workflow validators emission tests =="
 bats tests/workflow-validators-emission.bats
 
 echo
-echo "== SubagentStop/Stop hooks emission tests =="
-bats tests/stop-hooks-emission.bats
-
-echo
 echo "== factory-query CLI tests =="
 bats tests/factory-query.bats
 
@@ -116,10 +112,6 @@ bats tests/factory-obs.bats
 echo
 echo "== factory-replay (session replay) tests =="
 bats tests/factory-replay.bats
-
-echo
-echo "== Agent tracking hooks (track-agent-start/stop) tests =="
-bats tests/agent-tracking.bats
 
 echo
 echo "== factory-sla (agent SLO) tests =="


### PR DESCRIPTION
Removes `stop-hooks-emission.bats` and `agent-tracking.bats` invocations from `run-all.sh`. PR #63 deleted these files (W-15 native WASM ports retired the bash hooks they tested) but `run-all.sh` retained the hardcoded list, causing release.yml workflow #3 to fail Pre-release Validation when bats hit "Test file does not exist". This is the second rc.3 hotfix; after merge, re-tag v1.0.0-rc.3 from new main HEAD.