### PR TITLE
hotfix: release.yml — drop job-level secrets context (unblocks v1.0.0-rc.7)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -495,9 +495,30 @@ jobs:
     name: Bump claude-mp marketplace version
     needs: release
     runs-on: ubuntu-latest
-    if: ${{ secrets.CLAUDE_MP_PAT != '' }}
     steps:
+      # GitHub Actions does NOT expose the `secrets` context in
+      # job-level `if:` conditions (only in step-level `if:`). So instead
+      # of `jobs.bump-marketplace.if: ${{ secrets.CLAUDE_MP_PAT != '' }}`,
+      # we gate every subsequent step on a flag set by this preflight
+      # step. When the secret is missing, the job runs but no work
+      # happens — same effective behavior as a job-level skip.
+      - name: Preflight — check CLAUDE_MP_PAT secret
+        id: preflight
+        env:
+          PAT: ${{ secrets.CLAUDE_MP_PAT }}
+        run: |
+          if [ -z "$PAT" ]; then
+            echo "CLAUDE_MP_PAT secret is not configured. Skipping marketplace bump."
+            echo "To enable: create a PAT with contents:write + pull-requests:write"
+            echo "scopes on drbothen/claude-mp and add it as CLAUDE_MP_PAT in this"
+            echo "repo's Actions secrets."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Check out claude-mp
+        if: steps.preflight.outputs.configured == 'true'
         uses: actions/checkout@v6
         with:
           repository: drbothen/claude-mp
@@ -505,6 +526,7 @@ jobs:
           ref: main
 
       - name: Bump vsdd-factory version in marketplace.json
+        if: steps.preflight.outputs.configured == 'true'
         run: |
           set -e
           version="${GITHUB_REF_NAME#v}"
@@ -517,6 +539,7 @@ jobs:
           echo "Bumped vsdd-factory to $version in claude-mp marketplace.json"
 
       - name: Open PR
+        if: steps.preflight.outputs.configured == 'true'
         env:
           GH_TOKEN: ${{ secrets.CLAUDE_MP_PAT }}
         run: |


### PR DESCRIPTION
## Summary

Fixes the workflow-file-level error that caused EVERY release.yml run since commit \`c706df6\` to fail before any job started. The v1.0.0-rc.7 tag push currently has 0 successful jobs because of this.

### Root cause

GitHub Actions does NOT support the \`secrets\` context in job-level \`if:\` conditions. The \`bump-marketplace\` job used:

\`\`\`yaml
if: \${{ secrets.CLAUDE_MP_PAT != '' }}
\`\`\`

at job level, which makes the workflow file invalid. Every run since shows \"This run likely failed because of a workflow file issue\" with empty jobs array.

### Fix

Same effective behavior (skip work when secret absent) but moved into a step-level preflight that emits a \`configured=true|false\` output. Subsequent steps gate on \`steps.preflight.outputs.configured == 'true'\`.

### Recovery

After this merges to main:
1. Delete the broken v1.0.0-rc.7 tag (local + remote)
2. Recreate v1.0.0-rc.7 pointing at main HEAD (which has the fix)
3. Push new tag → release.yml fires correctly this time

### Verification

- YAML still parses (\`python3 -c \"import yaml; yaml.safe_load(open(...))\"\`)
- Step-level preflight pattern matches GitHub Actions' documented contract for skip-if-secret-absent
- Once merged, the next release tag will fire bump-marketplace correctly when CLAUDE_MP_PAT is set