### PR TITLE
hotfix #2: re-track hooks.json (unblock v1.0.0-rc.7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,10 +26,24 @@ __pycache__/
 *.pyc
 
 # v1.0 activation skill copies the right hooks.json.<platform> variant
-# into hooks.json after install — that copy is per-machine and must not
-# be committed. The 5 hooks.json.<platform> files (CI-generated from
-# hooks.json.template by scripts/generate-hooks-json.sh) ARE committed.
+# into hooks.json after install — that copy is per-machine. Per S-0.4
+# the file is gitignored so future runtime overwrites don't get
+# accidentally committed. Despite the gitignore entry, the seed
+# version of hooks.json IS tracked in this repo because:
+#   - 11 bats test suites assert against it (asserting wired hooks)
+#   - BC-9.01.005 Rust test asserts the gitignore entry exists
+# Git's rule: a tracked file stays tracked even when it later matches
+# a gitignore pattern. So both contracts hold simultaneously: the
+# seed hooks.json ships with the repo, runtime overwrites by the
+# activation skill won't accidentally land in commits, and both test
+# layers stay green. Migration to assert against hooks-registry.toml
+# (the new source of truth) is tracked as a follow-up; once that
+# lands, the seed file can be untracked and the gitignore entry will
+# do the real work alone.
 plugins/vsdd-factory/hooks/hooks.json
+
+# The 5 hooks.json.<platform> files (CI-generated from
+# hooks.json.template by scripts/generate-hooks-json.sh) ARE committed.
 
 # WASM plugin binaries the dispatcher loads at runtime. Built from the
 # Rust workspace per release; staged here for local smoke tests. The

--- a/plugins/vsdd-factory/hooks/hooks.json
+++ b/plugins/vsdd-factory/hooks/hooks.json
@@ -1,0 +1,80 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/brownfield-discipline.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/protect-vp.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/protect-bc.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/red-gate.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/factory-branch-guard.sh", "timeout": 5 }
+        ]
+      },
+      {
+        "matcher": "Agent",
+        "hooks": [
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-wave-gate-prerequisite.sh", "timeout": 10 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-pr-merge-prerequisites.sh", "timeout": 10 }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/destructive-command-guard.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/protect-secrets.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/verify-git-push.sh", "timeout": 10 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/check-factory-commit.sh", "timeout": 5 }
+        ]
+      },
+      {
+        "matcher": "Read",
+        "hooks": [
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/protect-secrets.sh", "timeout": 5 }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/purity-check.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-vp-consistency.sh", "timeout": 10 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-subsystem-names.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-bc-title.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-story-bc-sync.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-template-compliance.sh", "timeout": 10 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-finding-format.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-input-hash.sh", "timeout": 10 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-state-size.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-novelty-assessment.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/convergence-tracker.sh", "timeout": 10 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-table-cell-count.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-changelog-monotonicity.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-state-pin-freshness.sh", "timeout": 10 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-index-self-reference.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-state-index-status-coherence.sh", "timeout": 10 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-anchor-capabilities-union.sh", "timeout": 10 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-demo-evidence-story-scoped.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-pr-description-completeness.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-wave-gate-completeness.sh", "timeout": 10 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-factory-path-root.sh", "timeout": 5 }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/dispatcher/bin/${PLATFORM}/factory-dispatcher", "timeout": 10000, "async": true }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/dispatcher/bin/${PLATFORM}/factory-dispatcher", "timeout": 10000, "async": true }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Second hotfix needed to ship v1.0.0-rc.7. The first hotfix (#74) fixed a workflow-file syntax error in release.yml. After that landed and the v1.0.0-rc.7 tag was force-recreated, the **validate** job started running successfully — and immediately failed because the bats suite expects \`plugins/vsdd-factory/hooks/hooks.json\` to exist (PR #72 untracked it).

### Failure

11 bats test suites assert against \`hooks.json\`:

\`\`\`
not ok 17 convergence-tracker: hooks.json wires convergence-tracker
not ok 42 corpus-lint: hooks.json wires validate-table-cell-count
... (11 suites total)

# jq: error: Could not open file plugins/vsdd-factory/hooks/hooks.json: No such file or directory
\`\`\`

### Fix

Re-tracks \`hooks.json\` with the working pre-untrack content, but with the 3 stale .sh references replaced by the canonical dispatcher pattern:

| Hook | Was | Now |
|---|---|---|
| Stop / session-learning | session-learning.sh (deleted in S-8.06) | factory-dispatcher |
| SubagentStop / handoff-validator | handoff-validator.sh (deleted in S-8.01) | factory-dispatcher |
| SubagentStop / track-agent-stop | track-agent-stop.sh (deleted in S-8.03) | factory-dispatcher |

Updated \`.gitignore\` comment to explain why \`hooks.json\` is tracked again (was gitignored per S-0.4; now tracked because tests assume it). Tracked as follow-up to migrate the 11 test suites to assert against \`hooks-registry.toml\` (the actual source of truth) so \`hooks.json\` can return to gitignored status per original S-0.4 design.

### Recovery for v1.0.0-rc.7

1. Merge this hotfix to main
2. Force-recreate v1.0.0-rc.7 tag (currently points at the broken commit before this hotfix)
3. New tag push triggers release.yml correctly with all tests passing

### Note

The v1.0.0-rc.7 tag has now been force-recreated TWICE in this release cycle:
- First time: after PR #74 fixed the release.yml workflow syntax error
- Second time (after this PR): with the bats suite passing