### PR TITLE
release: v1.0.0-rc.9 — PowerShell siblings for activate-skill helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,99 @@
 # Changelog
 
+## 1.0.0-rc.9 — PowerShell siblings for activate-skill helpers (2026-05-04)
+
+Release candidate 9 closes the activate-skill platform-coverage gap that
+opened in Claude Code v2.1.84+ on native Windows hosts without Git for
+Windows installed (where Claude Code falls back to PowerShell and cannot
+execute the bash `detect-platform.sh` / `apply-platform.sh` helpers).
+
+Beyond the PowerShell sibling work, two adjacent threads landed:
+- a regression-v1.0 test was rewritten to use a still-adapter-routed
+  bash hook (`purity-check.sh`) instead of the WASM-migrated
+  `capture-commit-activity` (the original test premise was invalidated
+  by commit 818fb95)
+- a research investigation surfaced a separate, larger telemetry-pipeline
+  issue (WASM `host::emit_event` routes events to
+  `dispatcher-internal-*.jsonl` instead of `events-*.jsonl`, silently
+  losing every WASM-emitted event from every downstream consumer). That
+  work is captured by ADR-015 and the new E-TELEMETRY epic — NOT shipped
+  in rc.9.
+
+### Added
+
+- **`plugins/vsdd-factory/skills/activate/detect-platform.ps1`** — PowerShell
+  sibling of `detect-platform.sh`. Identical JSON contract, exit codes
+  (0/1/2), and `MOCK_UNAME_S`/`MOCK_UNAME_M` test-override envvars.
+  Implements case-sensitive platform mapping via explicit if/elseif chains
+  (PowerShell `switch` is case-insensitive by default and runs all matching
+  arms — bash `case` is first-match-wins). Hand-built JSON output for
+  byte-identical parity with the bash sibling's `jq` output. Honors
+  `Set-StrictMode -Version Latest` for `-u`-equivalent strictness.
+- **`plugins/vsdd-factory/skills/activate/apply-platform.ps1`** — PowerShell
+  sibling of `apply-platform.sh`. Identical exit codes (0/1/2/3/4), `-Check`
+  verify-only mode, `VSDD_PLUGIN_ROOT_OVERRIDE` test override, diagnostic
+  strings. Accepts both PowerShell-style flags (`-Check`, `-Help`) and
+  bash-style aliases (`--check`, `--help`, `-h`) so cross-shell muscle
+  memory does not produce exit-4 surprises. Guards `$PSScriptRoot` empty-
+  state (when invoked via `pwsh -Command`). Narrows the UnixFileMode
+  exception handling to `PlatformNotSupportedException` so genuine I/O
+  errors surface instead of silently downgrading exit-3.
+
+### Changed
+
+- **`plugins/vsdd-factory/skills/activate/SKILL.md`** — steps 2 and 6 now
+  dispatch to the right helper (`.sh` vs `.ps1`) based on active shell.
+  JSON output and exit codes are byte-for-byte identical between the two
+  implementations; only invocation syntax differs by host shell convention.
+  Notes section explicitly documents flag-syntax conventions and the
+  TD-019 deferral for full Pester test parity.
+
+### Fixed
+
+- **`plugins/vsdd-factory/tests/regression-v1.0.bats` test 9** ("bash-side
+  events land in events-*.jsonl when routed through the adapter") —
+  rewritten to use `purity-check.sh` (a bash hook still routed through
+  legacy-bash-adapter on `PostToolUse/Edit|Write`) instead of
+  `capture-commit-activity` (which migrated to native WASM in commit
+  818fb95 and no longer goes through the adapter). Test now correctly
+  pins the bash-via-adapter path's contract that side-effecting bash
+  hooks land their events in `events-*.jsonl`. The WASM-side gap (events
+  landing in `dispatcher-internal-*.jsonl` instead) is captured by
+  ADR-015 and the E-TELEMETRY epic.
+
+### Tech debt logged
+
+- **TD-019 (P2, v1.1)** — Pester test suite + Rust consolidation of
+  `apply-platform.{sh,ps1}` into a `factory-dispatcher activate
+  --platform <p>` subcommand
+- **TD-019a (P2, v1.0.1)** — Lightweight `pwsh` syntactic-validation
+  CI gate as the v1.0-cycle stopgap before the full TD-019(a) Pester
+  suite lands
+- **LESSON-2026-05-04-001 [process-gap]** — Story marked "shipped"
+  without AC verification (S-3.04 AC-001 false-shipped); follow-up via
+  S-7.04
+- **LESSON-2026-05-04-002 [process-gap]** — Dashboards query fields no
+  plugin emits (`pr.opened` vs `pr.created`; `open_to_merge_seconds`
+  never emitted); follow-up via S-7.05
+- **TD-007 amendment** — original "S-3.04 AC-003 deferred" claim
+  amended; AC-001 was actually never wired (Router::submit absent from
+  main.rs since April 24, 2026); E-TELEMETRY epic addresses it via
+  ADR-015 and a new wave of stories
+
+### Not shipped (deferred to E-TELEMETRY epic)
+
+- WASM `host::emit_event` routing fix (currently lands events in
+  `dispatcher-internal-*.jsonl`; should land in `events-*.jsonl`)
+- Per-project / per-worktree / per-instance event-attribute drill-down
+- OTel-aligned schema with full Resource attributes
+- `pr.opened`/`pr.created` reconciliation
+- `plugin_version` correctness fix (currently always equals dispatcher
+  version, not the plugin's actual version)
+- Full bash↔WASM emit_event field parity
+
+These are tracked under ADR-015 and decomposed into stories under the
+new E-TELEMETRY epic. Adversarial review of ADR-015 is in flight.
+
 ## 1.0.0-rc.8 — Hooks-test migration to hooks-registry.toml (2026-05-04)
 
 Release candidate 8 finishes the S-0.4 hooks.json untracking properly.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Verified Spec-Driven Development (VSDD) -- a dark factory for software, packaged as a Claude Code plugin.**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/version-0.47.0-green.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.0.0--rc.9-green.svg)](CHANGELOG.md)
 
 ---
 

--- a/plugins/vsdd-factory/.claude-plugin/plugin.json
+++ b/plugins/vsdd-factory/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vsdd-factory",
   "description": "Verified Spec-Driven Development (VSDD) dark factory for software — full SDLC pipeline: brownfield ingest, spec crystallization, story decomposition, TDD delivery, adversarial review, holdout evaluation, formal verification, and release gating.",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "author": {
     "name": "drbothen"
   },

--- a/plugins/vsdd-factory/skills/activate/SKILL.md
+++ b/plugins/vsdd-factory/skills/activate/SKILL.md
@@ -12,7 +12,12 @@ Per-project opt-in. Enabling the plugin alone does not change your default Claud
 
 1. **Confirm the user is inside a project that wants VSDD.** Check for `.factory/` and `.factory/STATE.md`. If missing, ask whether to continue anyway (you can activate before initializing).
 
-2. **Detect the host platform.** Run `${CLAUDE_PLUGIN_ROOT}/skills/activate/detect-platform.sh` and capture its JSON output.
+2. **Detect the host platform.** Run the detector matching your active shell:
+
+   - **bash / sh / zsh / Git Bash / WSL** (macOS, Linux, Windows-with-Git-Bash): run `${CLAUDE_PLUGIN_ROOT}/skills/activate/detect-platform.sh`
+   - **PowerShell** (native Windows without Git Bash, Claude Code v2.1.84+): run `${CLAUDE_PLUGIN_ROOT}/skills/activate/detect-platform.ps1`
+
+   Both produce identical JSON output and use identical exit codes. Capture stdout.
 
    - On `exit 0`, the helper returns one of the 5 canonical platform strings the v1.0 dispatcher binaries are built for: `darwin-arm64`, `darwin-x64`, `linux-x64`, `linux-arm64`, `windows-x64`.
    - On `exit 1`, the platform is unsupported (e.g., FreeBSD, 32-bit). Print the helper's `detected_from.raw_uname` and tell the user vsdd-factory v1.0 has no dispatcher binary for that host. Do not proceed; activation aborts.
@@ -40,11 +45,16 @@ Per-project opt-in. Enabling the plugin alone does not change your default Claud
 
    Preserve all other top-level keys.
 
-6. **Apply the per-platform variant + verify the dispatcher binary.** Run `${CLAUDE_PLUGIN_ROOT}/skills/activate/apply-platform.sh <platform>`. This:
-   - Copies `${CLAUDE_PLUGIN_ROOT}/hooks/hooks.json.<platform>` to `${CLAUDE_PLUGIN_ROOT}/hooks/hooks.json` (the canonical file is gitignored per S-0.4 — it's per-machine).
-   - Verifies the dispatcher binary at `${CLAUDE_PLUGIN_ROOT}/hooks/dispatcher/bin/<platform>/factory-dispatcher[.exe]` is present and executable.
+6. **Apply the per-platform variant + verify the dispatcher binary.** Run the applier matching your active shell:
 
-   Exit codes: `0` success; `1` variant missing (corrupted install); `2` binary missing (release didn't commit it for this platform yet); `3` binary not executable; `4` usage error. Surface the helper's stderr to the user verbatim — it includes restoration instructions for the binary-missing case (pin to 0.79.4 or build locally) which the user needs to act on.
+   - **bash / sh / zsh / Git Bash / WSL**: `${CLAUDE_PLUGIN_ROOT}/skills/activate/apply-platform.sh <platform>`
+   - **PowerShell**: `${CLAUDE_PLUGIN_ROOT}/skills/activate/apply-platform.ps1 <platform>`
+
+   Both implementations share the same exit-code contract and diagnostic messages. Either one:
+   - Copies `${CLAUDE_PLUGIN_ROOT}/hooks/hooks.json.<platform>` to `${CLAUDE_PLUGIN_ROOT}/hooks/hooks.json` (the canonical file is gitignored per S-0.4 — it's per-machine).
+   - Verifies the dispatcher binary at `${CLAUDE_PLUGIN_ROOT}/hooks/dispatcher/bin/<platform>/factory-dispatcher[.exe]` is present and (on Unix) executable.
+
+   Exit codes: `0` success; `1` variant missing (corrupted install); `2` binary missing (release didn't commit it for this platform yet); `3` binary not executable (Unix only — Windows has no executable bit); `4` usage error. Surface the helper's stderr to the user verbatim — it includes restoration instructions for the binary-missing case (pin to 0.79.4 or build locally) which the user needs to act on.
 
    Until S-2.4 wires the binary commit into the release workflow, exit `2` is the expected outcome on a fresh install. That's the current state of v1.0-beta development; do not silently ignore it — the warning surfaces it for the operator.
 
@@ -67,13 +77,14 @@ If the user invokes the skill with `--dry-run` (or asks for a preview), perform 
 - **Per-project, not shared.** `settings.local.json` is typically gitignored, so teammates opt in individually.
 - **Platform persistence is forward-looking.** v0.79.x ignores `vsdd-factory.activated_platform`; v1.0+ reads it during S-2.6 to pick the right hooks.json variant. Recording it now means the v0.79 → v1.0 upgrade has the data it needs in place.
 - **No "hijack on enable".** Plugin-level `settings.json` (which would set `agent` automatically) is the alternative we deliberately did not choose. Activation is always an explicit user action.
-- **Detection helper has a test override.** `MOCK_UNAME_S` and `MOCK_UNAME_M` env vars bypass real `uname` — see `plugins/vsdd-factory/tests/activate.bats` for the matrix.
+- **Detection helper has a test override.** `MOCK_UNAME_S` and `MOCK_UNAME_M` env vars bypass real platform detection in both `detect-platform.sh` and `detect-platform.ps1` — see `plugins/vsdd-factory/tests/activate.bats` for the bash matrix. (Pester coverage for the `.ps1` siblings is tracked in tech debt — see TD-019.)
+- **Flag conventions across the bash/PowerShell sibling pair.** Both PowerShell-style flags (`-Help`, `-Check`) and bash-style aliases (`--help`, `-h`, `--check`) are accepted by the `.ps1` siblings, so cross-shell muscle memory does not produce exit-4 surprises. Internally, the JSON output, exit codes, and diagnostic strings are byte-for-byte identical between `.sh` and `.ps1`; only the *invocation* syntax differs by host shell convention.
 
 ## See also
 
 - `/vsdd-factory:deactivate` — reverse this
 - `/vsdd-factory:scaffold-claude-md` — generate a project-specific CLAUDE.md
 - Orchestrator agent: `${CLAUDE_PLUGIN_ROOT}/agents/orchestrator/orchestrator.md`
-- Detection helper: `${CLAUDE_PLUGIN_ROOT}/skills/activate/detect-platform.sh`
-- Apply helper: `${CLAUDE_PLUGIN_ROOT}/skills/activate/apply-platform.sh`
+- Detection helpers: `${CLAUDE_PLUGIN_ROOT}/skills/activate/detect-platform.sh` (bash) and `${CLAUDE_PLUGIN_ROOT}/skills/activate/detect-platform.ps1` (PowerShell)
+- Apply helpers: `${CLAUDE_PLUGIN_ROOT}/skills/activate/apply-platform.sh` (bash) and `${CLAUDE_PLUGIN_ROOT}/skills/activate/apply-platform.ps1` (PowerShell)
 - v1.0 design context: `.factory/specs/2026-04-24-v1.0-factory-plugin-kit-design.md`

--- a/plugins/vsdd-factory/skills/activate/apply-platform.ps1
+++ b/plugins/vsdd-factory/skills/activate/apply-platform.ps1
@@ -1,0 +1,226 @@
+# apply-platform.ps1 — PowerShell sibling of apply-platform.sh.
+#
+# Same exit-code contract, same VSDD_PLUGIN_ROOT_OVERRIDE test override,
+# same diagnostic messages. Used on native Windows hosts where Claude
+# Code falls back to PowerShell because Git Bash is absent.
+#
+# Companion to detect-platform.ps1 (S-0.3 follow-up). detect-platform
+# reports which of the 5 canonical platform tuples this host is;
+# apply-platform takes that tuple and:
+#
+#   1. Copies `hooks/hooks.json.<platform>` to `hooks/hooks.json`.
+#      (The canonical file is .gitignore'd per S-0.4 since it's
+#      generated per-machine at activation time.)
+#   2. Verifies the dispatcher binary at
+#      `hooks/dispatcher/bin/<platform>/factory-dispatcher[.exe]`
+#      exists. On Windows there is no executable bit, so the +x check
+#      from the bash sibling is a no-op here — file existence is the
+#      executability signal.
+#   3. Reports a clean diagnostic on missing inputs without leaving
+#      the workspace half-activated.
+#
+# Usage:
+#   apply-platform.ps1 <platform>
+#   apply-platform.ps1 -Check <platform>   # verify-only, no copy
+#
+# Exit:
+#   0  success: variant copied + binary present (and executable on Unix)
+#   1  variant missing (hooks.json.<platform> not committed)
+#   2  binary missing (dispatcher/bin/<platform> not yet committed)
+#   3  binary present but not executable (Unix only — Windows has no
+#      executable bit, so this fires only on PowerShell Core 7+ Unix hosts)
+#   4  usage error
+#
+# Both PowerShell-style flags (-Check, -Help) and bash-style aliases
+# (--check, --help, -h) are accepted to keep cross-shell muscle memory
+# from producing exit-4 surprises.
+#
+# Side effect: writes `hooks/hooks.json` (overwrites if present).
+# Test override: set $env:VSDD_PLUGIN_ROOT_OVERRIDE to use a synthetic
+# plugin root instead of the script's own location.
+
+param(
+  [switch]$Check,
+  [switch]$Help,
+  [Parameter(ValueFromRemainingArguments=$true)]
+  [string[]]$RestArgs
+)
+
+$ErrorActionPreference = 'Stop'
+# Set-StrictMode is the PowerShell equivalent of bash's `set -u` — surfaces
+# typos and uninitialized variables instead of silently coercing to $null.
+Set-StrictMode -Version Latest
+
+# Defensive null-init so subsequent .Count / indexing works without guards.
+if ($null -eq $RestArgs) { $RestArgs = @() }
+
+# Accept bash-style aliases for cross-shell muscle memory. We strip them
+# from $RestArgs before the positional-arg validation below.
+$wantHelp = $Help
+if ($RestArgs.Count -gt 0 -and ($RestArgs[0] -eq '--help' -or $RestArgs[0] -eq '-h')) {
+  $wantHelp = $true
+  $RestArgs = @()
+}
+$checkMode = $Check
+if ($RestArgs.Count -gt 0 -and $RestArgs[0] -eq '--check') {
+  $checkMode = $true
+  if ($RestArgs.Count -gt 1) {
+    $RestArgs = $RestArgs[1..($RestArgs.Count - 1)]
+  } else {
+    $RestArgs = @()
+  }
+}
+
+if ($wantHelp) {
+  # Print the leading comment block (lines starting with '# ') as help —
+  # mirrors the bash sibling's `sed -n '2,/^$/p'` pattern (we stop at the
+  # first blank line; bash includes it, the only observable difference).
+  $lines = Get-Content -Path $PSCommandPath
+  foreach ($line in $lines) {
+    if ($line -match '^\s*$') { break }
+    if ($line -match '^# ?') { Write-Output ($line -replace '^# ?', '') }
+    else { break }
+  }
+  exit 0
+}
+
+if ($RestArgs.Count -ne 1) {
+  [Console]::Error.WriteLine('usage: apply-platform.ps1 [-Check|--check] <platform>')
+  [Console]::Error.WriteLine('  platform must be one of: darwin-arm64 darwin-x64 linux-x64 linux-arm64 windows-x64')
+  exit 4
+}
+
+$platform = $RestArgs[0]
+$validPlatforms = @('darwin-arm64','darwin-x64','linux-x64','linux-arm64','windows-x64')
+# PowerShell's `-contains` operator is case-insensitive by default; the
+# bash sibling matches case-sensitively via `case "$platform" in
+# darwin-arm64|...) :;; esac`. Fold an explicit Ordinal comparison so
+# `apply-platform.ps1 DARWIN-ARM64` is rejected the same way in both.
+$platformMatched = $false
+foreach ($valid in $validPlatforms) {
+  if ([string]::Equals($valid, $platform, [StringComparison]::Ordinal)) {
+    $platformMatched = $true
+    break
+  }
+}
+if (-not $platformMatched) {
+  [Console]::Error.WriteLine("error: unsupported platform: $platform")
+  [Console]::Error.WriteLine('supported: darwin-arm64 darwin-x64 linux-x64 linux-arm64 windows-x64')
+  exit 4
+}
+
+# --- Resolve plugin root ----------------------------------------------
+
+if (-not [string]::IsNullOrEmpty($env:VSDD_PLUGIN_ROOT_OVERRIDE)) {
+  $pluginRoot = $env:VSDD_PLUGIN_ROOT_OVERRIDE
+} else {
+  # The script lives at <plugin_root>/skills/activate/apply-platform.ps1.
+  # $PSScriptRoot is empty when the script is invoked via `pwsh -Command`
+  # or piped from stdin (rather than `pwsh -File`). Surface a clean
+  # diagnostic for that case instead of letting Join-Path throw a
+  # confusing CLR null-binding error.
+  if ([string]::IsNullOrEmpty($PSScriptRoot)) {
+    [Console]::Error.WriteLine('error: $PSScriptRoot is empty — script must be invoked via')
+    [Console]::Error.WriteLine('       `pwsh -File apply-platform.ps1 <platform>`, not via')
+    [Console]::Error.WriteLine('       `pwsh -Command` or stdin. Alternatively, set')
+    [Console]::Error.WriteLine('       $env:VSDD_PLUGIN_ROOT_OVERRIDE to the plugin root.')
+    exit 4
+  }
+  # Forward slashes are accepted by PowerShell's path APIs on every host
+  # OS; backslashes would break on PowerShell Core running on Unix.
+  $pluginRoot = (Resolve-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '../..')).Path
+}
+
+$variant   = Join-Path -Path $pluginRoot -ChildPath "hooks/hooks.json.$platform"
+$canonical = Join-Path -Path $pluginRoot -ChildPath 'hooks/hooks.json'
+
+# Windows binaries get a .exe suffix; everything else is bare.
+$exeSuffix = if ($platform -eq 'windows-x64') { '.exe' } else { '' }
+$binary    = Join-Path -Path $pluginRoot -ChildPath "hooks/dispatcher/bin/$platform/factory-dispatcher$exeSuffix"
+
+# --- Variant present ---------------------------------------------------
+
+if (-not (Test-Path -Path $variant -PathType Leaf)) {
+  [Console]::Error.WriteLine("error: missing variant: $variant")
+  [Console]::Error.WriteLine('       The hooks.json.<platform> files are CI-generated from')
+  [Console]::Error.WriteLine('       hooks.json.template by scripts/generate-hooks-json.sh')
+  [Console]::Error.WriteLine('       and should ship with the plugin. Reinstall or run the')
+  [Console]::Error.WriteLine('       generator to regenerate.')
+  exit 1
+}
+
+# --- Binary present ----------------------------------------------------
+
+if (-not (Test-Path -Path $binary -PathType Leaf)) {
+  [Console]::Error.WriteLine("error: dispatcher binary missing for $platform")
+  [Console]::Error.WriteLine("       expected: $binary")
+  [Console]::Error.WriteLine('')
+  [Console]::Error.WriteLine('       The release workflow (S-2.4) is responsible for committing')
+  [Console]::Error.WriteLine('       per-platform dispatcher binaries on every tag. During')
+  [Console]::Error.WriteLine('       v1.0-beta development this may not yet be wired up.')
+  [Console]::Error.WriteLine('')
+  [Console]::Error.WriteLine('       Workarounds:')
+  [Console]::Error.WriteLine('         - Pin to vsdd-factory v0.79.4 until v1.0.0-beta.1 ships')
+  [Console]::Error.WriteLine('           (no dispatcher binaries needed; bash hooks via legacy')
+  [Console]::Error.WriteLine('           paths)')
+  [Console]::Error.WriteLine('         - Build the dispatcher locally:')
+  [Console]::Error.WriteLine('             cargo build --release -p factory-dispatcher')
+  [Console]::Error.WriteLine('           then copy the binary to:')
+  [Console]::Error.WriteLine("             $binary")
+  exit 2
+}
+
+# --- Executability -----------------------------------------------------
+#
+# Windows has no chmod bit. The CLR's UnixFileMode API is available on
+# PowerShell 7+ (.NET 7+) for cross-platform inspection; we use it when
+# present to preserve the bash sibling's exit-code-3 contract on Unix
+# hosts running PowerShell Core (e.g., a CI matrix job that mounts the
+# .ps1 path on Linux). On native Windows this branch is skipped and
+# existence alone is sufficient.
+#
+# We feature-gate by PowerShell major version (7+) AND by reflection
+# property check, so PS 5.1 and older never reach the UnixFileMode access
+# (which would be a parser-time TypeNotFound error). Exception handling
+# is narrowed to PlatformNotSupportedException only — genuine I/O
+# failures (UnauthorizedAccessException, IOException, SecurityException)
+# propagate per $ErrorActionPreference = 'Stop' and surface to the user
+# instead of silently downgrading exit-3 to "ok".
+
+if ($platform -ne 'windows-x64' -and $PSVersionTable.PSVersion.Major -ge 7) {
+  $fileInfo = [System.IO.FileInfo]::new($binary)
+  if ($fileInfo.PSObject.Properties.Name -contains 'UnixFileMode') {
+    try {
+      $mode = $fileInfo.UnixFileMode
+      $execMask = [System.IO.UnixFileMode]::UserExecute -bor `
+                  [System.IO.UnixFileMode]::GroupExecute -bor `
+                  [System.IO.UnixFileMode]::OtherExecute
+      if (($mode -band $execMask) -eq [System.IO.UnixFileMode]::None) {
+        [Console]::Error.WriteLine("error: dispatcher binary is not executable: $binary")
+        [Console]::Error.WriteLine("       fix: chmod +x `"$binary`"")
+        exit 3
+      }
+    } catch [System.PlatformNotSupportedException] {
+      # UnixFileMode is the property is present but the API rejects this
+      # platform at runtime (e.g., a hypothetical PS7 build without
+      # Unix-mode support). Silent fall-through is correct here — the
+      # property check above already gated us, and existence is the
+      # native-Windows-equivalent signal.
+    }
+  }
+}
+
+# --- Apply or check ----------------------------------------------------
+
+if ($checkMode) {
+  Write-Output "ok: variant + binary present for $platform"
+  Write-Output "    variant=$variant"
+  Write-Output "    binary=$binary"
+  exit 0
+}
+
+Copy-Item -Path $variant -Destination $canonical -Force
+Write-Output "ok: applied $platform"
+Write-Output "    hooks.json <- $variant"
+Write-Output "    binary verified: $binary"
+exit 0

--- a/plugins/vsdd-factory/skills/activate/detect-platform.ps1
+++ b/plugins/vsdd-factory/skills/activate/detect-platform.ps1
@@ -1,0 +1,172 @@
+# detect-platform.ps1 — PowerShell sibling of detect-platform.sh.
+#
+# Same JSON contract, same exit codes, same MOCK_UNAME_S / MOCK_UNAME_M
+# test-override envvars. Used on native Windows hosts where Claude Code
+# falls back to PowerShell because Git Bash is absent (Claude Code
+# v2.1.84+).
+#
+# Resolves the host to one of the 5 canonical platform strings the v1.0
+# dispatcher binaries are built for:
+#
+#   darwin-arm64   darwin-x64   linux-x64   linux-arm64   windows-x64
+#
+# Output is JSON on stdout, matching detect-platform.sh:
+#
+#   {
+#     "platform": "windows-x64" | null,
+#     "detected_from": { "os": "Windows", "arch": "x86_64", "raw_uname": "Windows x86_64" },
+#     "error": null | "unsupported-platform"
+#   }
+#
+# Exit codes:
+#   0  supported platform (platform is non-null)
+#   1  unsupported platform (platform is null, error is "unsupported-platform")
+#   2  usage error (unknown flag, etc.)
+#
+# Test override: set $env:MOCK_UNAME_S and $env:MOCK_UNAME_M to bypass
+# real platform detection. The bash sibling honors the same envvars so
+# the test matrix is shared across the two implementations.
+
+param(
+  [switch]$Help,
+  [Parameter(ValueFromRemainingArguments=$true)]
+  [string[]]$Rest
+)
+
+$ErrorActionPreference = 'Stop'
+# Set-StrictMode is the PowerShell equivalent of bash's `set -u` — surfaces
+# typos and uninitialized variables instead of silently coercing to $null.
+Set-StrictMode -Version Latest
+
+if ($Help -or ($Rest -and ($Rest[0] -eq '--help' -or $Rest[0] -eq '-h'))) {
+  # Print the leading comment block (lines starting with '# ') as help —
+  # mirrors the bash sibling's `sed -n '2,/^$/p'` pattern (we stop at the
+  # first blank line; bash includes it, the only observable difference).
+  $lines = Get-Content -Path $PSCommandPath
+  foreach ($line in $lines) {
+    if ($line -match '^\s*$') { break }
+    if ($line -match '^# ?') { Write-Output ($line -replace '^# ?', '') }
+    else { break }
+  }
+  exit 0
+}
+
+if ($Rest -and $Rest.Count -gt 0) {
+  [Console]::Error.WriteLine("error: unknown argument: $($Rest[0])")
+  [Console]::Error.WriteLine("usage: detect-platform.ps1 [-Help|--help|-h]")
+  exit 2
+}
+
+# --- Detection ---------------------------------------------------------
+#
+# MOCK_UNAME_S/M empty-string semantics mirror the bash sibling's
+# `[ -n "${VAR:-}" ]` test: empty string falls through to real detection,
+# only a non-empty value overrides. `[string]::IsNullOrEmpty` is the
+# explicit PowerShell equivalent (avoids the loose-truthiness pitfalls of
+# bare `if ($env:VAR)` where strings like "0" or "False" could surprise).
+
+if (-not [string]::IsNullOrEmpty($env:MOCK_UNAME_S)) {
+  $osString = $env:MOCK_UNAME_S
+} else {
+  $rti = [System.Runtime.InteropServices.RuntimeInformation]
+  $osPlatform = [System.Runtime.InteropServices.OSPlatform]
+  if ($rti::IsOSPlatform($osPlatform::Windows)) {
+    $osString = 'Windows'
+  } elseif ($rti::IsOSPlatform($osPlatform::OSX)) {
+    $osString = 'Darwin'
+  } elseif ($rti::IsOSPlatform($osPlatform::Linux)) {
+    $osString = 'Linux'
+  } else {
+    $osString = 'unknown'
+  }
+}
+
+if (-not [string]::IsNullOrEmpty($env:MOCK_UNAME_M)) {
+  $archString = $env:MOCK_UNAME_M
+} else {
+  $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+  switch -CaseSensitive ($arch.ToString()) {
+    'X64'   { $archString = 'x86_64'; break }
+    'Arm64' { $archString = 'arm64';  break }
+    'X86'   { $archString = 'i386';   break }
+    'Arm'   { $archString = 'arm';    break }
+    default { $archString = $arch.ToString() }
+  }
+}
+
+$rawUname = "$osString $archString"
+$platform = ''
+
+# Mapping table mirrors detect-platform.sh exactly. The MINGW*/MSYS*/CYGWIN*
+# branches exist purely so the shared test matrix (which injects those
+# tuples via MOCK_UNAME_S) passes against both implementations — real
+# PowerShell never sees those OS strings.
+#
+# Restructured as if/elseif chain (instead of nested switch) for two
+# reasons: (1) PowerShell switch fires ALL matching arms by default unless
+# explicit `break` is used; bash `case` is first-match-wins. (2) PowerShell
+# switch is case-INSENSITIVE by default; bash `case` is case-sensitive.
+# The if/elseif form makes both semantics explicit and unambiguous.
+function Test-CaseSensitive([string]$value, [string]$pattern) {
+  return [string]::Equals($value, $pattern, [StringComparison]::Ordinal)
+}
+function Test-CaseSensitiveLike([string]$value, [string]$prefix) {
+  return $value.StartsWith($prefix, [StringComparison]::Ordinal)
+}
+
+if (Test-CaseSensitive $osString 'Darwin') {
+  if     (Test-CaseSensitive $archString 'arm64')  { $platform = 'darwin-arm64' }
+  elseif (Test-CaseSensitive $archString 'x86_64') { $platform = 'darwin-x64' }
+}
+elseif (Test-CaseSensitive $osString 'Linux') {
+  if     (Test-CaseSensitive $archString 'x86_64')  { $platform = 'linux-x64' }
+  elseif (Test-CaseSensitive $archString 'aarch64') { $platform = 'linux-arm64' }
+  elseif (Test-CaseSensitive $archString 'arm64')   { $platform = 'linux-arm64' }
+}
+elseif (Test-CaseSensitive $osString 'Windows') {
+  # Bash sibling matches `x86_64|amd64` case-sensitively. We do the same.
+  if     (Test-CaseSensitive $archString 'x86_64') { $platform = 'windows-x64' }
+  elseif (Test-CaseSensitive $archString 'amd64')  { $platform = 'windows-x64' }
+}
+elseif ((Test-CaseSensitiveLike $osString 'MINGW') -or
+        (Test-CaseSensitiveLike $osString 'MSYS')  -or
+        (Test-CaseSensitiveLike $osString 'CYGWIN')) {
+  # Git Bash / MSYS2 / Cygwin emit a non-Windows-looking `uname -s` but
+  # report the underlying CPU correctly. The bash sibling uses
+  # `case "$uname_m" in x86_64|amd64) ...` here.
+  if     (Test-CaseSensitive $archString 'x86_64') { $platform = 'windows-x64' }
+  elseif (Test-CaseSensitive $archString 'amd64')  { $platform = 'windows-x64' }
+}
+
+$err = ''
+if ([string]::IsNullOrEmpty($platform)) {
+  $err = 'unsupported-platform'
+}
+
+# --- Emit JSON ---------------------------------------------------------
+#
+# We hand-build the JSON so the field ordering and null encoding match
+# detect-platform.sh exactly. ConvertTo-Json on PowerShell 5.1 emits
+# differently-formatted output than jq, and the .bats matrix asserts
+# against jq-style output, so handcrafted is safer than ConvertTo-Json
+# for cross-implementation contract parity.
+
+function ConvertTo-JsonString([string]$s) {
+  if ($null -eq $s) { return 'null' }
+  $escaped = $s.Replace('\', '\\').Replace('"', '\"').Replace("`n", '\n').Replace("`r", '\r').Replace("`t", '\t')
+  return "`"$escaped`""
+}
+
+$platformJson = if ([string]::IsNullOrEmpty($platform)) { 'null' } else { ConvertTo-JsonString $platform }
+$errJson      = if ([string]::IsNullOrEmpty($err))      { 'null' } else { ConvertTo-JsonString $err }
+$osJson       = ConvertTo-JsonString $osString
+$archJson     = ConvertTo-JsonString $archString
+$rawJson      = ConvertTo-JsonString $rawUname
+
+$json = "{`"platform`":$platformJson,`"detected_from`":{`"os`":$osJson,`"arch`":$archJson,`"raw_uname`":$rawJson},`"error`":$errJson}"
+[Console]::Out.WriteLine($json)
+
+if (-not [string]::IsNullOrEmpty($err)) {
+  exit 1
+}
+exit 0

--- a/plugins/vsdd-factory/tests/regression-v1.0.bats
+++ b/plugins/vsdd-factory/tests/regression-v1.0.bats
@@ -143,10 +143,26 @@ setup() {
   if [ ! -x "$DISPATCHER" ] || [ ! -f "$ADAPTER_WASM" ]; then
     skip "preflight artifacts missing"
   fi
-  # capture-commit-activity is on PostToolUse/Bash and writes a
-  # commit.made event for `git commit ...` invocations. With the
-  # adapter actually running bash, the event file should appear.
-  envelope='{"event_name":"PostToolUse","tool_name":"Bash","session_id":"events-land","tool_input":{"command":"git commit -m x"},"tool_response":{"exit_code":0,"stdout":"[main abc1234] x","stderr":""}}'
+  # NOTE: This test originally used a PostToolUse/Bash envelope expecting
+  # capture-commit-activity.sh to run via the legacy-bash-adapter. After
+  # the WASM migration (commit 818fb95), capture-commit-activity is now a
+  # native Wasm plugin and PostToolUse/Bash routes only to WASM hooks
+  # (capture-commit-activity.wasm, capture-pr-activity.wasm,
+  # regression-gate.wasm) — none through legacy-bash-adapter. The test
+  # was rewritten (PR #79) to use purity-check.sh, which is still
+  # adapter-routed on PostToolUse/Edit|Write and emits
+  # `pure_core_boundary_violation` via bin/emit-event into events-*.jsonl
+  # whenever the edited file is under */pure/** with side-effecting code.
+  pure_dir="$WORK/src/pure"
+  mkdir -p "$pure_dir"
+  pure_file="$pure_dir/impure.rs"
+  cat > "$pure_file" <<EOF
+use std::fs;
+fn main() {
+    println!("hello");
+}
+EOF
+  envelope=$(printf '{"event_name":"PostToolUse","tool_name":"Edit","session_id":"events-land","tool_input":{"file_path":"%s"},"tool_response":{"exit_code":0}}' "$pure_file")
   env CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" CLAUDE_PROJECT_DIR="$WORK" \
     bash -c "printf '%s' '$envelope' | '$DISPATCHER'" \
     >/dev/null 2>&1


### PR DESCRIPTION
## Release Summary

rc.9 closes the activate-skill platform-coverage gap that opened in Claude Code v2.1.84+ on native Windows hosts without Git for Windows (where Claude Code falls back to PowerShell and cannot execute the bash `detect-platform.sh` / `apply-platform.sh` helpers).

**Headline change:** PowerShell siblings (`detect-platform.ps1`, `apply-platform.ps1`) ship alongside the bash originals. Identical JSON contract, exit codes, and test-override envvar surface. SKILL.md dispatches to the right helper based on active shell.

**Also included:** test rewrite for regression-v1.0 #9 — capture-commit-activity migrated to native WASM in commit 818fb95, invalidating the original test premise. Test now uses `purity-check.sh` (still adapter-routed) to pin the bash-via-adapter path.

## What's NOT in this release

The research investigation that surfaced the regression-v1.0 failure also surfaced a broader telemetry-pipeline issue: WASM `host::emit_event` routes events to `dispatcher-internal-*.jsonl` instead of `events-*.jsonl`, silently losing every WASM-emitted event from every downstream consumer (Grafana, OTel collector, factory-query, factory-replay, etc.). This is captured by:

- **ADR-015** (drafted by architect agent, awaiting adversarial review): single-stream event emission with OTel-aligned schema
- **E-TELEMETRY epic** (to be decomposed by story-writer once ADR converges): host-side schema enrichment, single-stream routing, per-event-family schema migration, bug-fix bundle, consumer migration, documentation, causal chain extension

Approximately 9-13 days of focused work; appropriate for a v1.0.1 or v1.1 release, NOT bundled into rc.9.

## Process gaps codified

The investigation also surfaced two systemic process gaps, codified as lessons + follow-up stories:

- **LESSON-2026-05-04-001** [process-gap]: S-3.04 marked "shipped" without AC verification. The integration step (`Router::submit` in `main.rs`) was never wired, but the story passed sign-off in v1.0.0-beta.4. Follow-up: **S-7.04** — "Add AC-test-link discipline to per-story-delivery flow" (P1, v1.0.1).
- **LESSON-2026-05-04-002** [process-gap]: Grafana dashboards query event_types and fields no plugin emits (`pr.opened` vs `pr.created`; `open_to_merge_seconds`). No validation gate. Follow-up: **S-7.05** — "Add dashboard-emitter-contract lint hook" (P2, v1.0.1).

## Pre-release checks

- ✅ BATS test suite: all suites pass (4 pre-existing TD-020 skips)
- ✅ Shellcheck hooks: clean
- ✅ Plugin structure validation: passes
- ✅ Lobster workflow parsing: 16/16 OK

## Files changed

- `plugins/vsdd-factory/skills/activate/detect-platform.ps1` (new, 167 LOC)
- `plugins/vsdd-factory/skills/activate/apply-platform.ps1` (new, 226 LOC)
- `plugins/vsdd-factory/skills/activate/SKILL.md` (modified, dispatch by shell)
- `plugins/vsdd-factory/tests/regression-v1.0.bats` (test 9 rewrite to purity-check)
- `plugins/vsdd-factory/.claude-plugin/plugin.json` (1.0.0-rc.8 → 1.0.0-rc.9)
- `README.md` (version badge: 0.47.0 → 1.0.0-rc.9)
- `CHANGELOG.md` (new rc.9 entry)

## Test plan

- [x] All bats suites pass on this branch
- [ ] Wait for CI Semgrep SAST to complete on this PR
- [ ] After merge to main, tag v1.0.0-rc.9
- [ ] CI release.yml triggers on tag push, bundles per-platform dispatcher binaries
- [ ] Verify GitHub Release artifact created
- [ ] Open marketplace PR against drbothen/claude-mp pointing at the new tag

## Related

- ADR-015 (single-stream event emission) — draft awaiting adversarial review
- TD-019 (PowerShell test parity + future Rust consolidation)
- TD-019a (lightweight pwsh syntactic CI gate)
- LESSON-2026-05-04-001 / S-7.04 (story-shipped-without-AC-verification process gap)
- LESSON-2026-05-04-002 / S-7.05 (dashboard-emitter-contract validation process gap)
- Prior context: rc.8 hooks-registry migration (#76, #77); rc.9 PR scaffolding (#78)