### PR TITLE
fix(skills,agents): remove vsdd-factory release-version refs

### DIFF
--- a/plugins/vsdd-factory/agents/orchestrator/steady-state.md
+++ b/plugins/vsdd-factory/agents/orchestrator/steady-state.md
@@ -8,12 +8,13 @@ description: Orchestrator workflow reference for steady-state operations once a 
 
 # Steady-State Operations
 
-Reference file for the orchestrator. Load after v1.0.0 release or when
+Reference file for the orchestrator. Load after the first stable release
+(or whichever release transitions the project out of greenfield) or when
 operating in maintenance/feature mode.
 
 ## Greenfield to Steady-State Handoff
 
-After v1.0.0 releases:
+After the first stable release ships:
 
 1. Archive greenfield cycle:
    Spawn state-manager: move operational artifacts to cycles/vX.Y.Z-greenfield/

--- a/plugins/vsdd-factory/skills/activate/SKILL.md
+++ b/plugins/vsdd-factory/skills/activate/SKILL.md
@@ -6,7 +6,7 @@ disable-model-invocation: true
 
 # Activate VSDD Factory
 
-Per-project opt-in. Enabling the plugin alone does not change your default Claude persona — it only makes the factory's agents, skills, and hooks available. Running this skill flips the default agent to `orchestrator` so that a plain session becomes the VSDD pipeline driver, and (in v1.0+) records the host platform so the dispatcher copies the right per-platform `hooks.json` variant into place.
+Per-project opt-in. Enabling the plugin alone does not change your default Claude persona — it only makes the factory's agents, skills, and hooks available. Running this skill flips the default agent to `orchestrator` so that a plain session becomes the VSDD pipeline driver, and records the host platform so the dispatcher copies the right per-platform `hooks.json` variant into place.
 
 ## Procedure
 
@@ -15,12 +15,12 @@ Per-project opt-in. Enabling the plugin alone does not change your default Claud
 2. **Detect the host platform.** Run the detector matching your active shell:
 
    - **bash / sh / zsh / Git Bash / WSL** (macOS, Linux, Windows-with-Git-Bash): run `${CLAUDE_PLUGIN_ROOT}/skills/activate/detect-platform.sh`
-   - **PowerShell** (native Windows without Git Bash, Claude Code v2.1.84+): run `${CLAUDE_PLUGIN_ROOT}/skills/activate/detect-platform.ps1`
+   - **PowerShell** (native Windows without Git Bash): run `${CLAUDE_PLUGIN_ROOT}/skills/activate/detect-platform.ps1`
 
    Both produce identical JSON output and use identical exit codes. Capture stdout.
 
-   - On `exit 0`, the helper returns one of the 5 canonical platform strings the v1.0 dispatcher binaries are built for: `darwin-arm64`, `darwin-x64`, `linux-x64`, `linux-arm64`, `windows-x64`.
-   - On `exit 1`, the platform is unsupported (e.g., FreeBSD, 32-bit). Print the helper's `detected_from.raw_uname` and tell the user vsdd-factory v1.0 has no dispatcher binary for that host. Do not proceed; activation aborts.
+   - On `exit 0`, the helper returns one of the 5 canonical platform strings the dispatcher binaries are built for: `darwin-arm64`, `darwin-x64`, `linux-x64`, `linux-arm64`, `windows-x64`.
+   - On `exit 1`, the platform is unsupported (e.g., FreeBSD, 32-bit). Print the helper's `detected_from.raw_uname` and tell the user vsdd-factory has no dispatcher binary for that host. Do not proceed; activation aborts.
 
 3. **Read existing `.claude/settings.local.json`.** If it doesn't exist, create an empty `{}`. If it does, parse it with `jq`.
 
@@ -51,12 +51,10 @@ Per-project opt-in. Enabling the plugin alone does not change your default Claud
    - **PowerShell**: `${CLAUDE_PLUGIN_ROOT}/skills/activate/apply-platform.ps1 <platform>`
 
    Both implementations share the same exit-code contract and diagnostic messages. Either one:
-   - Copies `${CLAUDE_PLUGIN_ROOT}/hooks/hooks.json.<platform>` to `${CLAUDE_PLUGIN_ROOT}/hooks/hooks.json` (the canonical file is gitignored per S-0.4 — it's per-machine).
+   - Copies `${CLAUDE_PLUGIN_ROOT}/hooks/hooks.json.<platform>` to `${CLAUDE_PLUGIN_ROOT}/hooks/hooks.json` (the canonical file is gitignored — it's per-machine, generated at activation time).
    - Verifies the dispatcher binary at `${CLAUDE_PLUGIN_ROOT}/hooks/dispatcher/bin/<platform>/factory-dispatcher[.exe]` is present and (on Unix) executable.
 
-   Exit codes: `0` success; `1` variant missing (corrupted install); `2` binary missing (release didn't commit it for this platform yet); `3` binary not executable (Unix only — Windows has no executable bit); `4` usage error. Surface the helper's stderr to the user verbatim — it includes restoration instructions for the binary-missing case (pin to 0.79.4 or build locally) which the user needs to act on.
-
-   Until S-2.4 wires the binary commit into the release workflow, exit `2` is the expected outcome on a fresh install. That's the current state of v1.0-beta development; do not silently ignore it — the warning surfaces it for the operator.
+   Exit codes: `0` success; `1` variant missing (corrupted install); `2` binary missing (release did not commit it for this platform); `3` binary not executable (Unix only — Windows has no executable bit); `4` usage error. Surface the helper's stderr to the user verbatim — it includes restoration instructions for the binary-missing case (build locally with `cargo build --release -p factory-dispatcher`) which the user needs to act on.
 
 7. **Confirm activation.** Print:
    - File written
@@ -75,7 +73,7 @@ If the user invokes the skill with `--dry-run` (or asks for a preview), perform 
 ## Notes
 
 - **Per-project, not shared.** `settings.local.json` is typically gitignored, so teammates opt in individually.
-- **Platform persistence is forward-looking.** v0.79.x ignores `vsdd-factory.activated_platform`; v1.0+ reads it during S-2.6 to pick the right hooks.json variant. Recording it now means the v0.79 → v1.0 upgrade has the data it needs in place.
+- **Platform is recorded for the dispatcher.** `vsdd-factory.activated_platform` tells the dispatcher which `hooks.json.<platform>` variant to copy into place; activation is what binds the plugin to the host's CPU/OS combination.
 - **No "hijack on enable".** Plugin-level `settings.json` (which would set `agent` automatically) is the alternative we deliberately did not choose. Activation is always an explicit user action.
 - **Detection helper has a test override.** `MOCK_UNAME_S` and `MOCK_UNAME_M` env vars bypass real platform detection in both `detect-platform.sh` and `detect-platform.ps1` — see `plugins/vsdd-factory/tests/activate.bats` for the bash matrix. (Pester coverage for the `.ps1` siblings is tracked in tech debt — see TD-019.)
 - **Flag conventions across the bash/PowerShell sibling pair.** Both PowerShell-style flags (`-Help`, `-Check`) and bash-style aliases (`--help`, `-h`, `--check`) are accepted by the `.ps1` siblings, so cross-shell muscle memory does not produce exit-4 surprises. Internally, the JSON output, exit codes, and diagnostic strings are byte-for-byte identical between `.sh` and `.ps1`; only the *invocation* syntax differs by host shell convention.
@@ -87,4 +85,3 @@ If the user invokes the skill with `--dry-run` (or asks for a preview), perform 
 - Orchestrator agent: `${CLAUDE_PLUGIN_ROOT}/agents/orchestrator/orchestrator.md`
 - Detection helpers: `${CLAUDE_PLUGIN_ROOT}/skills/activate/detect-platform.sh` (bash) and `${CLAUDE_PLUGIN_ROOT}/skills/activate/detect-platform.ps1` (PowerShell)
 - Apply helpers: `${CLAUDE_PLUGIN_ROOT}/skills/activate/apply-platform.sh` (bash) and `${CLAUDE_PLUGIN_ROOT}/skills/activate/apply-platform.ps1` (PowerShell)
-- v1.0 design context: `.factory/specs/2026-04-24-v1.0-factory-plugin-kit-design.md`

--- a/plugins/vsdd-factory/skills/adversarial-review/SKILL.md
+++ b/plugins/vsdd-factory/skills/adversarial-review/SKILL.md
@@ -134,7 +134,7 @@ The adversary agent has only Read/Grep/Glob tools — it cannot write files. Aft
 
 1. **Capture the adversary's full output** verbatim (do not summarize or filter)
 2. **Determine the target path:** `.factory/cycles/<current-cycle>/adversarial-reviews/pass-<N>.md`
-   - Read `.factory/current-cycle` for the cycle name (e.g., `v1.0.0-greenfield`)
+   - Read `.factory/current-cycle` for the cycle name (operator-defined slug; e.g., `<release>-greenfield` or `<feature>-patch`)
    - If no current-cycle file exists, use the active cycle from STATE.md
    - `<N>` is the pass number (1-based, sequential within the cycle)
 3. **Dispatch state-manager** to write the findings file at the target path

--- a/plugins/vsdd-factory/skills/claude-telemetry/SKILL.md
+++ b/plugins/vsdd-factory/skills/claude-telemetry/SKILL.md
@@ -19,13 +19,14 @@ to our collector. It writes them to `.claude/settings.local.json` under
 the `env` block so the current project's Claude sessions pick them up
 on next start.
 
-> **v0.76.0 note**: Earlier releases required a sixth env var,
+> **Legacy env var note**: Earlier installations required a sixth env var,
 > `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=cumulative`, to force
 > Claude to emit cumulative counters (Prometheus's `remote_write` receiver
-> rejects delta temporality). As of v0.76.0 the otel-collector runs the
+> rejects delta temporality). The otel-collector now runs the
 > `deltatocumulative` processor (available in collector-contrib 0.115+),
 > which converts in-flight. The env var is no longer needed. If you
-> previously ran this skill, `off` → `on` will prune the stale key.
+> previously ran this skill on a legacy installation, `off` → `on` will
+> prune the stale key.
 
 ## Prerequisites
 
@@ -60,7 +61,7 @@ Five keys, all strings, all go under the `env` object:
 | Key | Value | Why |
 |---|---|---|
 | `CLAUDE_CODE_ENABLE_TELEMETRY` | `"1"` | Master enable flag. |
-| `OTEL_METRICS_EXPORTER` | `"otlp"` | Metrics go to the collector (forwarded to Prometheus in v0.72.0+). |
+| `OTEL_METRICS_EXPORTER` | `"otlp"` | Metrics go to the collector (forwarded to Prometheus). |
 | `OTEL_LOGS_EXPORTER` | `"otlp"` | Logs go to Loki via the collector. |
 | `OTEL_EXPORTER_OTLP_PROTOCOL` | `"http/protobuf"` | Must match the receiver — compose exposes 4318 HTTP, not 4317 gRPC. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | `"http://localhost:4318"` | Host the collector is bound to. Override via `VSDD_OBS_OTLP_HTTP_PORT` if 4318 is remapped. |

--- a/plugins/vsdd-factory/skills/deactivate/SKILL.md
+++ b/plugins/vsdd-factory/skills/deactivate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deactivate
-description: Reverse `/vsdd-factory:activate` — remove the orchestrator default agent, the v1.0 platform activation state, and the generated `hooks.json`. Leaves the plugin enabled; only the default persona and per-machine hooks config are cleared.
+description: Reverse `/vsdd-factory:activate` — remove the orchestrator default agent, the platform activation state, and the generated `hooks.json`. Leaves the plugin enabled; only the default persona and per-machine hooks config are cleared.
 disable-model-invocation: true
 ---
 
@@ -8,7 +8,7 @@ disable-model-invocation: true
 
 Reverses everything `/vsdd-factory:activate` does: clears the
 orchestrator default-agent override in `.claude/settings.local.json`,
-removes the v1.0 platform activation block, and deletes the
+removes the platform activation block, and deletes the
 per-machine `hooks/hooks.json` (which was a copy of the platform
 variant). The plugin itself stays enabled — agents, skills, and the
 underlying `hooks.json.<platform>` files remain available for explicit
@@ -38,15 +38,15 @@ invocation or future re-activation.
    - That the plugin is still enabled (you can still invoke
      individual skills/agents explicitly)
    - That `/vsdd-factory:activate` is the inverse and is required
-     before the v1.0 dispatcher fires
+     before the dispatcher fires again
 
 ## Notes
 
-Step 4 is harmless on v0.79.x installs that never had a hooks.json
-copy (the file may be the v0.79.x committed one, in which case
-removing it temporarily breaks hook routing — operators rerun
-activate to restore). For v1.0-beta installs the file is purely a
-per-machine artifact and removing it is the correct cleanup.
+Step 4 deletes a per-machine artifact — `hooks/hooks.json` is generated
+at activation time by copying the right `hooks.json.<platform>` variant
+into place. Removing it has no git side effect (the file is gitignored)
+and the per-platform variants remain in place for the next activation
+to copy from.
 
 ## See also
 

--- a/plugins/vsdd-factory/skills/factory-cycles-bootstrap/SKILL.md
+++ b/plugins/vsdd-factory/skills/factory-cycles-bootstrap/SKILL.md
@@ -20,7 +20,7 @@ Migrate a project's `.factory/` from the flat layout (all reviews in `specs/`) t
 
 If `$ARGUMENTS` is provided, use it as the cycle name. Otherwise prompt:
 
-> "What should this convergence cycle be named? Examples: `v1.0.0-greenfield`, `phase-3-patch`, `v1.1.0-feature-auth`"
+> "What should this convergence cycle be named? Examples: `<release>-greenfield`, `phase-N-patch`, `<release>-feature-auth`"
 
 Cycle names must be lowercase, hyphenated, no spaces.
 

--- a/plugins/vsdd-factory/skills/factory-obs/SKILL.md
+++ b/plugins/vsdd-factory/skills/factory-obs/SKILL.md
@@ -13,7 +13,7 @@ Grafana Image Renderer) that ingests `.factory/logs/events-*.jsonl`
 into Loki and Claude Code's native OTel metrics into Prometheus, and
 surfaces the data in 7 preconfigured Grafana dashboards.
 
-Since v0.78.0 the stack can watch **multiple factory projects** at
+The stack can watch **multiple factory projects** at
 once. Each project is registered explicitly via a user-level registry
 at `~/.config/vsdd-factory/watched-factories`. `factory-obs up`
 generates a `docker-compose.override.yml` from that registry with one

--- a/plugins/vsdd-factory/skills/onboard-observability/SKILL.md
+++ b/plugins/vsdd-factory/skills/onboard-observability/SKILL.md
@@ -57,8 +57,8 @@ fi
 
 # Merge the 5 OTEL_* keys into .env. Prune the legacy
 # OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE key if present
-# (left over from pre-v0.76.0 runs of claude-telemetry when
-# deltatocumulative wasn't yet wired into the collector).
+# (left over from legacy claude-telemetry runs predating the
+# collector's deltatocumulative processor).
 jq '.env = ((.env // {}) + {
     "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
     "OTEL_METRICS_EXPORTER": "otlp",

--- a/plugins/vsdd-factory/skills/release/SKILL.md
+++ b/plugins/vsdd-factory/skills/release/SKILL.md
@@ -234,15 +234,15 @@ Execute the full Release Mode flow but only print what would happen:
 ```
 DRY RUN — no changes will be made.
 
-1. Version bump: 0.10.2 → 0.10.3 (MINOR)
+1. Version bump: <CURRENT> → <NEXT> (MINOR)
 2. Files to update:
-   - plugins/vsdd-factory/.claude-plugin/plugin.json: "version" → "0.10.3"
-   - README.md: badge → 0.10.3
-   - .claude-plugin/marketplace.json: "plugins[0].version" → "0.10.3"
-3. CHANGELOG: would generate entry from 3 commits since v0.10.2
-4. Commit: "chore: release v0.10.3"
-5. Tag: v0.10.3
-6. Push: main + v0.10.3
+   - plugins/vsdd-factory/.claude-plugin/plugin.json: "version" → "<NEXT>"
+   - README.md: badge → <NEXT>
+   - .claude-plugin/marketplace.json: "plugins[0].version" → "<NEXT>"
+3. CHANGELOG: would generate entry from N commits since v<CURRENT>
+4. Commit: "chore: release v<NEXT>"
+5. Tag: v<NEXT>
+6. Push: main + v<NEXT>
 7. CI workflow: .github/workflows/release.yml would be triggered
 8. Publish: none (no publish config)
 


### PR DESCRIPTION
## Summary

Skills and agents should describe BEHAVIOR, not which release first introduced it. Version-coupled prose ages poorly and confuses operators running older releases. This PR removes vsdd-factory release-version references from skill and agent bodies and replaces hardcoded version examples with parametric placeholders.

## Scope categorization

**Removed (vsdd-factory release versions in skill/agent prose):**
- `v0.X` / `v1.X` / `beta.N` / `rc.N` literal references
- Hardcoded version examples (`v0.10.2 → v0.10.3` → `<CURRENT> → <NEXT>`)
- Cycle-name examples (`v1.0.0-greenfield` → `<release>-greenfield`)

**Kept (NOT vsdd version refs):**
- Spec artifact IDs (BC-X.X, S-X.X, FR-X) — stable identifiers tied to design artifacts, intended to be permanent
- Spec/template versions in spec-versioning skill (that skill IS about version handling; examples are the point)
- Generic semver guidance in devops-engineer (about releasing OTHER projects, not vsdd)
- Third-party tool versions (`excalidraw-brute-export-cli v0.4.0+`) — required for tool to work
- Illustrative example filenames in sdk-generation (`openapi-v1.0.0.yaml` etc.) — hypothetical user content

## Files changed

| File | Refs cleaned |
|------|--------------|
| skills/activate/SKILL.md | 5 (v1.0+, v1.0, v0.79.x, v2.1.84+, S-* IDs, design-doc path) |
| skills/deactivate/SKILL.md | 5 (v1.0, v0.79.x, v1.0-beta) |
| skills/factory-obs/SKILL.md | 1 ("Since v0.78.0") |
| skills/claude-telemetry/SKILL.md | 3 (v0.76.0, v0.72.0+) |
| skills/onboard-observability/SKILL.md | 1 (pre-v0.76.0) |
| skills/release/SKILL.md | 4 (v0.10.x dry-run examples → placeholders) |
| skills/adversarial-review/SKILL.md | 1 (cycle-name example) |
| skills/factory-cycles-bootstrap/SKILL.md | 1 (cycle-name examples) |
| agents/orchestrator/steady-state.md | 2 ("v1.0.0 release" → "first stable release") |

## Test plan

- [x] Diff reviewed; no behavioral changes (prose-only)
- [ ] CI passes (Semgrep / lobster / cargo / etc)

## Related

- Discovered during a "scan all skills + agents for version refs" sweep prompted by version-laden prose in the activate skill body