### PR TITLE
fix(tests): TD-020 sweep — resolve 4 skipped bats suites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## Unreleased
+
+### TD-020 sweep — bats SKIP_SUITES cleanup
+
+Resolved the four bats suites permanently excluded from the
+release-validation gate via `SKIP_SUITES` in
+`plugins/vsdd-factory/tests/run-all.sh`. Each suite either now passes
+when un-skipped or had its broken assertions removed.
+
+#### Tests removed (with rationale)
+
+- **`codify-lessons.bats` — BC-5.36.007** ("all three agents updated
+  in the delivery branch"): asserted that the
+  `.worktrees/codify-lessons` delivery worktree contained diff-vs-main
+  changes to 3 agents. The worktree no longer exists post-merge, so
+  the assertion was structurally impossible. The same contract
+  (agents updated) is still validated by BC-5.36.001–006 which inspect
+  the merged files.
+- **`novelty-assessment.bats` — "validates adversarial-delta-review
+  files"**: asserted that the hook would block
+  `.factory/phase-f5-adversarial/adversarial-delta-review.md`. The
+  current case-statement matcher in
+  `validate-novelty-assessment.sh` only covers
+  `.factory/specs/adversarial-*review*.md`. Per TD-020 (no new
+  functionality to make tests pass), the test asserted behavior the
+  hook does not implement.
+- **`novelty-assessment.bats` — "validates story adversarial review
+  files"**: asserted that `.factory/stories/adversarial-reviews/`
+  paths are validated. That layout is not used anywhere in the
+  current plugin (zero grep hits). Per-story adversarial review is
+  not part of the current artifact tree.
+- **`novelty-assessment.bats` — "valid delta review passes"**: passed
+  only because the case-statement matcher does not cover
+  `.factory/phase-f5-adversarial/` and so falls through to exit 0.
+  With the matching negative-path test removed, keeping this
+  happy-path test gave a misleading signal.
+
+#### Suites un-skipped (no test changes needed)
+
+- **`generate-registry.bats`** — all 6 invariant tests now pass; the
+  generator stabilized after the TD-016 glob refactor that originally
+  surfaced the breakage.
+
 ## 1.0.0-rc.10 — Skill-body version-ref cleanup (2026-05-04)
 
 Hotfix release. Removes vsdd-factory release-version references

--- a/plugins/vsdd-factory/tests/codify-lessons.bats
+++ b/plugins/vsdd-factory/tests/codify-lessons.bats
@@ -34,19 +34,11 @@
   grep -qi "prose" plugins/vsdd-factory/agents/adversary.md
 }
 
-@test "BC-5.36.007: all three agents updated in the delivery branch" {
-  # Verify all 3 agent files were modified somewhere in this branch
-  # (checks branch diff vs origin/main, robust to additional review-cycle fix commits)
-  cd /Users/jmagady/Dev/vsdd-factory/.worktrees/codify-lessons
-  merge_base=$(git merge-base HEAD origin/main 2>/dev/null || git merge-base HEAD main 2>/dev/null || echo "")
-  if [[ -z "$merge_base" ]]; then
-    # Fallback: check last 5 commits
-    files_in_branch=$(git diff --name-only HEAD~5 HEAD | grep -c 'agents/' || true)
-  else
-    files_in_branch=$(git diff --name-only "$merge_base" HEAD | grep -c 'agents/')
-  fi
-  [ "$files_in_branch" -ge 3 ]
-}
+# BC-5.36.007 (REMOVED 2026-05-04, TD-020 sweep): Asserted that all three
+# agents were touched in the codify-lessons delivery worktree. The worktree
+# `.worktrees/codify-lessons` no longer exists post-merge, so the assertion
+# was structurally impossible to satisfy. The contract (agents updated)
+# is still validated by BC-5.36.001–006 which inspect the merged files.
 
 # ---------- S-7.02: Defensive sweep + hook + meta-rule (BC-5.37.001–002, BC-7.05.001–004, BC-8.28.001–002) ----------
 

--- a/plugins/vsdd-factory/tests/codify-lessons.bats
+++ b/plugins/vsdd-factory/tests/codify-lessons.bats
@@ -4,34 +4,38 @@
 # S-7.01: Agent prompt discipline (story-writer, product-owner, adversary)
 # S-7.02: Defensive sweep + hook + meta-rule
 
+setup() {
+  PLUGIN_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+}
+
 # ---------- S-7.01: Agent prompt tests (BC-5.36.001–007) ----------
 
 @test "BC-5.36.001: story-writer.md contains spec-first gate" {
-  grep -q "behavioral_contracts.*non-empty" plugins/vsdd-factory/agents/story-writer.md
-  grep -qE "BC-\\\\d\\+\\\\.\\\\d\\{2\\}\\\\.\\\\d\\{3\\}" plugins/vsdd-factory/agents/story-writer.md
+  grep -q "behavioral_contracts.*non-empty" "$PLUGIN_ROOT/agents/story-writer.md"
+  grep -qE "BC-\\\\d\\+\\\\.\\\\d\\{2\\}\\\\.\\\\d\\{3\\}" "$PLUGIN_ROOT/agents/story-writer.md"
 }
 
 @test "BC-5.36.002: story-writer.md requires AC↔BC bidirectional trace" {
-  grep -qi "AC.*BC.*bidirectional" plugins/vsdd-factory/agents/story-writer.md
+  grep -qi "AC.*BC.*bidirectional" "$PLUGIN_ROOT/agents/story-writer.md"
 }
 
 @test "BC-5.36.003: product-owner.md requires Capability Anchor Justification cell" {
-  grep -q "Capability Anchor Justification" plugins/vsdd-factory/agents/product-owner.md
+  grep -q "Capability Anchor Justification" "$PLUGIN_ROOT/agents/product-owner.md"
 }
 
 @test "BC-5.36.004: product-owner.md requires verbatim citation from capabilities.md" {
-  grep -qi "verbatim" plugins/vsdd-factory/agents/product-owner.md
-  grep -q "capabilities.md" plugins/vsdd-factory/agents/product-owner.md
+  grep -qi "verbatim" "$PLUGIN_ROOT/agents/product-owner.md"
+  grep -q "capabilities.md" "$PLUGIN_ROOT/agents/product-owner.md"
 }
 
 @test "BC-5.36.005: adversary.md requires partial-fix-regression check" {
-  grep -qi "partial.fix.regression" plugins/vsdd-factory/agents/adversary.md
+  grep -qi "partial.fix.regression" "$PLUGIN_ROOT/agents/adversary.md"
 }
 
 @test "BC-5.36.006: adversary.md requires propagation check to bodies, sibling files, prose" {
-  grep -qi "bodies" plugins/vsdd-factory/agents/adversary.md
-  grep -qi "sibling files" plugins/vsdd-factory/agents/adversary.md
-  grep -qi "prose" plugins/vsdd-factory/agents/adversary.md
+  grep -qi "bodies" "$PLUGIN_ROOT/agents/adversary.md"
+  grep -qi "sibling files" "$PLUGIN_ROOT/agents/adversary.md"
+  grep -qi "prose" "$PLUGIN_ROOT/agents/adversary.md"
 }
 
 # BC-5.36.007 (REMOVED 2026-05-04, TD-020 sweep): Asserted that all three
@@ -43,16 +47,16 @@
 # ---------- S-7.02: Defensive sweep + hook + meta-rule (BC-5.37.001–002, BC-7.05.001–004, BC-8.28.001–002) ----------
 
 @test "BC-5.37.001: state-manager.md requires defensive sweep" {
-  grep -qi "defensive sweep" plugins/vsdd-factory/agents/state-manager.md
-  grep -qi "corpus.wide grep" plugins/vsdd-factory/agents/state-manager.md
+  grep -qi "defensive sweep" "$PLUGIN_ROOT/agents/state-manager.md"
+  grep -qi "corpus.wide grep" "$PLUGIN_ROOT/agents/state-manager.md"
 }
 
 @test "BC-5.37.002: state-manager.md requires sweep result logging" {
-  grep -qi "log.*sweep result" plugins/vsdd-factory/agents/state-manager.md
+  grep -qi "log.*sweep result" "$PLUGIN_ROOT/agents/state-manager.md"
 }
 
 @test "BC-7.05.001: validate-count-propagation.sh exists and is executable" {
-  [ -x plugins/vsdd-factory/hooks/validate-count-propagation.sh ]
+  [ -x "$PLUGIN_ROOT/hooks/validate-count-propagation.sh" ]
 }
 
 @test "BC-7.05.001-drift: validate-count-propagation.sh exits 2 on drift" {
@@ -67,33 +71,33 @@ HEREDOC
 BCs | 200 |
 HEREDOC
   # Run hook on STATE.md change — capture exit status without triggering set -e
-  run bash plugins/vsdd-factory/hooks/validate-count-propagation.sh \
+  run bash "$PLUGIN_ROOT/hooks/validate-count-propagation.sh" \
     <<< '{"tool_input":{"file_path":"'"$TMPTEST"'/STATE.md"}}'
   [ "$status" -eq 2 ]
 }
 
 @test "BC-7.05.002: validate-count-propagation.sh runs <500ms" {
   start=$(date +%s%N)
-  echo '{"tool_input":{"file_path":"/dev/null"}}' | bash plugins/vsdd-factory/hooks/validate-count-propagation.sh || true
+  echo '{"tool_input":{"file_path":"/dev/null"}}' | bash "$PLUGIN_ROOT/hooks/validate-count-propagation.sh" || true
   end=$(date +%s%N)
   elapsed_ms=$(( (end - start) / 1000000 ))
   [ "$elapsed_ms" -lt 500 ]
 }
 
 @test "BC-7.05.003: validate-template-compliance.sh enforces VP multi-BC convention" {
-  grep -qi "multi.bc\|source_bc.*primary\|bcs.*list" plugins/vsdd-factory/bin/validate-template-compliance.sh ||
-  grep -qi "source_bc" plugins/vsdd-factory/bin/validate-template-compliance.sh
+  grep -qi "multi.bc\|source_bc.*primary\|bcs.*list" "$PLUGIN_ROOT/bin/validate-template-compliance.sh" ||
+  grep -qi "source_bc" "$PLUGIN_ROOT/bin/validate-template-compliance.sh"
 }
 
 @test "BC-7.05.004: hooks-registry.toml registers validate-count-propagation" {
-  grep -q "validate-count-propagation" plugins/vsdd-factory/hooks-registry.toml
+  grep -q "validate-count-propagation" "$PLUGIN_ROOT/hooks-registry.toml"
 }
 
 @test "BC-8.28.001: lessons-codification.md exists" {
-  [ -f plugins/vsdd-factory/rules/lessons-codification.md ]
-  grep -qi "novel.*process catch.*codification follow-up" plugins/vsdd-factory/rules/lessons-codification.md
+  [ -f "$PLUGIN_ROOT/rules/lessons-codification.md" ]
+  grep -qi "novel.*process catch.*codification follow-up" "$PLUGIN_ROOT/rules/lessons-codification.md"
 }
 
 @test "BC-8.28.002: orchestrator references lessons-codification.md in cycle-closing" {
-  grep -q "lessons-codification" plugins/vsdd-factory/agents/orchestrator/orchestrator.md
+  grep -q "lessons-codification" "$PLUGIN_ROOT/agents/orchestrator/orchestrator.md"
 }

--- a/plugins/vsdd-factory/tests/novelty-assessment.bats
+++ b/plugins/vsdd-factory/tests/novelty-assessment.bats
@@ -166,10 +166,14 @@ MISSING_VERDICT="# Adversarial Review — Pass 3
 
 # ---------- Delta review files ----------
 
-@test "novelty-assessment: validates adversarial-delta-review files" {
-  _write_and_check "$WORK/.factory/phase-f5-adversarial/adversarial-delta-review.md" "$MISSING_SECTION"
-  [ "$status" -eq 2 ]
-}
+# DELETED 2026-05-04 (TD-020 sweep):
+# "novelty-assessment: validates adversarial-delta-review files"
+# Asserted that the hook would block .factory/phase-f5-adversarial/adversarial-delta-review.md
+# files. The current case-statement matcher in validate-novelty-assessment.sh
+# only covers .factory/specs/adversarial-*review*.md. Per TD-020 constraints
+# (no new functionality to make tests pass), the test was wrong about what
+# the hook does. The valid-delta-review test below covers the
+# happy path for the same file (it short-circuits to exit 0).
 
 @test "novelty-assessment: validates round-N-review files" {
   _write_and_check "$WORK/.factory/phase-f5-adversarial/round-2-review.md" "$MISSING_SECTION"
@@ -181,15 +185,20 @@ MISSING_VERDICT="# Adversarial Review — Pass 3
   [ "$status" -eq 2 ]
 }
 
-@test "novelty-assessment: validates story adversarial review files" {
-  _write_and_check "$WORK/.factory/stories/adversarial-reviews/pass-1.md" "$MISSING_SECTION"
-  [ "$status" -eq 2 ]
-}
-
-@test "novelty-assessment: valid delta review passes" {
-  _write_and_check "$WORK/.factory/phase-f5-adversarial/adversarial-delta-review.md" "$VALID_REVIEW"
-  [ "$status" -eq 0 ]
-}
+# DELETED 2026-05-04 (TD-020 sweep):
+# "novelty-assessment: validates story adversarial review files"
+# Asserted that .factory/stories/adversarial-reviews/pass-1.md files would
+# be validated. That path is not used anywhere in the current plugin
+# (grep returns zero matches). Per-story adversarial review is not a
+# layout in the current artifact tree.
+#
+# DELETED 2026-05-04 (TD-020 sweep):
+# "novelty-assessment: valid delta review passes"
+# This test passed only because the hook's case-statement matcher does
+# not cover .factory/phase-f5-adversarial/ paths and so falls through to
+# exit 0. With the negative-path test for the same file already removed
+# (see comment above), keeping this happy-path test gave a misleading
+# signal — the hook isn't actually validating the file at all.
 
 # ---------- hooks.json wiring ----------
 

--- a/plugins/vsdd-factory/tests/run-all.sh
+++ b/plugins/vsdd-factory/tests/run-all.sh
@@ -35,9 +35,6 @@ echo "== Running all bats test suites =="
 # entries are removed as each is fixed or deleted.
 #
 # Remaining entries (each needs cleanup in TD-020 before un-skip):
-#   - generate-registry: migration-generator behavior drift; tests assert
-#     idempotency / one-line-per-hook invariants the current generator
-#     doesn't satisfy.
 #   - novelty-assessment: adversarial-delta-review file-validation tests
 #     reference a workflow that was never implemented.
 #   - state-health: state-size + state-health skill assertions reference
@@ -46,7 +43,6 @@ echo "== Running all bats test suites =="
 # To un-skip: fix or delete the underlying tests (TD-020), then remove from
 # this list. Do NOT add new entries without a TD ticket.
 SKIP_SUITES=(
-  "generate-registry"
   "novelty-assessment"
   "state-health"
 )

--- a/plugins/vsdd-factory/tests/run-all.sh
+++ b/plugins/vsdd-factory/tests/run-all.sh
@@ -31,11 +31,10 @@ echo "== Running all bats test suites =="
 # SKIP_SUITES — bats suites with known pre-existing failures excluded from the
 # release-validation gate. These suites were never in the OLD hardcoded
 # run-all.sh enumeration; the TD-016 glob refactor (Phase A) widened scope
-# and surfaced their breakage. Each entry needs cleanup in TD-020 before it
-# can be un-skipped:
-#   - codify-lessons: BC-5.36/5.37/7.05/8.28 assertions reference
-#     story-writer/product-owner/adversary patches that were never applied;
-#     validate-count-propagation.sh and lessons-codification.md don't exist.
+# and surfaced their breakage. TD-020 sweep (2026-05-04) is in progress;
+# entries are removed as each is fixed or deleted.
+#
+# Remaining entries (each needs cleanup in TD-020 before un-skip):
 #   - generate-registry: migration-generator behavior drift; tests assert
 #     idempotency / one-line-per-hook invariants the current generator
 #     doesn't satisfy.
@@ -47,7 +46,6 @@ echo "== Running all bats test suites =="
 # To un-skip: fix or delete the underlying tests (TD-020), then remove from
 # this list. Do NOT add new entries without a TD ticket.
 SKIP_SUITES=(
-  "codify-lessons"
   "generate-registry"
   "novelty-assessment"
   "state-health"

--- a/plugins/vsdd-factory/tests/run-all.sh
+++ b/plugins/vsdd-factory/tests/run-all.sh
@@ -35,15 +35,12 @@ echo "== Running all bats test suites =="
 # entries are removed as each is fixed or deleted.
 #
 # Remaining entries (each needs cleanup in TD-020 before un-skip):
-#   - novelty-assessment: adversarial-delta-review file-validation tests
-#     reference a workflow that was never implemented.
 #   - state-health: state-size + state-health skill assertions reference
 #     skills/commands that don't exist in the current plugin layout.
 #
 # To un-skip: fix or delete the underlying tests (TD-020), then remove from
 # this list. Do NOT add new entries without a TD ticket.
 SKIP_SUITES=(
-  "novelty-assessment"
   "state-health"
 )
 

--- a/plugins/vsdd-factory/tests/run-all.sh
+++ b/plugins/vsdd-factory/tests/run-all.sh
@@ -28,25 +28,21 @@ echo "all scripts ok"
 echo
 echo "== Running all bats test suites =="
 
-# SKIP_SUITES — bats suites with known pre-existing failures excluded from the
-# release-validation gate. These suites were never in the OLD hardcoded
-# run-all.sh enumeration; the TD-016 glob refactor (Phase A) widened scope
-# and surfaced their breakage. TD-020 sweep (2026-05-04) is in progress;
-# entries are removed as each is fixed or deleted.
+# SKIP_SUITES — bats suites excluded from the release-validation gate.
+# Currently empty after the TD-020 sweep (2026-05-04) resolved the four
+# previously-skipped suites (codify-lessons, generate-registry,
+# novelty-assessment, state-health). See CHANGELOG entry "TD-020 sweep —
+# bats SKIP_SUITES cleanup" for per-suite outcomes.
 #
-# Remaining entries (each needs cleanup in TD-020 before un-skip):
-#   - state-health: state-size + state-health skill assertions reference
-#     skills/commands that don't exist in the current plugin layout.
-#
-# To un-skip: fix or delete the underlying tests (TD-020), then remove from
-# this list. Do NOT add new entries without a TD ticket.
-SKIP_SUITES=(
-  "state-health"
-)
+# Do NOT add new entries without an accompanying tech-debt-register
+# ticket and an inline rationale.
+SKIP_SUITES=()
 
 is_skipped() {
   local target="$1"
   local s
+  # Guard for empty array under `set -u` on older bash (3.2 on macOS).
+  [ "${#SKIP_SUITES[@]}" -eq 0 ] && return 1
   for s in "${SKIP_SUITES[@]}"; do
     [ "$s" = "$target" ] && return 0
   done


### PR DESCRIPTION
## Summary

TD-020 sweep — resolves the four bats suites that were permanently
excluded from the release-validation gate via `SKIP_SUITES` in
`plugins/vsdd-factory/tests/run-all.sh`. After this PR the
`SKIP_SUITES` array is **empty** and `./run-all.sh` is fully green.

## Per-suite outcomes

### `codify-lessons` — FIXED (15/15 pass)

- **Removed** `BC-5.36.007` ("all three agents updated in the
  delivery branch"). It hard-coded a `cd` into
  `.worktrees/codify-lessons`, which no longer exists post-merge —
  the assertion was structurally impossible to satisfy. The contract
  it tried to verify (agents updated) is still covered by
  `BC-5.36.001`–`006` which inspect the merged files directly.
- **Path-portability fix:** the suite used
  `plugins/vsdd-factory/agents/...`-style paths that only resolved
  when bats was invoked from the repo root. `run-all.sh` does
  `cd $PLUGIN_ROOT` before each suite, so the paths broke when the
  suite was un-skipped. Rewrote all 15 path references to use
  `$BATS_TEST_DIRNAME`-rooted absolute paths (same pattern as
  state-health.bats and other suites).

### `generate-registry` — UN-SKIPPED, no test changes (6/6 pass)

The migration generator stabilized after the original TD-016 churn.
All invariant tests now pass:

- generator runs without errors
- idempotent across two runs
- every script under `hooks/` appears exactly once in the registry
- every gate hook entry has `on_error = block`
- every entry routes through `legacy-bash-adapter.wasm`
- registry parses through dispatcher's `Registry::load`

### `novelty-assessment` — FIXED (15/15 pass after deletions)

Three tests deleted because they asserted hook behavior the current
`validate-novelty-assessment.sh` does not implement:

1. **"validates adversarial-delta-review files"** — asserted the
   hook would block `.factory/phase-f5-adversarial/adversarial-delta-review.md`.
   The case-statement matcher only covers
   `.factory/specs/adversarial-*review*.md`. Adding a matcher entry
   would be new functionality (out of scope for TD-020 cleanup);
   per task constraints, the test asserted behavior production
   doesn't have, so it was removed.
2. **"validates story adversarial review files"** — asserted a path
   `.factory/stories/adversarial-reviews/` that is not used anywhere
   in the current plugin (zero grep hits). Per-story adversarial
   review is not part of the current artifact tree.
3. **"valid delta review passes"** — passed only because the
   un-matched path falls through to `exit 0`, giving a misleading
   signal. With its negative-path partner removed, this happy-path
   test was a false-positive.

CHANGELOG entry under `## Unreleased` documents these deletions.

### `state-health` — UN-SKIPPED, no test changes (31/31 pass)

The skipped state was stale. All referenced skills/commands
(`check-state-health`, `compact-state`, `state-manager`,
`state-template`) exist in the current plugin layout. All 31 tests
pass:

- 11 state-size hook tests (line-budget warn/block thresholds)
- 8 state-health skill content checks
- 6 state-manager content-routing rule checks
- 6 state-template structural checks

## SKIP_SUITES post-sweep

`SKIP_SUITES=()` — empty. The descriptive comment block above the
array (lines 31-48 pre-sweep) was rewritten to reflect the new
zero-skip state. Added a guard in `is_skipped()` for empty arrays
under `set -u` on bash 3.2 (macOS).

## Companion factory-artifacts commit

`tech-debt-register.md` updated on the `factory-artifacts` orphan
branch (commit `477f516`) to mark TD-020 RESOLVED with per-suite
outcomes recorded in the resolution-history table.

## Test plan

- [x] `cd plugins/vsdd-factory/tests && ./run-all.sh` — green, no
      skipped suites
- [x] Each affected suite verified individually:
  - `bats plugins/vsdd-factory/tests/codify-lessons.bats` — 15/15
  - `bats plugins/vsdd-factory/tests/generate-registry.bats` — 6/6
  - `bats plugins/vsdd-factory/tests/novelty-assessment.bats` — 15/15
  - `bats plugins/vsdd-factory/tests/state-health.bats` — 31/31
- [x] No production code (crates/, hooks/, bin/) modified — test-file
      and `run-all.sh` cleanup only