### PR TITLE
fix(state-manager): TD-VSDD-053 — retire two-commit burst protocol (single-commit)

### DIFF
--- a/plugins/vsdd-factory/agents/state-manager.md
+++ b/plugins/vsdd-factory/agents/state-manager.md
@@ -131,7 +131,7 @@ Read and follow the output format in:
 When the orchestrator sends you an update:
 
 1. **Phase transition:** Update the Phase Progress table row. One-line change.
-2. **Burst complete:** Append burst narrative to `cycles/<cycle>/burst-log.md`. Update Current Phase Steps in STATE.md (keep last 5 only, archive older rows to burst-log). For wave-gate remediation bursts that touch STATE.md + SESSION-HANDOFF.md + wave-state.yaml together, follow the **Single Canonical SHA + Two-Commit Protocol** (see "Wave-gate remediation bursts" below). Use the `vsdd-factory:state-burst` skill — it wraps the protocol with verification and refuses known anti-patterns.
+2. **Burst complete:** Append burst narrative to `cycles/<cycle>/burst-log.md`. Update Current Phase Steps in STATE.md (keep last 5 only, archive older rows to burst-log). For wave-gate remediation bursts that touch STATE.md + SESSION-HANDOFF.md + wave-state.yaml together, follow the **Single-Commit Burst Protocol** (TD-VSDD-053; see "Wave-gate remediation bursts" below). Use the `vsdd-factory:state-burst` skill — it wraps the protocol with verification and refuses known anti-patterns.
 3. **Adversary pass complete:** Append pass summary to `cycles/<cycle>/convergence-trajectory.md`. Update the Phase Progress Finding Progression column in STATE.md with the trajectory shorthand (e.g., `29→24→21→7→4→3`). Update convergence counter.
 4. **Lesson learned:** Append to `cycles/<cycle>/lessons.md`. Do NOT append to STATE.md.
 5. **Blocking issue resolved:** Move from STATE.md Blocking Issues to `cycles/<cycle>/blocking-issues-resolved.md`.
@@ -186,20 +186,37 @@ change complete" after updating only 2 of 4 index files.
 
 When committing a remediation burst to factory-artifacts that updates
 STATE.md + SESSION-HANDOFF.md + wave-state.yaml together, you MUST follow
-the **Single Canonical SHA + Two-Commit Protocol** via the
-`vsdd-factory:state-burst` skill. Anti-patterns that have caused 6+
-consecutive defect recurrences in real-world dogfood:
+the **Single-Commit Burst Protocol** via the `vsdd-factory:state-burst`
+skill. The protocol is a single atomic commit; the prior two-commit
+(Stage 1 + Stage 2 backfill) protocol was retired by TD-VSDD-053 because
+it was self-referential — Stage 2 wrote the Stage 1 SHA into the same
+content that just got committed, creating "fix-the-fix" loops when any
+of 8 cite locations was missed (manifested 6× in one session,
+5+ force-pushes).
+
+**How to know "the current factory-artifacts HEAD SHA":** STATE.md no
+longer cites it. Run `git -C .factory log -1 --format='%h %s'` (or
+`--format='%H'` for the full SHA). Git itself owns that data; no
+artifact prose claims it. Historical SHA references in changelog rows,
+decisions log, and cycle manifests remain valid — those point at PAST
+burst SHAs which are immutable audit trail.
+
+Anti-patterns that have caused defect recurrences in real-world dogfood:
 
 1. ❌ Writing narrative in "Pass N BLOCKED — REMEDIATION IN PROGRESS"
    voice. Always write past-tense "REMEDIATED — Awaiting Pass N+1" voice
    as if the burst has already completed.
-2. ❌ Citing intermediate burst SHAs (Stage 1 SHA, hook-fix SHA) in any
-   document during the burst. Use ONLY the literal `15fa97e6` placeholder
-   in Stage 1; replace globally in Stage 2.
-3. ❌ Adding a 3rd commit. If you need to fix the hook or any factory
-   tool mid-burst, fold it into commit 1.
-   `verify-sha-currency.sh` reports `MULTI_COMMIT_CHAIN_NOT_ALLOWED` if
-   HEAD and HEAD^ both contain `backfill`.
+2. ❌ Citing the current factory-artifacts HEAD SHA inside STATE.md or
+   SESSION-HANDOFF.md "current state" sections. Per TD-VSDD-053, the
+   current HEAD is `git -C .factory log -1`, not a string in any
+   artifact. Historical SHAs in changelog/decisions-log rows remain
+   normal (those reference PAST burst SHAs and are immutable).
+3. ❌ Reintroducing "backfill" commits. The single-commit protocol does
+   not use them. `verify-sha-currency.sh` reports
+   `MULTI_COMMIT_CHAIN_NOT_ALLOWED` if HEAD and HEAD^ both contain
+   `backfill` — that means the retired two-commit pattern was
+   accidentally reintroduced; recover with
+   `git -C .factory reset --soft HEAD~2` and re-author as one commit.
 4. ❌ Skipping post-push hook verification. The hook must `PASS` after
    every push, not just before.
 5. ❌ Updating one document (e.g., wave-state.yaml) without sweeping the

--- a/plugins/vsdd-factory/skills/state-burst/SKILL.md
+++ b/plugins/vsdd-factory/skills/state-burst/SKILL.md
@@ -1,32 +1,50 @@
 ---
 name: state-burst
-description: Execute the Single Canonical SHA + Two-Commit Protocol for state-manager remediation bursts. Refuses 3rd-commit chains, in-progress narrative voice, and unbackfilled placeholders. Eliminates the SHA-drift / narrative-staleness defect class.
+description: Execute the Single-Commit Burst Protocol (TD-VSDD-053) for state-manager remediation bursts. One atomic commit per burst — no Stage 2 backfill, no SHA placeholder, no chain. Refuses in-progress narrative voice and reintroduction of the retired two-commit pattern.
 disable-model-invocation: false
 allowed-tools: Read, Write, Edit, Bash
 ---
 
-# State-Burst Protocol
+# State-Burst Protocol (Single-Commit)
 
-This skill executes the canonical state-manager remediation burst safely. It
-is the structural fix for a defect class that produced **6 consecutive
-recurrences** in real-world dogfood (see
+This skill executes the canonical state-manager remediation burst safely.
+
+## History
+
+This skill previously implemented the two-commit "Single Canonical SHA +
+Stage 2 Backfill" protocol. That pattern was self-referential: STATE.md
+sits ON the factory-artifacts branch, so committing STATE.md changes
+HEAD, instantly staling any HEAD-SHA cite inside the same content. The
+two-commit workaround (Stage 1 placeholder → commit → Stage 2 backfill
+SHA → commit) created "fix-the-fix" loops when any of 8 cite locations
+was missed, manifesting **6 consecutive recurrences in one session
+costing 5+ force-pushes** (see
 `docs/lessons-learned/wave-gate-bookkeeping.md`).
+
+TD-VSDD-053 (2026-05-04) retired the two-commit protocol by removing
+the self-referential cite altogether: STATE.md and SESSION-HANDOFF.md
+no longer claim the current factory-artifacts HEAD SHA in their
+"current state" sections. Git itself owns that data — run
+`git -C .factory log -1 --format='%h %s'` for it. Historical SHA
+references in changelog rows, decisions log, and cycle manifests remain
+valid (immutable PAST burst SHAs).
 
 ## Announce at Start
 
 Before any other action, say verbatim:
 
-> I'm using the state-burst skill to execute the Single Canonical SHA +
-> Two-Commit Protocol for this remediation burst. Stage 1 will write all
-> fixes with the `15fa97e6` placeholder; Stage 2 will backfill the real
-> SHA via global replace. No 3rd commit is permitted.
+> I'm using the state-burst skill to execute the Single-Commit Burst
+> Protocol for this remediation burst. One atomic commit; no Stage 2
+> backfill; no SHA placeholder. The current factory-artifacts HEAD SHA
+> is not cited in STATE.md/HANDOFF.md "current state" sections.
 
 ## When to use
 
-- You are remediating findings from an adversarial pass (Phase 3 wave-gate
-  convergence, or any analogous gate that produces a per-pass review).
-- You need to update STATE.md, SESSION-HANDOFF.md, and wave-state.yaml in
-  lockstep with a single commit's SHA.
+- You are remediating findings from an adversarial pass (Phase 3
+  wave-gate convergence, or any analogous gate that produces a per-pass
+  review).
+- You need to update STATE.md, SESSION-HANDOFF.md, and wave-state.yaml
+  in lockstep with a single commit.
 - You're committing to the `factory-artifacts` branch (not `develop`).
 
 If you only need to update one of those files for non-burst bookkeeping
@@ -35,7 +53,7 @@ update protocol — this skill is overkill.
 
 ## Pre-burst hygiene
 
-Run before invoking Stage 1:
+Run before applying any changes:
 
 ```bash
 git -C .factory status
@@ -46,11 +64,8 @@ If there are unrelated modifications (sidecar logs, etc.):
 - Stash them with `git -C .factory stash push -u`.
 
 Pre-existing modifications **must not** contaminate the burst commit.
-The recovery procedure (`git reset --soft HEAD~3` + manual unstage) is
-spelled out in `templates/state-manager-checklist-template.md` if this
-hygiene step is skipped.
 
-## Stage 1 — Apply fixes with placeholder
+## Apply changes (single atomic commit)
 
 Apply every change required by the
 [State-Manager Checklist](../../templates/state-manager-checklist-template.md):
@@ -58,8 +73,11 @@ Apply every change required by the
 1. **Remediation deltas** to source/spec files closing the adversarial
    findings.
 2. **STATE.md** updates:
-   - Frontmatter `adversary_<wave>_pass_N_<gate>` entry with
-     `remediation_sha: 15fa97e6` (literal placeholder).
+   - Frontmatter `adversary_<wave>_pass_N_<gate>` entry (with
+     `remediation_sha:` if your project still uses that field for
+     historical record — that field is OK because once written it
+     points at THIS burst's commit and never gets re-cited; future
+     bursts add new entries, never modify this one).
    - Frontmatter `convergence_status` advanced to the
      `*_REMEDIATED_AWAITING_PASS_N+1` form (or `_CLEAN_WINDOW_K_OF_3`,
      `_CONVERGED`).
@@ -68,14 +86,26 @@ Apply every change required by the
    - Body table rows updated.
    - Session Resume Checkpoint replaced with current snapshot.
    - Version bumped (X.Y → X.Y+1).
-3. **SESSION-HANDOFF.md** updates:
-   - `factory-artifacts HEAD: 15fa97e6` (placeholder).
-   - `develop HEAD` set to the actual current develop SHA.
+   - **DO NOT** cite the current factory-artifacts HEAD SHA anywhere in
+     "current state" prose. It's `git -C .factory log -1` — git owns it.
+3. **SESSION-HANDOFF.md** updates (if your project uses it):
+   - `develop HEAD` set to the actual current develop SHA (cross-branch
+     cite — fine, no loop).
    - PR / story / test counts current.
    - Next-session priority outcome-neutral.
-4. **wave-state.yaml** updates:
-   - `<wave>.gate_pass_N` record with `remediation_sha: 15fa97e6`
-     placeholder.
+   - **DO NOT** cite the current factory-artifacts HEAD anywhere.
+4. **wave-state.yaml** updates (write the eventual SHA AFTER the commit
+   exists is no longer needed — see Stage-2-retirement note below):
+   - `<wave>.gate_pass_N` record (the `remediation_sha:` field, if
+     present, gets the SHA of the commit you're about to make; you
+     can't know this in advance under the single-commit model. Two
+     options:
+     (a) Omit the SHA field for this burst — wave-state.yaml records
+         only that pass N happened, and the historical lookup uses
+         `git log` to map pass→commit by date/message.
+     (b) Pre-compute the SHA via `git commit-tree` dry-run and write
+         it before the actual commit. Most projects pick (a) — it
+         avoids the loop AND the pre-compute complexity.
    - `<wave>.gate_status` updated.
    - `<wave>.notes` extended.
    - `next_gate_required` advanced.
@@ -85,97 +115,51 @@ Write all narrative as if the burst has already completed. ❌ Never
 "REMEDIATION IN PROGRESS" or "this burst remediates…". ✅ Always
 "REMEDIATED — Awaiting Pass N+1".
 
-When Stage 1 is staged:
+## Commit
+
+When all changes are staged:
 
 ```bash
 git -C .factory add -A
 git -C .factory commit -m "fix(<wave>): close pass N findings — REMEDIATED awaiting pass N+1"
 ```
 
-The commit message must NOT contain the word `backfill` (Stage 2 owns
-that token).
+The commit message must NOT contain the word `backfill` (that token is
+reserved for the retired Stage 2 pattern; using it would trigger
+`MULTI_COMMIT_CHAIN_NOT_ALLOWED` if any subsequent commit also uses it).
 
-### Stage 1 verification
+## Verification
 
-Before declaring Stage 1 done, run:
-
-```bash
-bash .factory/hooks/verify-sha-currency.sh
-```
-
-The hook will report STALE on the `15fa97e6` placeholder cites — that is
-expected and the two-commit-protocol exception will accept it during
-Stage 2. What you're checking now is:
-
-- `develop` SHA is current
-- No tense-flip WARN
-- No multi-commit chain WARN
-- No fabricated SHA cites
-
-If Stage 1 verification surfaces issues other than the `15fa97e6`
-placeholder, fix them before committing — or `git reset --soft HEAD` and
-redo.
-
-## Stage 2 — Global SHA replace + backfill commit
-
-Read Stage 1's SHA:
-
-```bash
-STAGE1_SHA=$(git -C .factory rev-parse HEAD | cut -c1-8)
-```
-
-Globally replace the placeholder. Use a portable invocation:
-
-```bash
-# macOS BSD sed (use -i.bak suffix)
-for f in .factory/STATE.md .factory/SESSION-HANDOFF.md .factory/wave-state.yaml; do
-  sed -i.bak "s/15fa97e6/$STAGE1_SHA/g" "$f" && rm "${f}.bak"
-done
-
-# Or, on GNU sed (Linux):
-# sed -i "s/15fa97e6/$STAGE1_SHA/g" .factory/STATE.md .factory/SESSION-HANDOFF.md .factory/wave-state.yaml
-```
-
-Verify exactly one SHA value is now cited:
-
-```bash
-grep -oE "[0-9a-f]{8}" .factory/STATE.md .factory/SESSION-HANDOFF.md .factory/wave-state.yaml \
-  | sort -u | grep -v -E "(develop SHA values, listed separately)"
-```
-
-Commit Stage 2 with `backfill` in the message:
-
-```bash
-git -C .factory add -A
-git -C .factory commit -m "chore(<wave>): backfill stage-1 SHA $STAGE1_SHA into pass-N records"
-```
-
-### Stage 2 verification
-
-Run the hook again:
+Run the hook:
 
 ```bash
 bash .factory/hooks/verify-sha-currency.sh
 ```
 
-Must report `PASS`. If FAIL:
+Must report `PASS`. The hook now checks:
+- `develop` SHA cited in STATE.md/HANDOFF.md matches actual develop HEAD
+  (cross-branch cite — no loop)
+- No `MULTI_COMMIT_CHAIN_NOT_ALLOWED` (the chain-shape regression guard)
+- Cross-record agreement between wave-state.yaml `gate_pass_N`
+  remediation_sha entries and STATE.md frontmatter (if both record the
+  same SHA, they must agree)
+- No tense-flip in active-pass narrative (advisory)
+
+If FAIL:
 - Inspect the failure message.
-- DO NOT add a third commit. Instead:
+- DO NOT add a second commit. Instead:
   ```bash
-  git -C .factory reset --soft HEAD~2
+  git -C .factory reset --soft HEAD
   ```
-  then redo from Stage 1.
+  then re-edit and re-commit.
 
 ## Push
-
-Both commits get pushed together:
 
 ```bash
 git -C .factory push origin factory-artifacts
 ```
 
-After push, run the hook one more time to catch any push-side issues
-(branch protection rejecting the bot, etc.):
+After push, run the hook one more time to catch any push-side issues:
 
 ```bash
 bash .factory/hooks/verify-sha-currency.sh
@@ -183,16 +167,13 @@ bash .factory/hooks/verify-sha-currency.sh
 
 ## Anti-patterns this skill blocks
 
-The skill refuses to proceed if any of these conditions are detected:
-
 | Anti-pattern | Detection | Recovery |
 |--------------|-----------|----------|
-| 3rd commit on the burst chain | `verify-sha-currency.sh` reports `MULTI_COMMIT_CHAIN_NOT_ALLOWED` | `git reset --soft HEAD~2` + redo Stage 1 |
-| Unbackfilled placeholder after Stage 2 | `grep 15fa97e6 .factory/STATE.md` returns hits | Re-run the global `sed` |
-| In-progress voice in narrative | Hook tense-flip WARN | Edit narrative to past-tense before Stage 2 push |
-| Stage 1 commit message contains `backfill` | Hook two-commit exception fails | Amend Stage 1 commit message |
-| Stage 1 SHA does not exist as a git object | Hook FABRICATED warning | Investigate — usually means a typo in Stage 2 sed |
+| Reintroducing two-commit chain (HEAD and HEAD^ both contain `backfill`) | `verify-sha-currency.sh` reports `MULTI_COMMIT_CHAIN_NOT_ALLOWED` | `git reset --soft HEAD~2` + re-author as one commit |
+| Citing current factory-artifacts HEAD SHA in STATE.md/HANDOFF.md "current state" sections | Code review / per-burst editor discipline (the hook no longer enforces this since the cite is gone) | Edit out the cite; replace with "see `git -C .factory log -1`" if guidance is needed |
+| In-progress voice in narrative | Hook tense-flip WARN | Edit narrative to past-tense before push |
 | Cross-record SHA drift between STATE.md and wave-state.yaml | Hook DRIFT report | Fix the disagreeing record (per Schema Semantics in checklist) |
+| Develop SHA in STATE.md does not match actual develop HEAD | Hook FAIL | Update the develop cite to the current develop HEAD |
 
 ## When to bypass
 
@@ -210,6 +191,5 @@ In both cases, document the bypass reason in
 - Checklist: `templates/state-manager-checklist-template.md`
 - Hook: `templates/verify-sha-currency.sh`
 - Case study: `docs/lessons-learned/wave-gate-bookkeeping.md`
-- Originating defect class: a 6-recurrence wave-gate convergence cycle
-  whose Pass 7 finally executed clean under this protocol. The case
-  study doc enumerates each recurrence and root cause.
+- TD: TD-VSDD-053 (single-commit protocol replacing two-commit; resolves
+  TD-VSDD-044 self-referential-cite loop)

--- a/plugins/vsdd-factory/templates/state-manager-checklist-template.md
+++ b/plugins/vsdd-factory/templates/state-manager-checklist-template.md
@@ -2,17 +2,38 @@
 
 When remediating findings from an adversarial pass and committing to
 `factory-artifacts`, the state-manager MUST update ALL of the artifacts in
-this checklist as a single burst.
+this checklist as a single atomic burst.
 
 This checklist exists because narrow-scope bursts that miss one or more of
 these items have produced **6+ consecutive defect recurrences** in
 real-world dogfood (see `docs/lessons-learned/wave-gate-bookkeeping.md`
-for the full trajectory). The recurrence stops when the **Single
-Canonical SHA + Two-Commit Protocol** is followed exactly.
+for the full trajectory). The recurrence stops when the **Single-Commit
+Burst Protocol** is followed exactly.
 
 > **Use the `vsdd-factory:state-burst` skill to execute this protocol.** It
 > wraps every step below with verification and refuses to ship known
 > anti-patterns. Manual execution is supported but error-prone.
+
+## History
+
+This checklist previously prescribed a **Single Canonical SHA + Two-Commit
+Protocol** (Stage 1 placeholder → commit → Stage 2 backfill SHA → commit).
+That protocol was self-referential — STATE.md sits ON the factory-artifacts
+branch, so committing STATE.md changes HEAD, instantly staling any
+HEAD-SHA cite inside the same content. Stage 2's backfill had to update
+the SHA in 8 specific cite locations; missing any one created a
+"fix-the-fix" loop. That loop manifested 6× in one session, costing
+5+ force-pushes.
+
+TD-VSDD-053 (2026-05-04) retired the two-commit protocol by removing the
+self-referential cite altogether: STATE.md and SESSION-HANDOFF.md no
+longer claim the current factory-artifacts HEAD SHA in their "current
+state" sections. Git itself owns that data — `git -C .factory log -1`
+returns the current HEAD. Historical SHA references in changelog rows,
+decisions log, and cycle manifests remain valid (immutable past burst
+SHAs).
+
+This checklist is now single-commit only.
 
 ---
 
@@ -26,21 +47,34 @@ Replace `<WAVE>` with the active wave (e.g. `wave_1`, `wave_1_5`,
 - [ ] **`<WAVE>.gate_status:`** — update to
   `integration_gate_pass_N_remediated_awaiting_pass_N+1` (or analogous
   string for non-integration gates).
-- [ ] **Add `<WAVE>.gate_pass_N:` record** with all required fields:
+- [ ] **Add `<WAVE>.gate_pass_N:` record** with all required fields
+  EXCEPT `remediation_sha` (see below):
   ```yaml
   gate_pass_N:
     verdict: BLOCKED|CLEAN
     findings: <int>
     remediated: <int>
-    remediation_sha: <SHA or 15fa97e6 placeholder>
     timestamp: YYYY-MM-DD
     passed: true|false
   ```
+- [ ] **`remediation_sha:` field handling.** Two acceptable patterns:
+  - **(a) Omit the field for THIS burst.** Look up pass→commit mapping
+    later via `git log --all --oneline | grep "pass N"`. Simplest; no
+    self-reference; recommended for new projects. Historical pass
+    records (entries written by EARLIER bursts) keep their
+    `remediation_sha` values — those are immutable history.
+  - **(b) Write the field POST-COMMIT in a follow-up amendment.** After
+    the single-commit burst lands, run a separate small commit that
+    fills `remediation_sha:` for the just-completed pass with that
+    commit's SHA. This creates a 2-commit chain ONLY when the
+    record-keeping is critical AND the operator accepts the chain
+    explicitly. NOT the default.
 - [ ] **Extend `<WAVE>.notes:`** with a paragraph describing Pass N:
-  outcome, findings, remediation SHA, what was fixed.
-- [ ] **Verify no placeholders remain** before pushing Stage 2:
+  outcome, findings, what was fixed. Reference the commit by message
+  not SHA where possible.
+- [ ] **Verify no in-progress placeholders** before pushing:
   ```bash
-  grep -E "TBD|TODO|FIXME|this_burst|XXX|backfill" .factory/wave-state.yaml
+  grep -E "TBD|TODO|FIXME|this_burst|XXX" .factory/wave-state.yaml
   # Must return empty.
   ```
 - [ ] **Verify pass record count** matches current pass:
@@ -50,42 +84,37 @@ Replace `<WAVE>` with the active wave (e.g. `wave_1`, `wave_1_5`,
 
 ---
 
-## Single Canonical SHA Rule (mandatory)
+## Single-Commit Burst Rule (mandatory)
 
-A burst MUST reference exactly ONE SHA value across ALL documents.
+A burst is exactly ONE commit on factory-artifacts. No Stage 2 backfill.
+No SHA placeholder. No 2-commit chain.
 
-1. **Stage 1 (commit 1):** Apply ALL fixes — documents, narrative,
-   frontmatter, wave-state.yaml, hook updates, checklist updates — using
-   the literal placeholder `15fa97e6` everywhere a SHA is needed. Write
-   narrative in **past-tense / "REMEDIATED" voice** from the start. Never
-   "in progress" voice. Commit with a normal fix-commit message.
-2. **Stage 2 (commit 2):** Read commit 1's SHA via
-   `git -C .factory rev-parse HEAD`. Globally replace `15fa97e6` with that
-   SHA across STATE.md, SESSION-HANDOFF.md, and wave-state.yaml. Commit
-   message MUST contain the word `backfill`. Push both commits.
-3. **NO third commit.** If you discover a missed fix after Stage 2:
-   ```bash
-   git -C .factory reset --soft HEAD~2
-   ```
-   then redo from Stage 1. Force-push requires human approval.
+- Apply ALL fixes (documents, narrative, frontmatter, wave-state.yaml,
+  hook updates, checklist updates) in one staged change.
+- Write narrative in **past-tense / "REMEDIATED" voice** from the start.
+  Never "in progress" voice.
+- Commit with a normal fix-commit message — must NOT contain the word
+  `backfill`. (That token is reserved for the retired Stage 2 pattern;
+  using it would trigger `MULTI_COMMIT_CHAIN_NOT_ALLOWED` if a
+  subsequent commit also uses it.)
+- If you discover a missed fix:
+  ```bash
+  git -C .factory reset --soft HEAD
+  ```
+  then re-edit and re-commit.
 
-**Why not per-document SHA writes:** Writing SHAs document-by-document
-during the burst creates a SHA chain where each intermediate commit is
-cited somewhere. The recurring drift had this root cause. The placeholder
-+ global replace approach guarantees exactly one SHA value is cited: the
-Stage 1 commit.
-
-**Exactly-2-commit-chain rule** (enforced by `verify-sha-currency.sh`):
-- HEAD's commit message contains `backfill` (Stage 2 marker), AND
-- HEAD^'s commit message does NOT contain `backfill` (Stage 1 must be
-  the fix, not another backfill).
-- If HEAD^ also contains `backfill`: `MULTI_COMMIT_CHAIN_NOT_ALLOWED`.
+**`MULTI_COMMIT_CHAIN_NOT_ALLOWED` regression guard** (enforced by
+`verify-sha-currency.sh`):
+- HEAD's commit message contains `backfill` AND HEAD^'s also contains
+  `backfill` → FAIL. This means the retired two-commit pattern was
+  accidentally reintroduced. Recover with `git reset --soft HEAD~2` and
+  re-author as one commit.
 
 ---
 
 ## Tense Flip Rule
 
-Stage 1 writes the narrative as if the burst has already completed. Pass
+Burst narrative is written as if the burst has already completed. Pass
 N+1 is the future event, not the burst itself.
 
 ❌ Wrong (recurred across three consecutive passes in the originating
@@ -94,9 +123,8 @@ case study):
 > "this burst remediates findings from..."
 
 ✅ Right (Pass 7 clean form):
-> "Pass N — REMEDIATED. Findings closed at SHA 15fa97e6. Awaiting Pass
-> N+1 (if CLEAN, 1st of 3 clean-pass window opens; if BLOCKED, remediate
-> + Pass N+1)."
+> "Pass N — REMEDIATED. Findings closed. Awaiting Pass N+1 (if CLEAN,
+> 1st of 3 clean-pass window opens; if BLOCKED, remediate + Pass N+1)."
 
 The `verify-sha-currency.sh` hook surfaces tense-flip violations as WARN
 (not FAIL) so you can choose strict-mode enforcement at the pre-push
@@ -107,7 +135,8 @@ boundary.
 ## STATE.md Bookkeeping
 
 - [ ] **Frontmatter `adversary_<wave>_pass_N_<gate>:`** — add new entry
-  with `{passed, findings, remediated, remediation_sha, timestamp}`.
+  with `{passed, findings, remediated, timestamp}`. Same `remediation_sha`
+  guidance as wave-state.yaml above.
 - [ ] **Frontmatter `convergence_status:`** — advance to one of:
   - `<PHASE>_<WAVE>_GATE_PASS_N_REMEDIATED_AWAITING_PASS_N+1` (verdict
     BLOCKED)
@@ -129,19 +158,23 @@ boundary.
   (outcome-neutral next-steps); archive old to
   `cycles/<cycle>/session-checkpoints.md`.
 - [ ] **Version bump** — minor for normal burst (X.Y → X.Y+1).
+- [ ] **DO NOT** cite the current factory-artifacts HEAD SHA anywhere
+  in "current state" prose — there is no such cite under TD-VSDD-053.
+  Use `git -C .factory log -1` to look up the current SHA.
 
 ---
 
-## SESSION-HANDOFF.md
+## SESSION-HANDOFF.md (if your project uses it)
 
-- [ ] **Verify `develop HEAD`** is current.
+- [ ] **Verify `develop HEAD`** is current. (Cross-branch cite — fine,
+  no loop. The hook validates this.)
 - [ ] **Verify PR / story-merged counts** are current.
 - [ ] **Verify test counts** are current.
 - [ ] **Next session priority** uses outcome-neutral language.
 - [ ] **No references** to in-progress work that is now complete.
-- [ ] **`factory-artifacts HEAD`** must be a concrete SHA — never
-  `(current after this burst)`, `TBD`, or any placeholder string. Use
-  `15fa97e6` in Stage 1 and the global-replace pattern in Stage 2.
+- [ ] **DO NOT** cite the current factory-artifacts HEAD SHA. Per
+  TD-VSDD-053, the factory-artifacts HEAD is `git -C .factory log -1`,
+  not a string in any artifact.
 
 ---
 
@@ -160,47 +193,46 @@ originating case study. Use neutral framing always.
 
 ## Schema Semantics: `remediation_sha` for multi-pass closures
 
-When a burst closes findings from MULTIPLE prior passes (because earlier
-remediation was incomplete), each affected pass record's
-`remediation_sha` is set to the SHA of the **closing burst's Stage 1
-commit**. Subsequent re-closures DO NOT advance the SHA backward.
+Historical pass records keep their original `remediation_sha` values
+(immutable). Subsequent re-closures DO NOT advance the SHA backward.
 
 Example:
-- Pass 3 was incompletely remediated at SHA `b1b145b3` (Stage 2 tense-flip
-  skipped).
-- Pass 4 burst at SHA `99563fd1` closes both Pass 3 leftovers AND Pass 4
-  findings.
-- `gate_pass_3.remediation_sha` stays `b1b145b3` (where Pass 3 was first
-  remediated, even partially).
-- `gate_pass_4.remediation_sha` is `99563fd1`.
-- Pass 4's `notes` field documents that `99563fd1` also closed Pass 3
-  leftovers.
+- Pass 3 was incompletely remediated; the original `gate_pass_3.remediation_sha`
+  was set under the prior two-commit protocol and remains as historical
+  record.
+- Pass 4 burst closes both Pass 3 leftovers AND Pass 4 findings under the
+  new single-commit protocol.
+- `gate_pass_3.remediation_sha` stays at its historical value (immutable).
+- `gate_pass_4.remediation_sha` is omitted under pattern (a), or filled
+  via post-commit amendment under pattern (b).
+- Pass 4's `notes` field documents that the Pass 4 burst also closed
+  Pass 3 leftovers.
 
 The `verify-sha-currency.sh` hook's cross-record check enforces that
 STATE.md frontmatter `remediation_sha` agrees with wave-state.yaml's
-`gate_pass_N.remediation_sha` for every pass.
+`gate_pass_N.remediation_sha` for every pass that has the field set in
+both places.
 
 ---
 
 ## Pre-Burst Hygiene
 
-Before starting Stage 1, run `git -C .factory status`. If unrelated files
-are modified (sidecar logs, etc.), either commit them separately first or
-stash them. Pre-existing modifications must NOT contaminate the burst
-commit.
+Before starting the burst, run `git -C .factory status`. If unrelated
+files are modified (sidecar logs, etc.), either commit them separately
+first or stash them. Pre-existing modifications must NOT contaminate the
+burst commit.
 
 ---
 
 ## Verification Commands
 
-Run these in sequence before pushing Stage 2:
+Run these in sequence before pushing:
 
 ```bash
 # 1. SHA currency + burst hygiene (encapsulates 90% of the checks below)
 bash .factory/hooks/verify-sha-currency.sh
 
-# 2. No placeholders in wave-state.yaml (Stage 2 only — Stage 1 expected
-#    to have them)
+# 2. No in-progress placeholders in wave-state.yaml
 grep -E "TBD|TODO|FIXME|this_burst|XXX" .factory/wave-state.yaml
 
 # 3. Pass record count matches current pass
@@ -211,44 +243,57 @@ grep "next_gate_required:" .factory/wave-state.yaml
 
 # 5. STATE.md version bumped
 grep "^version:" .factory/STATE.md
+
+# 6. No accidental factory-artifacts HEAD self-cite
+#    (per TD-VSDD-053 — STATE.md no longer cites its own branch HEAD)
+grep -E "factory-artifacts HEAD\W+\`?[0-9a-f]{8}" .factory/STATE.md \
+  .factory/SESSION-HANDOFF.md 2>/dev/null
+# Must return empty (or only matches inside the historical Changelog
+# section — those are PAST burst SHAs and are immutable).
 ```
 
 ---
 
 ## Recovery Procedures
 
-### A 3rd commit accidentally landed during Stage 1
+### A 2nd commit accidentally landed during the burst
 
 1. `git -C .factory log --oneline -5` — inspect the chain.
 2. `git -C .factory reset --soft HEAD~N` — N = number of accidental
-   commits.
+   extra commits.
 3. `git -C .factory status` — inspect ALL staged files.
 4. **Unstage anything this burst did not author** (e.g., session
    sidecar logs).
-5. Re-commit Stage 1 cleanly.
+5. Re-commit cleanly as one commit.
 
-### Stage 2 was already pushed when drift surfaces
+### The burst was already pushed when drift surfaces
 
 `git push --force-with-lease` requires human approval. Confirm before
 proceeding. Document the episode in `SESSION-HANDOFF.md` "Recent Burst
-Episodes" section.
+Episodes" section if your project uses one.
 
 ---
 
-## Failure Modes Observed (originating dogfood case study)
+## Failure Modes Observed (originating dogfood case study, retained for
+historical context)
 
-| Pass | What Was Missed | Root Cause |
-|------|-----------------|------------|
-| 1 | develop_head stale post-PR merge | Hook only checked factory-artifacts HEAD |
-| 2 | Tense-flip in Stage 1 commit | No checklist forcing past-tense voice |
-| 3 | Hook fired pre-push but missed multi-commit chain | Hook scope too narrow |
-| 4 | Burst chain extended to 4 commits | Multi-commit detection missing |
-| 5 | Per-document SHA writes fragmented citations | Single Canonical SHA Rule not yet codified |
-| 6 | STATE.md frontmatter pass-3 SHA disagreed with wave-state.yaml | Cross-record verification missing |
-| 7 | (CLEAN) — manual orchestrator execution proved the protocol works | Captured + shipped as this checklist |
+These are the failure modes that drove the original two-commit protocol.
+Most are obviated under the single-commit protocol — they're listed here
+so future maintainers understand why specific defenses still exist.
+
+| Pass | What Was Missed | Root Cause | Status under single-commit |
+|------|-----------------|------------|----------------------------|
+| 1 | develop_head stale post-PR merge | Hook only checked factory-artifacts HEAD | Still relevant — develop SHA cite check preserved |
+| 2 | Tense-flip in Stage 1 commit | No checklist forcing past-tense voice | Still relevant — tense-flip WARN preserved |
+| 3 | Hook fired pre-push but missed multi-commit chain | Hook scope too narrow | Still relevant — MULTI_COMMIT_CHAIN_NOT_ALLOWED preserved |
+| 4 | Burst chain extended to 4 commits | Multi-commit detection missing | Still relevant — MULTI_COMMIT_CHAIN_NOT_ALLOWED preserved |
+| 5 | Per-document SHA writes fragmented citations | Single Canonical SHA Rule not yet codified | Obviated — single-commit means one commit, one inherent SHA |
+| 6 | STATE.md frontmatter pass-3 SHA disagreed with wave-state.yaml | Cross-record verification missing | Still relevant — cross-record check preserved |
+| 7 | (CLEAN) — manual orchestrator execution proved the protocol works | Captured + shipped as the prior two-commit checklist | Replaced by single-commit (TD-VSDD-053) |
 
 Trajectory: **11 → 12 → 10 → 10 → 11 → 7 → 3 (CLEAN)** — six recurrences
-before convergence.
+before convergence under the prior two-commit protocol. The single-commit
+protocol eliminates the self-referential cite class entirely.
 
 ---
 

--- a/plugins/vsdd-factory/templates/verify-sha-currency.sh
+++ b/plugins/vsdd-factory/templates/verify-sha-currency.sh
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
 # verify-sha-currency.sh — state-manager burst hygiene gate
 #
-# Verifies that SHAs cited in .factory/STATE.md and .factory/SESSION-HANDOFF.md
-# are current (match git HEAD), that cross-record SHAs in
-# .factory/wave-state.yaml agree with STATE.md frontmatter, and that the
-# active-pass narrative is in past-tense voice.
+# Verifies cross-branch and cross-record SHA agreement, plus narrative
+# voice on the active pass. Specifically:
+#   - develop SHA cited in STATE.md/HANDOFF.md matches actual develop HEAD
+#     (cross-branch cite — not self-referential, no loop possible)
+#   - Cross-record SHA agreement between wave-state.yaml's gate_pass_N
+#     remediation_sha entries and STATE.md frontmatter
+#   - Multi-commit-chain guard (chains > 2 commits on factory-artifacts)
+#   - Tense-flip detection in active-pass narrative (advisory)
 #
-# Run BEFORE every push to factory-artifacts (Stage 1 of two-commit protocol)
-# AND AFTER (Stage 2 verification). The dispatcher's wave-gate-prerequisite
-# hook calls this automatically, but you can also run it manually:
+# Run as the state-manager burst hygiene gate; safe to invoke manually:
 #
 #   bash .factory/hooks/verify-sha-currency.sh
 #   bash .factory/hooks/verify-sha-currency.sh --project-root /path/to/proj
@@ -17,17 +19,28 @@
 #   0 — PASS (all checks clean)
 #   1 — FAIL (one or more checks detected drift)
 #
-# WARN-level issues (tense-flip, fabricated SHA cites) print to stdout but do
-# NOT fail the run — they're advisory.
+# WARN-level issues (tense-flip) print to stdout but do NOT fail the run.
+#
+# What this hook does NOT verify (TD-VSDD-053 narrowing, 2026-05-04):
+#
+# The hook used to verify that the *current-burst factory-artifacts HEAD* SHA
+# cited inside STATE.md / SESSION-HANDOFF.md matched git HEAD. That check
+# was removed because the cite was self-referential — STATE.md sits on the
+# factory-artifacts branch, so committing STATE.md changes HEAD, instantly
+# staling any HEAD-SHA cite inside the same content. The two-commit protocol
+# (Stage 1 placeholder → commit → Stage 2 backfill SHA → commit) was a
+# workaround that triggered "fix-the-fix" loops when any of 8 cite locations
+# was missed (manifested 6× in one session, 5+ force-pushes). Resolved by
+# removing the cite altogether: STATE.md no longer claims its own SHA;
+# `git -C .factory log -1` is the source of truth. Historical SHA references
+# in changelog rows, decisions log, and cycle manifests remain valid (they
+# point at PAST burst SHAs which are immutable audit trail).
 #
 # History: This hook started as a STATE.md/HANDOFF.md HEAD-currency check
 # during a wave-gate convergence cycle that hit six consecutive recurrences
-# of SHA drift / narrative-staleness. It hardened across each pass:
-#   - Multi-commit-chain guard (chains > 2 commits)
-#   - Single Canonical SHA Rule + 2-commit exception
-#   - Cross-record verification (STATE.md vs wave-state.yaml)
-#   - Tense-flip detection
-# See docs/lessons-learned/wave-gate-bookkeeping.md for the full case study.
+# of SHA drift / narrative-staleness. It hardened across each pass and was
+# narrowed in scope by TD-VSDD-053 (2026-05-04). See
+# docs/lessons-learned/wave-gate-bookkeeping.md for the full case study.
 
 set -euo pipefail
 
@@ -75,7 +88,18 @@ echo "Actual develop HEAD      : $ACTUAL_DEV"
 echo "Actual factory-artifacts : $ACTUAL_FA"
 echo ""
 
-# ---------- Read cited SHAs ----------
+# ---------- Read cited SHAs (cross-branch only — develop) ----------
+#
+# We deliberately do NOT extract the factory-artifacts HEAD SHA from STATE.md
+# or SESSION-HANDOFF.md. Per TD-VSDD-053 (2026-05-04), STATE.md no longer
+# cites its own branch's HEAD — that cite was self-referential and looped.
+# The current factory-artifacts HEAD is `git -C .factory log -1`, not a
+# string in any artifact.
+#
+# We DO extract the develop SHA cite because that's a cross-branch claim
+# (STATE.md sits on factory-artifacts but cites develop); committing STATE.md
+# does not change develop, so the cite is stable across the commit and the
+# loop class doesn't apply.
 
 if [ ! -f "$STATE_MD" ]; then
   echo "FAIL: $STATE_MD missing — state-manager has not initialized?"
@@ -84,26 +108,19 @@ fi
 
 CITED_DEV_STATE=$(grep -oE 'develop_head: "?[0-9a-f]{8,40}' "$STATE_MD" 2>/dev/null \
   | head -1 | grep -oE '[0-9a-f]{8,40}' | cut -c1-8 || echo "NOT_FOUND")
-CITED_FA_STATE=$(grep -oE 'factory-artifacts HEAD[^0-9a-f]*[0-9a-f]{8}' "$STATE_MD" 2>/dev/null \
-  | head -1 | grep -oE '[0-9a-f]{8}' | tail -1 || echo "NOT_FOUND")
 
 if [ -f "$HANDOFF_MD" ]; then
   CITED_DEV_HANDOFF=$(grep -oE 'develop HEAD[^|`]*`?[0-9a-f]{8}' "$HANDOFF_MD" 2>/dev/null \
     | head -1 | grep -oE '[0-9a-f]{8}' | tail -1 || echo "NOT_FOUND")
-  CITED_FA_HANDOFF=$(grep -oE 'factory-artifacts HEAD[^0-9a-f]*[0-9a-f]{8}' "$HANDOFF_MD" 2>/dev/null \
-    | head -1 | grep -oE '[0-9a-f]{8}' | tail -1 || echo "NOT_FOUND")
 else
   CITED_DEV_HANDOFF="NO_HANDOFF"
-  CITED_FA_HANDOFF="NO_HANDOFF"
 fi
 
 echo "STATE.md    develop cited      : $CITED_DEV_STATE"
-echo "STATE.md    factory-arts cited : $CITED_FA_STATE"
 echo "HANDOFF.md  develop cited      : $CITED_DEV_HANDOFF"
-echo "HANDOFF.md  factory-arts cited : $CITED_FA_HANDOFF"
 echo ""
 
-# ---------- develop SHA must match exactly ----------
+# ---------- develop SHA must match exactly (cross-branch cite, no loop) ----------
 
 if [ "$CITED_DEV_STATE" != "NOT_FOUND" ] && [ "$ACTUAL_DEV" != "$CITED_DEV_STATE" ]; then
   echo "FAIL: develop SHA in STATE.md is stale (cited=$CITED_DEV_STATE actual=$ACTUAL_DEV)"
@@ -115,12 +132,13 @@ if [ "$CITED_DEV_HANDOFF" != "NOT_FOUND" ] && [ "$CITED_DEV_HANDOFF" != "NO_HAND
   FAIL=1
 fi
 
-# ---------- Two-commit protocol exception (factory-artifacts SHA) ----------
+# ---------- Multi-commit chain guard (factory-artifacts) ----------
+#
+# The two-commit protocol is retired (TD-VSDD-053) — single-commit bursts
+# only. This guard remains as a regression defense: if any future workflow
+# reintroduces backfill-style chains, fail loudly so the discipline gap is
+# visible immediately.
 
-# Allow 1-commit drift between cited factory-artifacts SHA and HEAD ONLY when:
-#   (a) HEAD's commit message contains "backfill" (Stage 2 marker), AND
-#   (b) HEAD^'s commit message does NOT contain "backfill" (chain is exactly 2)
-# Without (b), the exception masks 3+ commit chain bursts.
 HEAD_MSG=$(git -C "$FACTORY_DIR" log -1 --format=%s 2>/dev/null || echo "")
 PARENT_MSG=$(git -C "$FACTORY_DIR" log -1 --format=%s HEAD^ 2>/dev/null || echo "")
 HEAD_IS_BACKFILL=0
@@ -130,40 +148,12 @@ echo "$PARENT_MSG" | grep -qi "backfill" && PARENT_IS_BACKFILL=1
 
 if [ "$HEAD_IS_BACKFILL" -eq 1 ] && [ "$PARENT_IS_BACKFILL" -eq 1 ]; then
   echo "FAIL: MULTI_COMMIT_CHAIN_NOT_ALLOWED — HEAD and HEAD^ both contain 'backfill'."
-  echo "      The two-commit protocol permits exactly 1 fix commit + 1 backfill commit."
-  echo "      Recover with: git -C .factory reset --soft HEAD~2 && redo Stage 1 + Stage 2."
+  echo "      The single-commit protocol (TD-VSDD-053) does not use backfill commits."
+  echo "      A 2+ chain of 'backfill' commits suggests reintroduction of the retired"
+  echo "      two-commit pattern. Recover with: git -C .factory reset --soft HEAD~2"
+  echo "      then re-author as a single commit per skills/state-burst/SKILL.md."
   FAIL=1
 fi
-
-# Fabrication check: verify cited SHAs actually exist as git objects.
-for label in "STATE.md:$CITED_FA_STATE" "SESSION-HANDOFF.md:$CITED_FA_HANDOFF"; do
-  doc="${label%%:*}"
-  sha="${label#*:}"
-  [ "$sha" = "NOT_FOUND" ] || [ "$sha" = "NO_HANDOFF" ] && continue
-  if ! git -C "$FACTORY_DIR" cat-file -e "${sha}^{commit}" 2>/dev/null; then
-    echo "WARN: $doc cites factory-artifacts SHA $sha but it does not exist as a git object (FABRICATED?)"
-    WARN=1
-  fi
-done
-
-PARENT_FA=$(git -C "$FACTORY_DIR" rev-parse HEAD^ 2>/dev/null | cut -c1-8 || echo "NO_PARENT")
-
-check_fa_currency() {
-  local doc="$1" cited="$2"
-  [ "$cited" = "NOT_FOUND" ] || [ "$cited" = "NO_HANDOFF" ] && return 0
-  if [ "$ACTUAL_FA" = "$cited" ]; then
-    return 0
-  fi
-  if [ "$PARENT_FA" = "$cited" ] && [ "$HEAD_IS_BACKFILL" -eq 1 ] && [ "$PARENT_IS_BACKFILL" -eq 0 ]; then
-    echo "NOTE: $doc cites HEAD^ ($cited) — within two-commit protocol exception (HEAD is backfill; HEAD^ is not)"
-    return 0
-  fi
-  echo "FAIL: factory-artifacts SHA in $doc is stale (cited=$cited actual=$ACTUAL_FA parent=$PARENT_FA head_is_backfill=$HEAD_IS_BACKFILL parent_is_backfill=$PARENT_IS_BACKFILL)"
-  return 1
-}
-
-check_fa_currency "STATE.md"           "$CITED_FA_STATE"   || FAIL=1
-check_fa_currency "SESSION-HANDOFF.md" "$CITED_FA_HANDOFF" || FAIL=1
 
 # ---------- Cross-record SHA verification (STATE.md ↔ wave-state.yaml) ----------
 


### PR DESCRIPTION
## Summary

Resolves external **TD-VSDD-044** (self-referential factory-artifacts HEAD cite in STATE.md/SESSION-HANDOFF.md "current state" sections caused 6× recurrence loops in real-world dogfood, costing 5+ force-pushes per session) by removing the cite class altogether and converting the state-manager burst to a single atomic commit.

## What was the loop

STATE.md sits ON the factory-artifacts branch. Every time STATE.md was committed, the commit BECAME the new HEAD — instantly staling any HEAD-SHA cite inside the same content. The two-commit workaround (Stage 1 placeholder → commit → Stage 2 backfill SHA → commit) had to update the SHA in 8 specific cite locations in lockstep; missing any one created a "fix-the-fix" loop.

## What was the fix

STATE.md and SESSION-HANDOFF.md no longer cite the current factory-artifacts HEAD anywhere in their "current state" sections. Git itself owns that data — `git -C .factory log -1` returns the current HEAD. Historical SHA references in changelog rows, decisions log, and cycle manifests remain valid (immutable past burst SHAs).

## Files changed (4)

| File | Edit |
|------|------|
| `templates/verify-sha-currency.sh` | Removed factory-arts cite extraction (~80 LOC: CITED_FA_*, fabrication check, check_fa_currency, PARENT_FA). Preserved: develop SHA cite check (cross-branch, no loop), MULTI_COMMIT_CHAIN_NOT_ALLOWED guard, wave-state↔STATE python cross-record check. |
| `agents/state-manager.md` | Protocol references updated; current factory-artifacts HEAD is `git -C .factory log -1` (operational guidance in agent doc, NOT in STATE.md prose). |
| `skills/state-burst/SKILL.md` | Full rewrite to single-commit; Stage 1/2 sections removed; `15fa97e6` placeholder removed; commit message must NOT contain `backfill`. |
| `templates/state-manager-checklist-template.md` | Full rewrite to single-commit; `remediation_sha:` two acceptable patterns (omit-and-look-up vs post-commit amendment). |

## What was NOT touched (preserved)

- `validate-input-hash.sh` — artifact-level drift detection (untouched)
- `validate-state-pin-freshness.sh` — version-pin freshness (untouched)
- Historical SHA references throughout (changelog rows, decisions log, cycle manifests, TL;DR History, BC/story/spec IDs)
- `verify-sha-currency.sh` cross-record drift check (wave-state.yaml ↔ STATE.md) — orthogonal mechanism catching a different drift class

## Test plan

- [x] Bash syntax: `bash -n templates/verify-sha-currency.sh` → OK
- [x] Hook still has all preserved checks: develop cite, MULTI_COMMIT_CHAIN_NOT_ALLOWED, wave-state cross-record, tense-flip
- [x] Zero remaining `CITED_FA*` / `check_fa_currency` / `PARENT_FA` references in active code
- [ ] Wait for CI Semgrep / cargo / lobster / validate
- [ ] Operator-verify single-commit protocol over next 10 wave-gate cycles

## Related

- **TD-023** (factory-artifacts) — engine-fix tracking entry cross-referencing external TD-VSDD-044/053 IDs
- Historical case study: `docs/lessons-learned/wave-gate-bookkeeping.md`
- Will ship in next rc cut