### PR TITLE
fix(generator): vendor legacy hooks.json — unblocks rc.11 retag (TD-VSDD-054)

### DIFF
--- a/scripts/generate-registry-from-hooks-json.sh
+++ b/scripts/generate-registry-from-hooks-json.sh
@@ -10,13 +10,15 @@
 # `[[hooks]]` entry that points at `legacy-bash-adapter.wasm`; the adapter
 # (S-2.1) reads `[hooks.config] script_path` and execs the underlying
 # `*.sh`. This is the migration tool that produces that registry from the
-# pre-templating hooks.json (committed at 7b4b774^ in git history; the
-# current hooks.json is a per-event dispatcher pointer and no longer
-# carries per-hook detail).
+# pre-templating hooks.json — vendored as a static file at
+# `scripts/legacy/hooks-json-pre-templating.json` (the current hooks.json
+# is a per-event dispatcher pointer and no longer carries per-hook
+# detail). Vendoring eliminates the prior git-history dependency that
+# broke under shallow CI clones (TD-VSDD-054, 2026-05-04).
 #
 # Usage:
 #   scripts/generate-registry-from-hooks-json.sh
-#       Read git show 7b4b774^:plugins/vsdd-factory/hooks/hooks.json
+#       Read scripts/legacy/hooks-json-pre-templating.json
 #       Write plugins/vsdd-factory/hooks-registry.toml
 #
 #   scripts/generate-registry-from-hooks-json.sh path/to/hooks.json
@@ -31,7 +33,7 @@
 #   * hooks.json entry references a script that no longer exists on disk
 #   * script on disk has no entry in hooks.json
 #   * jq missing
-#   * git missing (when reading the historical default)
+#   * vendored legacy file missing
 
 set -euo pipefail
 export LC_ALL=C
@@ -39,7 +41,7 @@ export LC_ALL=C
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 HOOKS_DIR="$REPO_ROOT/plugins/vsdd-factory/hooks"
 OUT_FILE="$REPO_ROOT/plugins/vsdd-factory/hooks-registry.toml"
-HISTORICAL_REF="7b4b774^:plugins/vsdd-factory/hooks/hooks.json"
+LEGACY_HOOKS_JSON="$REPO_ROOT/scripts/legacy/hooks-json-pre-templating.json"
 
 # Hooks that have been ported to native WASM (W-15+) and no longer have
 # a .sh counterpart on disk. The generator skips both the on-disk check
@@ -178,7 +180,7 @@ binary_allow_for_script() {
 
 require_cmd jq
 
-# Resolve input hooks.json — default to the historical commit; allow an
+# Resolve input hooks.json — default to the vendored legacy file; allow an
 # explicit path for tests / local experimentation.
 HOOKS_JSON_INPUT=""
 if [ $# -ge 1 ]; then
@@ -188,12 +190,13 @@ if [ $# -ge 1 ]; then
   fi
   HOOKS_JSON_INPUT="$(cat "$1")"
 else
-  require_cmd git
-  HOOKS_JSON_INPUT="$(git -C "$REPO_ROOT" show "$HISTORICAL_REF" 2>/dev/null || true)"
-  if [ -z "$HOOKS_JSON_INPUT" ]; then
-    echo "error: failed to read $HISTORICAL_REF — is the repo shallow-cloned?" >&2
+  if [ ! -f "$LEGACY_HOOKS_JSON" ]; then
+    echo "error: vendored legacy hooks.json not found: $LEGACY_HOOKS_JSON" >&2
+    echo "       This file should ship with the repo. If missing, restore via:" >&2
+    echo "       git show 7b4b774^:plugins/vsdd-factory/hooks/hooks.json > $LEGACY_HOOKS_JSON" >&2
     exit 1
   fi
+  HOOKS_JSON_INPUT="$(cat "$LEGACY_HOOKS_JSON")"
 fi
 
 # Cross-check: every script referenced must exist on disk; every script

--- a/scripts/legacy/hooks-json-pre-templating.json
+++ b/scripts/legacy/hooks-json-pre-templating.json
@@ -1,0 +1,94 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/brownfield-discipline.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/protect-vp.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/protect-bc.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/red-gate.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/factory-branch-guard.sh", "timeout": 5 }
+        ]
+      },
+      {
+        "matcher": "Agent",
+        "hooks": [
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/track-agent-start.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-wave-gate-prerequisite.sh", "timeout": 10 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-pr-merge-prerequisites.sh", "timeout": 10 }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/block-ai-attribution.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/destructive-command-guard.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/protect-secrets.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/verify-git-push.sh", "timeout": 10 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/check-factory-commit.sh", "timeout": 5 }
+        ]
+      },
+      {
+        "matcher": "Read",
+        "hooks": [
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/protect-secrets.sh", "timeout": 5 }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/regression-gate.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/capture-pr-activity.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/capture-commit-activity.sh", "timeout": 5 }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/purity-check.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-vp-consistency.sh", "timeout": 10 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-subsystem-names.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-bc-title.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-story-bc-sync.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-template-compliance.sh", "timeout": 10 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-finding-format.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-input-hash.sh", "timeout": 10 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-state-size.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-novelty-assessment.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/convergence-tracker.sh", "timeout": 10 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-table-cell-count.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-changelog-monotonicity.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-state-pin-freshness.sh", "timeout": 10 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-index-self-reference.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-state-index-status-coherence.sh", "timeout": 10 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-anchor-capabilities-union.sh", "timeout": 10 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-demo-evidence-story-scoped.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-pr-description-completeness.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-wave-gate-completeness.sh", "timeout": 10 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-factory-path-root.sh", "timeout": 5 }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/track-agent-stop.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/handoff-validator.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pr-manager-completion-guard.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/update-wave-state-on-merge.sh", "timeout": 10 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-pr-review-posted.sh", "timeout": 5 }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-learning.sh", "timeout": 5 },
+          { "type": "command", "command": "${CLAUDE_PLUGIN_ROOT}/hooks/warn-pending-wave-gate.sh", "timeout": 5 }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Hotfix Summary

Unblocks the v1.0.0-rc.11 retag. Cherry-picks PR #85 (TD-VSDD-054 generator vendoring) onto a branch off main so the rc.11 release tag can be force-moved to a HEAD that includes the fix.

## Why this PR exists

v1.0.0-rc.11 was tagged at main `a425969` but the release workflow failed at pre-release validation: `generate-registry.bats` invoked `scripts/generate-registry-from-hooks-json.sh` which read `git show 7b4b774^:plugins/vsdd-factory/hooks/hooks.json`. CI uses shallow clone (default `actions/checkout` fetch-depth: 1) so the historical SHA wasn't available; tests failed; binaries weren't bundled; no GitHub Release published.

PR #85 vendored the historical hooks.json as `scripts/legacy/hooks-json-pre-templating.json` and updated the generator to read the static file (no more git-history dependency). That landed on develop; this PR brings it to main so the rc.11 retag can succeed.

## Files changed

Same as PR #85 (cherry-picked `4ee68e4` from develop):
- `scripts/legacy/hooks-json-pre-templating.json` (NEW, 94 lines, byte-for-byte identical to historical hooks.json)
- `scripts/generate-registry-from-hooks-json.sh` (~10 lines diff)

## Test plan

- [x] PR #85 merged to develop with green CI
- [x] Cherry-pick clean, no conflicts
- [ ] CI passes on this branch
- [ ] After merge: orchestrator force-deletes + re-pushes `v1.0.0-rc.11` tag pointing at this PR's merge commit; release workflow re-runs; binaries bundle; GitHub Release publishes; marketplace PR auto-opens

## Related

- PR #85 (develop merge)
- Original rc.11 release PR #84 (already merged; the pre-release validation failure is what this PR fixes)
- TD-VSDD-054 (external; underlying shallow-clone fragility)