### PR TITLE
fix(tests): TD-VSDD-055 — state-health bats git config (unblocks rc.11 retag round 2)

### DIFF
--- a/plugins/vsdd-factory/tests/state-health.bats
+++ b/plugins/vsdd-factory/tests/state-health.bats
@@ -8,8 +8,15 @@ setup() {
   HOOK="$PLUGIN_ROOT/hooks/validate-state-size.sh"
   WORK=$(mktemp -d)
   mkdir -p "$WORK/.factory"
-  # Initialize a git repo so the hook can compare against HEAD
+  # Initialize a git repo so the hook can compare against HEAD.
+  # Configure user.email/name locally — required in CI environments
+  # where global git config is absent (otherwise commit fails with
+  # status 128). Using --local so the test's git config doesn't
+  # leak into the operator's global config.
   git -C "$WORK/.factory" init -q
+  git -C "$WORK/.factory" config user.email "test@vsdd-factory.local"
+  git -C "$WORK/.factory" config user.name "vsdd-factory test"
+  git -C "$WORK/.factory" config commit.gpgsign false
   git -C "$WORK/.factory" checkout -q --orphan factory-artifacts
   echo "# Initial STATE" > "$WORK/.factory/STATE.md"
   git -C "$WORK/.factory" add STATE.md


### PR DESCRIPTION
## Summary

Second TD-020-sweep CI regression. The state-health.bats suite was un-skipped by PR #82 with a "31/31 pass" claim — true LOCALLY, fails in CI: setup runs \`git commit\` which exits status 128 because user.email/name aren't globally configured on GitHub-hosted runners.

First regression (PR #86, TD-VSDD-054) vendored the historical hooks.json. This is the second of the same class.

## Fix

`plugins/vsdd-factory/tests/state-health.bats` setup() — add three local git config calls before the first commit:
- `user.email` / `user.name` (CI requires these for commit to succeed)
- `commit.gpgsign false` (some operators have signing required globally; test shouldn't depend on signing key availability)

Uses `--local` so test config doesn't leak into operator global config.

## Test plan

- [x] `bats state-health.bats` 31/31 pass locally (unchanged behavior)
- [x] Full bats matrix passes
- [ ] CI passes
- [ ] After merge: orchestrator force-deletes + re-pushes v1.0.0-rc.11 tag (round 2 retag); release workflow re-runs; binaries bundle; GitHub Release publishes; marketplace PR opens

## Why this is targeted to main (not develop first)

Same hotfix-to-main pattern as PR #86. Aim is to unblock the rc.11 retag immediately. After this lands and the retag succeeds, I'll separately sync this fix to develop.

## Related

- PR #82 (TD-020 sweep — source of both regressions)
- PR #86 (TD-VSDD-054 — first round retag-prep)
- TD-VSDD-055 (external; this one)