### PR TITLE
docs: fix 3 stale guides for rc.11 architecture

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -155,14 +155,14 @@ The plugin does not hijack your default Claude Code persona on install. To opt i
 VSDD orchestrator agent for a specific project:
 
 ```
-/activate
+/vsdd-factory:activate
 ```
 
 This writes `{"agent": "vsdd-factory:orchestrator"}` to `.claude/settings.local.json`.
 To revert:
 
 ```
-/deactivate
+/vsdd-factory:deactivate
 ```
 
 ### Environment variables
@@ -178,7 +178,7 @@ resolves correctly regardless of where the plugin is installed.
 
 ## Template customization
 
-The plugin ships 127 templates in `plugins/vsdd-factory/templates/`. These define the
+The plugin ships 126 templates in `plugins/vsdd-factory/templates/`. These define the
 exact output format for every artifact type: behavioral contracts, architecture sections,
 PRDs, adversarial findings, holdout evaluations, demo reports, convergence reports, and more.
 
@@ -194,8 +194,7 @@ Templates are read-only during pipeline execution. If you need to customize outp
 
 ## Hook behavior
 
-The plugin registers 19 hooks across four lifecycle events. Each hook enforces a specific
-discipline.
+The plugin registers 52 hooks across the lifecycle events declared in `plugins/vsdd-factory/hooks-registry.toml`. Each hook enforces a specific discipline.
 
 ### PreToolUse hooks (Edit|Write)
 
@@ -256,9 +255,7 @@ discipline.
 
 ### Disabling hooks
 
-Hooks cannot be individually disabled through configuration. They are wired in
-`plugins/vsdd-factory/hooks/hooks.json`. To disable a hook, you would need to edit
-`hooks.json` directly (not recommended -- the hooks exist to prevent common failure modes).
+Hooks are wired in `plugins/vsdd-factory/hooks-registry.toml` (the canonical source). To disable a hook, comment out or remove its `[[hooks]]` stanza from the registry, then re-run `/vsdd-factory:activate` to regenerate `hooks.json`. Editing `hooks.json` directly is futile — the activate skill clobbers your changes on next run. Disabling hooks is not recommended; they exist to prevent common failure modes.
 
 The `red-gate.sh` hook is opt-in: it only activates when `.factory/red-gate-state.json`
 exists and declares strict mode. Other hooks are always active.
@@ -281,7 +278,7 @@ mid-session (`export VSDD_TELEMETRY=off`, then `unset VSDD_TELEMETRY`).
 
 | Variable | Set by | Effect |
 |----------|--------|--------|
-| `CLAUDE_PLUGIN_ROOT` | Claude Code | Absolute path to the plugin directory. Hooks use this to locate `bin/emit-event`. Unset in test/non-Claude-Code contexts; the `_emit` wrapper no-ops when unset. |
+| `CLAUDE_PLUGIN_ROOT` | Claude Code | Absolute path to the plugin directory. Bash hooks use this to locate `bin/emit-event` (native WASM plugins use the `host::emit_event` SDK call instead; bash-to-native migration is tracked in epic E-8 and the ADR-015 wave 4 series). Unset in test/non-Claude-Code contexts; the `_emit` wrapper no-ops when unset. |
 
 ---
 

--- a/docs/guide/hooks-reference.md
+++ b/docs/guide/hooks-reference.md
@@ -1,8 +1,8 @@
 # Hooks Reference
 
-The vsdd-factory plugin ships hook scripts wired through `hooks.json`. Hooks fire automatically on tool use events, subagent completion, and session end. They enforce pipeline discipline without requiring manual intervention.
+The vsdd-factory plugin ships hook scripts wired through `hooks-registry.toml` (the dispatcher's canonical routing table). `hooks.json` is a per-platform generated artifact produced by the activate skill — operators do not edit it directly. Hooks fire automatically on tool use events, subagent completion, and session end. They enforce pipeline discipline without requiring manual intervention.
 
-The **Instrumented** column indicates whether the hook emits structured block events to `.factory/logs/events-YYYY-MM-DD.jsonl` via `bin/emit-event`. See the [observability guide](observability.md) for the event schema, reason-code registry, and query recipes.
+The **Instrumented** column indicates whether the hook emits structured block events to `.factory/logs/events-YYYY-MM-DD.jsonl`. Native WASM plugins use the `host::emit_event` SDK call; bash hooks invoke `bin/emit-event`. Migration of bash hooks to native is tracked in epic E-8 (S-8.01..S-8.09 merged) and the ADR-015 wave 4 series (S-10.08, S-10.09). See the [observability guide](observability.md) for the event schema, reason-code registry, and query recipes.
 
 > **Note:** This reference table currently undercounts. A doc audit reconciling every hook script in `plugins/vsdd-factory/hooks/` with this page is tracked in the observability roadmap (end-of-Phase-2 cleanup release).
 
@@ -288,13 +288,74 @@ At session end, appends a timestamped learning stub to `.factory/sidecar-learnin
 
 ## Hook Wiring
 
-All hooks are configured in `plugins/vsdd-factory/hooks/hooks.json`. The wiring uses four event types:
+All hooks are configured in `plugins/vsdd-factory/hooks-registry.toml` — the canonical, human-edited source of truth. Each entry is a `[[hooks]]` TOML stanza that the dispatcher reads at startup to build its routing table. `hooks.json` is regenerated from this file on every `/vsdd-factory:activate` run; operators never edit `hooks.json` directly.
+
+The wiring uses these event types:
 
 | Event | When It Fires |
 |-------|--------------|
-| `PreToolUse` | Before a tool call executes. Can block (exit 2) or inject context (exit 0 with JSON). |
+| `PreToolUse` | Before a tool call executes. Can block (`{"outcome":"block"}`) or inject context. |
 | `PostToolUse` | After a tool call completes. Cannot block -- advisory only. |
-| `SubagentStop` | When a subagent finishes and returns its result. |
+| `PostToolUseFailure` | After a tool call fails. |
+| `SubagentStop` | When a subagent finishes and returns its result. Some hooks use advisory-block-mode here. |
 | `Stop` | When the session ends. |
+| `SessionStart` / `SessionEnd` | Session lifecycle. |
+| `WorktreeCreate` / `WorktreeRemove` | Git worktree lifecycle. |
 
-Each hook has a 5-second timeout (10 seconds for `verify-git-push.sh`). All hooks require `jq` for JSON parsing of the tool input envelope.
+### Stanza format: legacy bash adapter
+
+Most hooks today are bash scripts adapted via `legacy-bash-adapter.wasm`. The adapter reads `[hooks.config] script_path` and execs the underlying script:
+
+```toml
+[[hooks]]
+name = "validate-bc-title"
+event = "PostToolUse"
+tool = "Edit|Write"
+plugin = "hook-plugins/legacy-bash-adapter.wasm"
+priority = 250
+timeout_ms = 5000
+on_error = "continue"
+
+[hooks.config]
+script_path = "hooks/validate-bc-title.sh"
+
+[hooks.capabilities]
+env_allow = ["PATH", "HOME", "TMPDIR", "CLAUDE_PROJECT_DIR", "CLAUDE_PLUGIN_ROOT", "VSDD_SESSION_ID"]
+
+[hooks.capabilities.exec_subprocess]
+binary_allow = ["bash", "jq"]
+shell_bypass_acknowledged = "legacy-bash-adapter runs unported hooks"
+env_allow = ["PATH", "HOME", "TMPDIR", "CLAUDE_PROJECT_DIR", "CLAUDE_PLUGIN_ROOT", "VSDD_SESSION_ID"]
+```
+
+### Stanza format: native WASM
+
+Native ports (S-2.5 onward) point `plugin` at the hook's own `.wasm` module and drop `[hooks.config] script_path` entirely:
+
+```toml
+[[hooks]]
+name = "capture-commit-activity"
+event = "PostToolUse"
+plugin = "hook-plugins/capture-commit-activity.wasm"
+priority = 110
+timeout_ms = 5000
+on_error = "continue"
+
+[hooks.capabilities]
+env_allow = []
+
+[hooks.capabilities.exec_subprocess]
+binary_allow = ["git"]
+```
+
+Native and legacy entries coexist in the same registry. Capabilities (env, files, subprocesses) are declared per stanza and enforced by the dispatcher's WASI sandbox.
+
+Each hook has a 5-second default timeout (10 seconds for several validators and `verify-git-push.sh`). Bash hooks require `jq` declared in `binary_allow` for JSON parsing of the tool input envelope.
+
+## The factory-dispatcher runtime
+
+`factory-dispatcher` is the WASM hook runtime that Claude Code invokes for every event in `hooks-registry.toml`. It is the single entrypoint shipped in `plugins/vsdd-factory/bin/` (rc.10/rc.11) — every routed hook runs inside the dispatcher's wasmtime host, never as a direct subprocess of Claude Code.
+
+On startup the dispatcher reads `hooks-registry.toml`, validates each stanza's schema, and builds an event → ordered-plugin-list routing table keyed by `event` (and optional `tool` matcher) and sorted by `priority`. When an event fires, the dispatcher loads each matching `.wasm` plugin into the sandbox, hands it the Claude Code event envelope on stdin, and enforces the declared capabilities (`env_allow`, `read_file.path_allow`, `write_file.path_allow`, `exec_subprocess.binary_allow`).
+
+Native plugins are first-class wasm modules built from `crates/hook-plugins/<name>` and link directly against the host SDK (`host::emit_event`, `host::read_file`, etc.). Legacy bash hooks route through `hook-plugins/legacy-bash-adapter.wasm`, which reads `[hooks.config] script_path` from its own stanza, execs the referenced bash script with the granted subprocess capabilities, and forwards the script's stdout/exit code back as a dispatcher decision. This keeps the wiring uniform: every hook — native or bash — is discoverable via the same `hooks-registry.toml` and runs through the same dispatcher pipeline.

--- a/docs/guide/phase-6-formal-hardening.md
+++ b/docs/guide/phase-6-formal-hardening.md
@@ -1,16 +1,16 @@
-# Phase 5: Formal Hardening
+# Phase 6: Formal Hardening
 
-## When to Enter Phase 5
+## When to Enter Phase 6
 
-Enter Phase 5 after the adversary converges in Phase 4 -- novelty is LOW, all CRITICAL and HIGH findings are resolved, and the adversary is reduced to nitpicking wording rather than finding real gaps.
+Enter Phase 6 after the adversary converges in Phase 5 -- novelty is LOW, all CRITICAL and HIGH findings are resolved, and the adversary is reduced to nitpicking wording rather than finding real gaps.
 
 ## Overview
 
-Phase 5 runs four independent verification tracks plus a performance validation pass. The verification architecture designed in Phase 1b is now executed against the battle-tested implementation.
+Phase 6 runs four independent verification tracks plus a performance validation pass. The verification architecture designed in Phase 1b is now executed against the battle-tested implementation.
 
 ```mermaid
 graph TD
-    START[Phase 4 Complete<br/>Adversary converged]:::start --> TRACKS
+    START[Phase 5 Complete<br/>Adversary converged]:::start --> TRACKS
 
     subgraph TRACKS[Verification Tracks — run in parallel]
         direction TB
@@ -26,7 +26,7 @@ graph TD
     DTU -->|No| REPORT[Formal Verification Report]:::artifact
     DTUV --> REPORT
     REPORT --> GATE{All reports<br/>PASS?}:::decision
-    GATE -->|Yes| DONE[Phase 5 Gate: PASS]:::start
+    GATE -->|Yes| DONE[Phase 6 Gate: PASS]:::start
     GATE -->|No| FIX[Fix via /fix-pr-delivery]:::action
     FIX --> TRACKS
 
@@ -152,11 +152,11 @@ The comparison harness runs both implementations with the same inputs and report
 
 ## Purity Boundary Audit
 
-The `purity-check.sh` hook runs automatically on every file edit, but Phase 5 includes an explicit audit: verify that all modules classified as "pure core" in the architecture document remain free of side effects. Side effects that crept into the pure core during implementation are flagged for refactoring.
+The `purity-check.sh` hook runs automatically on every file edit, but Phase 6 includes an explicit audit: verify that all modules classified as "pure core" in the architecture document remain free of side effects. Side effects that crept into the pure core during implementation are flagged for refactoring.
 
 ## Artifacts
 
-Phase 5 produces two primary reports:
+Phase 6 produces two primary reports:
 
 - `.factory/cycles/<current>/formal-verification-report.md` -- Kani results, fuzz results, mutation survivors, security findings, and the overall gate verdict
 - `.factory/cycles/<current>/performance-report.md` -- benchmark results, budget compliance, regression analysis
@@ -177,7 +177,7 @@ If a tool is not installed, `/vsdd-factory:formal-verify` reports which tools ar
 
 ## Quality Gate
 
-Phase 5 is complete when all verification reports show PASS:
+Phase 6 is complete when all verification reports show PASS:
 
 - All Kani proofs pass
 - No fuzz crashes
@@ -187,4 +187,4 @@ Phase 5 is complete when all verification reports show PASS:
 - DTU validation clean (if DTU clones exist)
 - Purity boundaries intact
 
-If any track fails, fix the issue via `/fix-pr-delivery` and re-run the failing track. Findings that require implementation changes route back through Phase 4 (adversarial review of the fix).
+If any track fails, fix the issue via `/fix-pr-delivery` and re-run the failing track. Findings that require implementation changes route back through Phase 5 (adversarial review of the fix).


### PR DESCRIPTION
## Summary

Fixes 3 stale guide docs that documented pre-rc.7 architecture.

- **`docs/guide/hooks-reference.md`** rewritten — rc.7/rc.8 made \`hooks-registry.toml\` canonical for hook registration; \`hooks.json\` is now a per-machine generated artifact (untracked since rc.8). The doc previously mentioned \`hooks.json\` 2× and \`hooks-registry.toml\` 0×, actively misleading hook authors. New section added explaining \`factory-dispatcher\` as the WASM hook runtime.
- **\`docs/guide/configuration.md\`** corrected — the "Disabling hooks" section instructed operators to edit \`hooks.json\` directly. That file is regenerated by \`/vsdd-factory:activate\` on every install, so any direct edits get clobbered. Fixed to point at \`hooks-registry.toml\`. Also refreshed stale counts (templates: 127 → 126; registered hooks: 19 → 52) and added missing \`vsdd-factory:\` slash-command prefixes.
- **\`docs/guide/phase-5-formal-hardening.md\`** → renamed to \`phase-6-formal-hardening.md\`. Current pipeline numbering: Phase 5 = adversarial refinement (already documented separately as \`phase-5-adversarial-refinement.md\`); Phase 6 = formal hardening. Phase numbering inside the file renumbered accordingly.

## Discoveries during the fix

- Hook count was 33 hooks behind reality (doc said 19; actual is 52).
- Zero inbound links to the old \`phase-5-formal-hardening\` filename — no cross-link breakage.
- 3 remaining "Phase 5" references inside the renamed file are intentional (they correctly refer to the new Phase 5 = adversarial refinement, which IS the prerequisite to formal hardening).

## Risk

LOW. Docs-only. No code, tests, or CI workflow files touched. No behavioral change. The most consequential fix is the configuration.md "Disabling hooks" correction — operators following the old instructions were editing a file that gets clobbered every activate.

## Test plan

- [ ] CI green (docs-only PR; if any CI jobs are wired to docs paths via paths-ignore inversion, they should pass trivially)
- [ ] No broken anchor links introduced (zero inbound links to the renamed file confirmed pre-flight)
- [ ] Spot-read of each modified file to confirm it scans correctly post-edit