### PR TITLE
docs: NEEDS-MINOR sweep (rc.11 follow-up to PR #89)

### DIFF
--- a/docs/guide/commands-reference.md
+++ b/docs/guide/commands-reference.md
@@ -1,6 +1,6 @@
 # Commands Reference
 
-The vsdd-factory plugin ships 103 slash commands. Each command dispatches to a corresponding skill. Run any command by typing its name in Claude Code.
+The vsdd-factory plugin ships 120 slash commands. Each command dispatches to a corresponding skill. Run any command by typing its name in Claude Code.
 
 All commands are prefixed with `/` when invoked. If you have multiple plugins installed, use the fully qualified form `/vsdd-factory:<command-name>` to avoid ambiguity.
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -178,7 +178,7 @@ resolves correctly regardless of where the plugin is installed.
 
 ## Template customization
 
-The plugin ships 126 templates in `plugins/vsdd-factory/templates/`. These define the
+The plugin ships 136 templates in `plugins/vsdd-factory/templates/`. These define the
 exact output format for every artifact type: behavioral contracts, architecture sections,
 PRDs, adversarial findings, holdout evaluations, demo reports, convergence reports, and more.
 

--- a/docs/guide/cross-cutting-skills.md
+++ b/docs/guide/cross-cutting-skills.md
@@ -523,7 +523,7 @@ Digital Twin Universe validation -- create and maintain behavioral clones of cri
 
 ### `/vsdd-factory:formal-verify`
 
-Run formal hardening -- Kani proofs for pure core functions, fuzz testing with cargo-fuzz, mutation testing with cargo-mutants, and security scanning with semgrep. Phase 5 quality gate.
+Run formal hardening -- Kani proofs for pure core functions, fuzz testing with cargo-fuzz, mutation testing with cargo-mutants, and security scanning with semgrep. Phase 6 quality gate.
 
 ```
 /vsdd-factory:formal-verify

--- a/docs/guide/glossary.md
+++ b/docs/guide/glossary.md
@@ -250,6 +250,9 @@ The architectural separation between the deterministic, side-effect-free Pure Co
 **R (Risk)**
 A risk identified during domain specification. Numbered as R-NNN. Lifecycle-scoped. Registry: L2-INDEX.md.
 
+**Remediation Burst**
+A specialized variant of Burst used by `state-manager` to apply state-file fixes under the Single-Commit Burst Protocol (TD-VSDD-053). Distinct from a regular Burst: exactly one atomic commit, no Stage 2 backfill, no SHA placeholder, no commit chain. Invoked via `/vsdd-factory:state-burst`. Where a regular Burst coordinates multiple agents and may produce multiple commits across roles, a Remediation Burst is single-agent, single-commit, and refuses to proceed if it cannot complete atomically.
+
 **Red Flags Table**
 A table embedded in discipline skills that enumerates the rationalizations agents use to bypass Iron Laws. Each row maps a tempting thought ("I'll skip the Red Gate for this small change") to the reality of why it is a protocol violation. 80 Red Flag entries across 9 skills.
 

--- a/docs/guide/migrating-from-0.79.md
+++ b/docs/guide/migrating-from-0.79.md
@@ -254,43 +254,50 @@ If v1.0 misbehaves on your factory and you need to revert:
   If the binary is absent, open an issue with your OS/arch so the release
   can be patched.
 
-## Regenerating `hooks-registry.toml`
+## Regenerating `hooks-registry.toml` (historical, retired at 1.0.0 GA)
+
+> **Status (1.0.0 GA):** The generator described below was **retired
+> at 1.0.0 GA**. `plugins/vsdd-factory/hooks-registry.toml` is now the
+> human-edited source of truth and the canonical place to add, remove,
+> or rewire hooks. This section is preserved as historical migration
+> guidance for operators reconstructing the v0.79.x → v1.0 path; it
+> does not describe an active workflow.
 
 The v1.0 dispatcher reads `plugins/vsdd-factory/hooks-registry.toml`
 to decide which hooks fire on which events. During the v0.79.x → v1.0
-migration the file is produced by a generator that reads the historical
+migration the file was produced by a generator that read the historical
 bash-hook inventory at `git show 7b4b774^:plugins/vsdd-factory/hooks/hooks.json`
-and emits one `[[hooks]]` entry per bash hook, all routed through
+and emitted one `[[hooks]]` entry per bash hook, all routed through
 `legacy-bash-adapter.wasm`.
 
-Run the generator from the repo root:
+The generator was invoked from the repo root:
 
 ```bash
 scripts/generate-registry-from-hooks-json.sh
 ```
 
-The script is idempotent — re-running it on an unchanged input
-produces byte-identical output. CI re-runs it on every push and fails
-the build if `git diff plugins/vsdd-factory/hooks-registry.toml` is
+The script was idempotent — re-running it on an unchanged input
+produced byte-identical output. CI re-ran it on every push and failed
+the build if `git diff plugins/vsdd-factory/hooks-registry.toml` was
 non-empty.
 
-**When to re-run:**
+**When it was used:**
 
-- During this migration, almost never. The bash hook inventory is
-  frozen at the historical commit; ongoing maintenance edits the
-  generated TOML directly. The generator exists so the *initial*
-  conversion is auditable, not so it runs continuously.
-- If a bash hook is added or removed (rare during migration), update
-  `git show 7b4b774^:plugins/vsdd-factory/hooks/hooks.json` to match
-  reality (or pass an explicit hooks.json path argument), then
-  re-run the generator and review the diff.
-- After 1.0.0 ships, the generator is retired entirely;
-  `hooks-registry.toml` becomes the human-edited source of truth for
+- During the migration window, rarely. The bash hook inventory was
+  frozen at the historical commit; ongoing maintenance edited the
+  generated TOML directly. The generator existed so the *initial*
+  conversion was auditable, not so it would run continuously.
+- If a bash hook was added or removed (rare during migration),
+  `git show 7b4b774^:plugins/vsdd-factory/hooks/hooks.json` was
+  updated to match reality (or an explicit hooks.json path was passed
+  as argument), then the generator was re-run and the diff reviewed.
+- After 1.0.0 shipped, the generator was retired entirely;
+  `hooks-registry.toml` became the human-edited source of truth for
   every native-WASM port (S-2.5+).
 
-**What it can't fix:** entries whose underlying bash script no longer
-exists. The generator hard-fails on script-without-entry or
-entry-without-script — those are operator-resolved drift, not
+**What it couldn't fix:** entries whose underlying bash script no
+longer existed. The generator hard-failed on script-without-entry or
+entry-without-script — those were operator-resolved drift, not
 generator-resolved.
 
 ## Known regressions (v1.0.0-beta.1)

--- a/docs/guide/phase-5-adversarial-refinement.md
+++ b/docs/guide/phase-5-adversarial-refinement.md
@@ -101,7 +101,7 @@ Findings are written to `.factory/cycles/<current>/vsdd-factory:adversarial-revi
 
 | Finding Severity | Action |
 |-----------------|--------|
-| **CRITICAL** | Create a fix PR immediately via `/fix-pr-delivery`. Blocks Phase 5. |
+| **CRITICAL** | Create a fix PR immediately via `/vsdd-factory:fix-pr-delivery`. Blocks Phase 5. |
 | **HIGH** | Fix now or log to tech debt register with `/vsdd-factory:track-debt add`. |
 | **MEDIUM** | Fix if effort is low, otherwise log to tech debt. |
 | **LOW** | Document in the review findings. No action required. |
@@ -119,7 +119,7 @@ Findings route to different phases depending on their nature:
 - **Implementation flaws** -- create fix PRs targeting develop
 - **New edge cases** -- add to the edge case catalog, write failing tests, implement
 
-The fix delivery flow uses `/fix-pr-delivery`, which is a streamlined version of the standard story delivery. It skips stubs, Red Gate enforcement, and wave gates since those apply to new feature work, not remediation.
+The fix delivery flow uses `/vsdd-factory:fix-pr-delivery`, which is a streamlined version of the standard story delivery. It skips stubs, Red Gate enforcement, and wave gates since those apply to new feature work, not remediation.
 
 ## Multi-Model Adversary
 

--- a/docs/guide/phase-6-formal-hardening.md
+++ b/docs/guide/phase-6-formal-hardening.md
@@ -187,4 +187,4 @@ Phase 6 is complete when all verification reports show PASS:
 - DTU validation clean (if DTU clones exist)
 - Purity boundaries intact
 
-If any track fails, fix the issue via `/fix-pr-delivery` and re-run the failing track. Findings that require implementation changes route back through Phase 5 (adversarial review of the fix).
+If any track fails, fix the issue via `/vsdd-factory:fix-pr-delivery` and re-run the failing track. Findings that require implementation changes route back through Phase 5 (adversarial review of the fix).

--- a/docs/guide/pipeline-overview.md
+++ b/docs/guide/pipeline-overview.md
@@ -43,21 +43,32 @@ graph TD
         WG -->|"FAIL"| DEL
     end
 
-    subgraph "Phase 4-6: Hardening & Release"
+    subgraph "Phase 4: Holdout Evaluation"
+        HE["/vsdd-factory:holdout-eval"]
+    end
+
+    subgraph "Phase 5: Adversarial Refinement"
         AR2["/vsdd-factory:adversarial-review\nimplementation"]
+    end
+
+    subgraph "Phase 6: Formal Hardening"
         FV["/vsdd-factory:formal-verify"]
+    end
+
+    subgraph "Phase 7: Convergence & Release"
         CC["/vsdd-factory:convergence-check"]
         REL["/vsdd-factory:release"]
-        AR2 --> FV --> CC
         CC -->|"NOT CONVERGED"| AR2
         CC -->|"CONVERGED"| REL
     end
+
+    HE --> AR2 --> FV --> CC
 
     BV -->|"validated"| CB
     START(("Greenfield")) --> CB
     P1DONE --> DS
     P2DONE --> DEL
-    WG -->|"PASS"| AR2
+    WG -->|"PASS"| HE
 
     style START fill:#40916c,color:#fff
     style P1DONE fill:#1d3557,color:#fff
@@ -269,7 +280,7 @@ every rule has a cost, and the human operator is the final authority on ceremony
 Common shortcuts:
 
 - **Skip Phase 0** if you are building greenfield with no reference codebase.
-- **Skip Phase 5 (formal hardening)** for utility modules, prototypes, or low-risk code.
+- **Skip Phase 6 (formal hardening)** for utility modules, prototypes, or low-risk code.
   Document the decision in an ADR.
 - **Reduce adversarial passes** for small, well-understood changes. The `/vsdd-factory:quick-dev-routing`
   command identifies changes with zero blast radius that can bypass full adversarial review.

--- a/docs/guide/semver-commitment.md
+++ b/docs/guide/semver-commitment.md
@@ -5,8 +5,9 @@ v1.0 line, what remains intentionally unstable, how breaking changes are handled
 and what HOST_ABI_VERSION = 1 means for plugin authors. It is the authoritative
 reference for operators and plugin authors evaluating upgrade safety.
 
-This document is locked at v1.0.0-beta.4. Amendments require a new doc version
-and a changelog entry.
+This document's lock target is **1.0.0 GA**. Pre-GA release candidates may
+revise it without a doc-version bump; once 1.0.0 ships, amendments require
+a new doc version and a changelog entry.
 
 ---
 
@@ -60,6 +61,11 @@ The per-platform variants (`hooks.json.darwin-arm64`, etc.) follow the same sche
 The format is stable; Claude Code reads it, not vsdd-factory, so format breaks
 would originate upstream — but vsdd-factory guarantees it will not write
 non-conforming `hooks.json` content.
+
+> **Operator note:** Operators edit `hooks-registry.toml`, not `hooks.json`
+> directly. `hooks.json` is a generated artifact bundled into the plugin
+> package; the canonical, human-edited source for hook routing is
+> `plugins/vsdd-factory/hooks-registry.toml`.
 
 ### Event type namespaces detail
 

--- a/docs/guide/templates-reference.md
+++ b/docs/guide/templates-reference.md
@@ -1,6 +1,6 @@
 # Templates Reference
 
-The vsdd-factory plugin ships 127 template files in `plugins/vsdd-factory/templates/`. Templates define the exact output structure for every artifact the pipeline produces. Skills reference templates via `${CLAUDE_PLUGIN_ROOT}/templates/<name>` and agents read them before generating output.
+The vsdd-factory plugin ships 136 template files in `plugins/vsdd-factory/templates/`. Templates define the exact output structure for every artifact the pipeline produces. Skills reference templates via `${CLAUDE_PLUGIN_ROOT}/templates/<name>` and agents read them before generating output.
 
 ---
 

--- a/docs/guide/workflow-modes.md
+++ b/docs/guide/workflow-modes.md
@@ -8,7 +8,7 @@ The VSDD factory supports 8 workflow modes. Each mode strings together a differe
 
 | Mode | When to Use | Phases Run | Steps |
 |------|-------------|-----------|-------|
-| **Greenfield** | New project, no existing code | 0-7 (skip 0) | 68 |
+| **Greenfield** | New project, no existing code | 0-7 (skip 0) | 72 |
 | **Brownfield** | Existing codebase to extend or rebuild | 0-7 (all) | 24 + greenfield |
 | **Feature** | Adding to a VSDD-managed project | F1-F7 (delta phases) | 82 |
 | **Maintenance** | Scheduled quality sweeps | Per-sweep | 34 |


### PR DESCRIPTION
## Summary

Follow-up sweep to PR #89. Addresses 14 NEEDS-MINOR docs from yesterday's audit plus 2 follow-up findings from the PR #89 review.

### Commits

| Commit | Files | Change |
|---|---|---|
| `bac1730` | `cross-cutting-skills.md`, `pipeline-overview.md` | Renumber lingering Phase-5-formal-hardening references to Phase 6; rewrote pipeline-overview Phase 4-6 mermaid lump into 4 distinct subgraphs (4 holdout / 5 adversarial / 6 formal / 7 convergence) |
| `e7551ea` | `configuration.md`, `templates-reference.md`, `commands-reference.md` | Refresh stale counts (templates 126/127 → 136; skills 103 → 120). Hook count of 52 already correct in configuration.md — left alone. |
| `7c116ec` | `phase-5-adversarial-refinement.md` (×2), `phase-6-formal-hardening.md` (×1) | Three bare `/fix-pr-delivery` references prefixed with `vsdd-factory:`. Bare `/plugin*` and `/reload-plugins` left (Claude Code natives). |
| `ea31b5b` | `migrating-from-0.79.md`, `semver-commitment.md` | Reframed migration generator section as historical (past tense + status callout); semver lock target → 1.0.0 GA + operator note clarifying hooks.json is generated. |
| `04c2b6b` | `workflow-modes.md` | Reconcile greenfield step count 68 → 72 (verified via `lobster-parse '.workflow.steps | length' = 72`). pipeline-paths.md was already correct. |
| `e23c587` | `glossary.md` | Added "Remediation Burst" entry adjacent to "Burst" referencing TD-VSDD-053 single-commit semantics + `/vsdd-factory:state-burst`. |

## Out-of-scope (deferred)

- `observability.md` — large rewrite (whole "what shipped" framing is pre-v1.0); too big for sweep PR.
- `observability-sinks.md` — TODO sweep gated on story content fill.
- `authoring-hooks.md` — TODO placeholders gated on stories.
- `v1.0-index.md` — gated on S-5.07 v1.0 release gate landing.

## Risk

LOW. Docs-only. No code, tests, or CI workflow files touched. No behavioral change. Largest semantic correction is the pipeline-overview mermaid that previously lumped Phase 4-6 into one block (now split into 4 distinct phases reflecting current pipeline taxonomy).

## Architecture Changes

```mermaid
graph TD
    A[docs/sweep-rc11-minor-fixes] -->|docs-only| B[develop]
    B --> C[No code changes]
    C --> D[No behavioral change]
```

## Spec Traceability

```mermaid
flowchart LR
    A[PR #89 audit findings] --> B[14 NEEDS-MINOR items]
    B --> C[6 commits]
    C --> D[docs/sweep-rc11-minor-fixes]
    D --> E[develop]
```

## Test Evidence

Docs-only PR. No test suite changes. CI runs link-check and markdown lint only.

## Security Review

N/A — docs-only, no code paths, no data handling, no authentication surface.

## Pre-Merge Checklist

- [x] PR description matches actual diff
- [x] No code, tests, or CI workflow files touched
- [x] All 6 commits are docs-only
- [x] Deferred items documented with rationale
- [ ] CI green
- [ ] AI review: no blocking findings
- [ ] Branch deleted after merge

## Test Plan

- [ ] CI green
- [ ] No broken anchor links introduced
- [ ] Spot-read of mermaid diagram render (pipeline-overview.md) to verify the new subgraph structure renders correctly on GitHub
