### PR TITLE
feat(hooks): canonical Why/Fix/Code block-message pattern (slices 1+2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Run hook tests
         run: bats plugins/vsdd-factory/tests/hooks.bats
 
+      - name: Run block-helper tests
+        run: bats tests/integration/hooks/block-helper.bats
+
       - name: Run bin tests
         run: bats plugins/vsdd-factory/tests/bin.bats
 

--- a/crates/hook-plugins/block-ai-attribution/src/lib.rs
+++ b/crates/hook-plugins/block-ai-attribution/src/lib.rs
@@ -41,11 +41,20 @@ const PHRASE_PATTERNS: &[(&str, &str)] = &[
     ("noreply@openai.com", "noreply@openai.com"),
 ];
 
-/// Detect the first AI attribution pattern in `command`, returning a
-/// human-readable description of the matched pattern, or `None` if clean.
+/// Detected AI attribution: (reason, recommendation, code).
+/// Returned by detect_attribution; consumed by on_hook_logic.
+#[derive(Debug)]
+pub struct Attribution {
+    pub reason: String,
+    pub recommendation: String,
+    pub code: &'static str,
+}
+
+/// Detect the first AI attribution pattern in `command`, returning a structured
+/// [`Attribution`] describing the match, or `None` if clean.
 ///
 /// Pure-core function — no I/O, no side effects (BC-4.05.004 candidate).
-pub fn detect_attribution(command: &str) -> Option<String> {
+pub fn detect_attribution(command: &str) -> Option<Attribution> {
     let lower = command.to_lowercase();
 
     // --- Co-Authored-By: <AI name> ---
@@ -58,10 +67,16 @@ pub fn detect_attribution(command: &str) -> Option<String> {
         let after_colon = lower[abs_pos + coauthor_marker.len()..].trim_start();
         for ai_name in COAUTHORED_AI_NAMES {
             if after_colon.starts_with(ai_name) {
-                return Some(format!(
-                    "AI attribution detected: Co-Authored-By: {}",
-                    ai_name
-                ));
+                return Some(Attribution {
+                    reason: format!(
+                        "Commit message contains AI attribution: Co-Authored-By: {ai_name}"
+                    ),
+                    recommendation:
+                        "Remove the Co-Authored-By line for AI vendors and retry the commit; \
+                         project policy disallows AI co-authorship"
+                            .to_string(),
+                    code: "ai_attribution_coauthor",
+                });
             }
         }
         search_from = abs_pos + coauthor_marker.len();
@@ -70,7 +85,19 @@ pub fn detect_attribution(command: &str) -> Option<String> {
     // --- Phrase patterns (Generated with/by, email addresses) ---
     for (pattern, label) in PHRASE_PATTERNS {
         if lower.contains(pattern) {
-            return Some(format!("AI attribution detected: {}", label));
+            // Pick a code per pattern category for telemetry distinction.
+            let code = if pattern.starts_with("generated") {
+                "ai_attribution_generated"
+            } else {
+                "ai_attribution_email"
+            };
+            return Some(Attribution {
+                reason: format!("Commit message contains AI attribution: {label}"),
+                recommendation: format!(
+                    "Remove the '{label}' reference from the commit message and retry"
+                ),
+                code,
+            });
         }
     }
 
@@ -101,7 +128,12 @@ pub fn on_hook_logic(payload: HookPayload) -> HookResult {
 
     // Scan for attribution patterns.
     match detect_attribution(&command) {
-        Some(reason) => HookResult::block(reason),
+        Some(att) => HookResult::block_with_fix(
+            "block-ai-attribution",
+            att.reason,
+            att.recommendation,
+            att.code,
+        ),
         None => HookResult::Continue,
     }
 }

--- a/crates/hook-plugins/block-ai-attribution/tests/contract_pattern_matching.rs
+++ b/crates/hook-plugins/block-ai-attribution/tests/contract_pattern_matching.rs
@@ -147,15 +147,23 @@ fn test_TV_011_noreply_openai_email_is_detected() {
 // detect_attribution returns matched pattern text (BC-4.05.001)
 // ---------------------------------------------------------------------------
 
-/// BC-4.05.001: detect_attribution returns Some(matched_text) — the returned
-/// string must be non-empty and describe the match.
+/// BC-4.05.001: detect_attribution returns Some(Attribution) — the returned
+/// reason string must be non-empty and describe the match.
 #[test]
 fn test_BC_4_05_001_detect_attribution_returns_matched_text() {
     let cmd = "git commit -m \"fix\n\nCo-Authored-By: Claude <noreply@anthropic.com>\"";
-    let matched = detect_attribution(cmd).expect("must return Some");
+    let att = detect_attribution(cmd).expect("must return Some");
     assert!(
-        !matched.is_empty(),
-        "matched pattern string must be non-empty"
+        !att.reason.is_empty(),
+        "Attribution.reason must be non-empty"
+    );
+    assert!(
+        !att.recommendation.is_empty(),
+        "Attribution.recommendation must be non-empty"
+    );
+    assert!(
+        !att.code.is_empty(),
+        "Attribution.code must be non-empty"
     );
 }
 
@@ -171,12 +179,21 @@ fn test_BC_4_05_002_detect_attribution_returns_none_for_clean_commit() {
 }
 
 /// BC-4.05.004: detect_attribution is callable with no payload context —
-/// confirms pure-core interface (no I/O, just string in / Option<String> out).
+/// confirms pure-core interface (no I/O, just string in / Option<Attribution> out).
 #[test]
 fn test_BC_4_05_004_detect_attribution_is_pure_function() {
     // Calling it twice with the same input must return the same result.
+    // Since Attribution doesn't impl PartialEq, verify both are Some with
+    // identical fields — sufficient to confirm determinism.
     let cmd = "git commit -m \"fix\n\nCo-Authored-By: Claude <x@anthropic.com>\"";
     let a = detect_attribution(cmd);
     let b = detect_attribution(cmd);
-    assert_eq!(a, b, "pure function must be deterministic");
+    match (a, b) {
+        (Some(a), Some(b)) => {
+            assert_eq!(a.reason, b.reason, "reason must be deterministic");
+            assert_eq!(a.code, b.code, "code must be deterministic");
+        }
+        (None, None) => {}
+        _ => panic!("pure function must return the same Some/None for the same input"),
+    }
 }

--- a/crates/hook-plugins/legacy-bash-adapter/src/lib.rs
+++ b/crates/hook-plugins/legacy-bash-adapter/src/lib.rs
@@ -103,13 +103,19 @@ where
     match outcome.exit_code {
         0 => HookResult::Continue,
         2 => {
-            let reason = outcome
-                .stderr
-                .lines()
-                .next()
-                .filter(|l| !l.is_empty())
-                .map(|s| s.to_string())
-                .unwrap_or_else(|| format!("legacy bash hook {script_path} blocked"));
+            // Capture the full stderr (up to 4 KiB), trimmed. Bash hooks now emit
+            // a single canonical line via lib/block.sh, but if a hook emits
+            // multi-line stderr we surface all of it rather than dropping
+            // everything after the first line. The 4 KiB cap keeps
+            // `permissionDecisionReason` reasonable for Claude Code consumption.
+            let raw = outcome.stderr.trim();
+            let reason = if raw.is_empty() {
+                format!("legacy bash hook {script_path} blocked (no stderr)")
+            } else if raw.len() > 4096 {
+                format!("{}…[truncated]", &raw[..4096])
+            } else {
+                raw.to_string()
+            };
             HookResult::block(reason)
         }
         code => HookResult::error(format!(
@@ -258,15 +264,45 @@ mod tests {
     }
 
     #[test]
-    fn maps_exit_two_to_block_with_first_stderr_line() {
+    fn maps_exit_two_to_block_with_stderr() {
+        // After the truncation fix, single-line stderr is preserved as-is.
         let p = payload_with_config(serde_json::json!({"script_path": "validate.sh"}));
+        let r = adapter_logic(p, always_ok(2, "policy violation: imports unsafe"));
+        match r {
+            HookResult::Block { reason } => {
+                assert!(reason.contains("policy violation: imports unsafe"));
+            }
+            other => panic!("expected Block, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn maps_exit_two_to_block_with_full_stderr() {
+        // After the truncation fix, multi-line stderr is preserved (joined as-is).
+        let p = payload_with_config(serde_json::json!({"script_path": "/x/v.sh"}));
         let r = adapter_logic(
             p,
-            always_ok(2, "policy violation: imports unsafe\nstack trace..."),
+            always_ok(2, "first line\nsecond line\nthird line"),
         );
         match r {
             HookResult::Block { reason } => {
-                assert_eq!(reason, "policy violation: imports unsafe");
+                assert!(reason.contains("first line"));
+                assert!(reason.contains("second line"));
+                assert!(reason.contains("third line"));
+            }
+            other => panic!("expected Block, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn truncates_oversized_stderr_to_4kb() {
+        let big = "x".repeat(8000);
+        let p = payload_with_config(serde_json::json!({"script_path": "/x/v.sh"}));
+        let r = adapter_logic(p, always_ok(2, &big));
+        match r {
+            HookResult::Block { reason } => {
+                assert!(reason.len() <= 4096 + 20); // 4 KiB + truncation marker
+                assert!(reason.contains("[truncated]"));
             }
             other => panic!("expected Block, got {other:?}"),
         }

--- a/crates/hook-plugins/legacy-bash-adapter/src/lib.rs
+++ b/crates/hook-plugins/legacy-bash-adapter/src/lib.rs
@@ -108,11 +108,16 @@ where
             // multi-line stderr we surface all of it rather than dropping
             // everything after the first line. The 4 KiB cap keeps
             // `permissionDecisionReason` reasonable for Claude Code consumption.
+            //
+            // Safety: use floor_char_boundary (stable since Rust 1.65) so the
+            // byte-slice never lands in the middle of a multi-byte UTF-8 sequence,
+            // which would panic. Hook stderr may contain Unicode file paths.
             let raw = outcome.stderr.trim();
             let reason = if raw.is_empty() {
                 format!("legacy bash hook {script_path} blocked (no stderr)")
             } else if raw.len() > 4096 {
-                format!("{}…[truncated]", &raw[..4096])
+                let safe = raw.floor_char_boundary(4096);
+                format!("{}…[truncated]", &raw[..safe])
             } else {
                 raw.to_string()
             };
@@ -303,6 +308,27 @@ mod tests {
             HookResult::Block { reason } => {
                 assert!(reason.len() <= 4096 + 20); // 4 KiB + truncation marker
                 assert!(reason.contains("[truncated]"));
+            }
+            other => panic!("expected Block, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn truncates_at_utf8_char_boundary_not_mid_char() {
+        // Build a string where a 3-byte UTF-8 character (€ = U+20AC) straddles
+        // the 4096-byte boundary: 4095 ASCII bytes + '€' (bytes 4095..4098).
+        // Without floor_char_boundary, &raw[..4096] would panic.
+        let mut s = "a".repeat(4095);
+        s.push('€'); // 3 bytes: E2 82 AC — byte positions 4095, 4096, 4097
+        s.push_str(&"b".repeat(100));
+        let p = payload_with_config(serde_json::json!({"script_path": "/x/v.sh"}));
+        let r = adapter_logic(p, always_ok(2, &s));
+        match r {
+            HookResult::Block { reason } => {
+                // Must not panic and must contain [truncated]
+                assert!(reason.contains("[truncated]"));
+                // The slice boundary must be at 4095 (before '€'), not 4096
+                assert!(reason.is_char_boundary(reason.len()));
             }
             other => panic!("expected Block, got {other:?}"),
         }

--- a/crates/hook-sdk/src/result.rs
+++ b/crates/hook-sdk/src/result.rs
@@ -39,6 +39,27 @@ impl HookResult {
         }
     }
 
+    /// Canonical agent-actionable block constructor.
+    ///
+    /// Formats reason + recommendation + code into the single-line
+    /// `BLOCKED by <hook>: <reason>. Fix: <recommendation>. Code: <code>.`
+    /// shape used across all factory hooks (bash + WASM unified).
+    ///
+    /// Use this in every blocking plugin going forward — `block()` remains
+    /// for backward compatibility but new sites should prefer this.
+    pub fn block_with_fix(
+        hook: &str,
+        reason: impl AsRef<str>,
+        recommendation: impl AsRef<str>,
+        code: &str,
+    ) -> Self {
+        let reason = reason.as_ref().trim_end_matches('.');
+        let fix = recommendation.as_ref().trim_end_matches('.');
+        HookResult::Block {
+            reason: format!("BLOCKED by {hook}: {reason}. Fix: {fix}. Code: {code}."),
+        }
+    }
+
     /// Convenience constructor: `HookResult::error("message")`.
     pub fn error(message: impl Into<String>) -> Self {
         HookResult::Error {
@@ -92,5 +113,49 @@ mod tests {
         assert_eq!(HookResult::Continue.exit_code(), 0);
         assert_eq!(HookResult::block("x").exit_code(), 2);
         assert_eq!(HookResult::error("y").exit_code(), 1);
+    }
+
+    #[test]
+    fn block_with_fix_formats_canonical_line() {
+        let r = HookResult::block_with_fix(
+            "verify-git-push",
+            "Force push overwrites remote history irreversibly",
+            "Use 'git push --force-with-lease' for safe force push",
+            "git_push_force",
+        );
+        match r {
+            HookResult::Block { reason } => {
+                assert_eq!(
+                    reason,
+                    "BLOCKED by verify-git-push: Force push overwrites remote history irreversibly. Fix: Use 'git push --force-with-lease' for safe force push. Code: git_push_force."
+                );
+            }
+            _ => panic!("expected Block"),
+        }
+    }
+
+    #[test]
+    fn block_with_fix_strips_trailing_periods_to_avoid_duplication() {
+        let r = HookResult::block_with_fix(
+            "h",
+            "Reason already ends in period.",
+            "Recommendation already ends in period.",
+            "code",
+        );
+        match r {
+            HookResult::Block { reason } => {
+                // Verify exactly one period after each segment, never doubled.
+                assert!(!reason.contains(".."));
+                assert!(reason.contains("Reason already ends in period."));
+                assert!(reason.contains("Recommendation already ends in period."));
+            }
+            _ => panic!("expected Block"),
+        }
+    }
+
+    #[test]
+    fn block_with_fix_exit_code_matches_block() {
+        let r = HookResult::block_with_fix("h", "r", "f", "c");
+        assert_eq!(r.exit_code(), 2);
     }
 }

--- a/plugins/vsdd-factory/hooks/lib/block.sh
+++ b/plugins/vsdd-factory/hooks/lib/block.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# block.sh — canonical block-message helper for all PreToolUse blocking hooks.
+#
+# Source from each hook with:
+#   source "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh"
+#
+# Provides two functions:
+#   block_pre <hook> <reason> <recommendation> <code> [k=v ...]
+#       Single-line stderr block in canonical Why/Fix/Code form, then exit 2.
+#       Designed so the message survives legacy-bash-adapter truncation
+#       (which takes only the first stderr line).
+#
+#   block_pre_json <hook> <reason> <recommendation> <code> [k=v ...]
+#       Same canonical message but emitted via PreToolUse JSON envelope as
+#       permissionDecision: deny + permissionDecisionReason. Used by
+#       hooks that prefer the JSON path (protect-bc, protect-vp).
+#
+# Telemetry: both helpers call the project's emit-event tool if available;
+# silent no-op otherwise.
+
+# Internal: emit telemetry without ever causing the hook to fail.
+_emit() {
+  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" ]; then
+    "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" "$@" 2>/dev/null || true
+  fi
+  return 0
+}
+
+# Internal: trim trailing period so we can re-add it consistently.
+_strip_trailing_period() {
+  local s="$1"
+  s="${s%.}"
+  printf '%s' "$s"
+}
+
+# Format the canonical block line.
+# Args: <hook> <reason> <recommendation> <code>
+_format_block_line() {
+  local hook="$1" reason="$2" rec="$3" code="$4"
+  reason="$(_strip_trailing_period "$reason")"
+  rec="$(_strip_trailing_period "$rec")"
+  printf 'BLOCKED by %s: %s. Fix: %s. Code: %s.' "$hook" "$reason" "$rec" "$code"
+}
+
+# Public: bash exit-2 block.
+# Usage: block_pre <hook> <reason> <recommendation> <code> [extra_emit_kv...]
+block_pre() {
+  local hook="${1:?block_pre: hook name required}"; shift
+  local reason="${1:?block_pre: reason required}"; shift
+  local rec="${1:?block_pre: recommendation required}"; shift
+  local code="${1:?block_pre: reason code required}"; shift
+  _emit type=hook.block hook="$hook" reason="$code" "$@"
+  _format_block_line "$hook" "$reason" "$rec" "$code" >&2
+  printf '\n' >&2
+  exit 2
+}
+
+# Public: PreToolUse JSON envelope deny.
+# Usage: block_pre_json <hook> <reason> <recommendation> <code> [extra_emit_kv...]
+# Requires jq.
+block_pre_json() {
+  local hook="${1:?block_pre_json: hook name required}"; shift
+  local reason="${1:?block_pre_json: reason required}"; shift
+  local rec="${1:?block_pre_json: recommendation required}"; shift
+  local code="${1:?block_pre_json: reason code required}"; shift
+  _emit type=hook.block hook="$hook" reason="$code" "$@"
+  local msg
+  msg="$(_format_block_line "$hook" "$reason" "$rec" "$code")"
+  jq -nc --arg msg "$msg" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: $msg
+    }
+  }'
+  exit 0
+}

--- a/plugins/vsdd-factory/hooks/lib/block.sh
+++ b/plugins/vsdd-factory/hooks/lib/block.sh
@@ -26,10 +26,13 @@ _emit() {
   return 0
 }
 
-# Internal: trim trailing period so we can re-add it consistently.
+# Internal: trim ALL trailing periods so we can re-add exactly one consistently.
+# Uses a loop to match Rust's trim_end_matches('.') greedy behavior — both strip
+# every trailing period, not just the last one. Prevents double-period sequences
+# when callers pass strings already ending in '.'.
 _strip_trailing_period() {
   local s="$1"
-  s="${s%.}"
+  while [[ "$s" == *. ]]; do s="${s%.}"; done
   printf '%s' "$s"
 }
 
@@ -57,13 +60,20 @@ block_pre() {
 
 # Public: PreToolUse JSON envelope deny.
 # Usage: block_pre_json <hook> <reason> <recommendation> <code> [extra_emit_kv...]
-# Requires jq.
+# Requires jq. If jq is unavailable, falls back to block_pre (stderr + exit 2)
+# so the call is never silently allowed.
 block_pre_json() {
   local hook="${1:?block_pre_json: hook name required}"; shift
   local reason="${1:?block_pre_json: reason required}"; shift
   local rec="${1:?block_pre_json: recommendation required}"; shift
   local code="${1:?block_pre_json: reason code required}"; shift
   _emit type=hook.block hook="$hook" reason="$code" "$@"
+  # Fail-safe: if jq is absent fall back to the stderr+exit-2 path rather than
+  # silently allowing the tool call (exit 0 with no JSON envelope).
+  if ! command -v jq >/dev/null 2>&1; then
+    block_pre "$hook" "$reason" "$rec" "$code"
+    # block_pre exits 2; unreachable
+  fi
   local msg
   msg="$(_format_block_line "$hook" "$reason" "$rec" "$code")"
   jq -nc --arg msg "$msg" '{

--- a/plugins/vsdd-factory/hooks/purity-check.sh
+++ b/plugins/vsdd-factory/hooks/purity-check.sh
@@ -67,14 +67,14 @@ for p in "${PATTERNS[@]}"; do
 done
 
 if (( ${#HITS[@]} > 0 )); then
-  _emit type=hook.block hook=purity-check matcher=PostToolUse \
+  _emit type=hook.warn hook=purity-check matcher=PostToolUse \
         reason=pure_core_boundary_violation file_path="$FILE_PATH" severity=warn \
         patterns="${HITS[*]}"
-  echo "purity-check: $FILE_PATH is in a pure-core path but contains side-effect patterns:" >&2
+  echo "purity-check [ADVISORY]: $FILE_PATH is in a pure-core path but contains side-effect patterns:" >&2
   for h in "${HITS[@]}"; do
     echo "  - $h" >&2
   done
-  echo "Consider moving side effects to an adapter layer. See SOUL.md (pure-core boundary)." >&2
+  echo "Fix: Move the side effect to an adapter at crates/<crate>/src/adapters/ and call it from the pure-core function via dependency injection or an explicit interface. See SOUL.md section pure-core boundary." >&2
 fi
 
 exit 0

--- a/plugins/vsdd-factory/hooks/validate-changelog-monotonicity.sh
+++ b/plugins/vsdd-factory/hooks/validate-changelog-monotonicity.sh
@@ -13,6 +13,12 @@
 
 set -euo pipefail
 
+# Source canonical block-message helper if available (provides block_pre).
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh" ]; then
+  # shellcheck source=lib/block.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh"
+fi
+
 if ! command -v jq &>/dev/null; then
   exit 0
 fi
@@ -60,6 +66,7 @@ FM_VERSION=$(awk '
 ' "$FILE_PATH")
 
 ERRORS=""
+FIRST_CODE=""
 PREV_VERSION=""
 PREV_DATE=""
 FIRST_VERSION=""
@@ -124,12 +131,14 @@ while IFS= read -r line; do
     # Check version ordering (must be strictly decreasing)
     if [[ -n "$PREV_VERSION" ]] && [[ "$PREV_VERSION" == "$VERSION" ]]; then
       ERRORS="${ERRORS:+$ERRORS\n}Line $LINE_NUM: duplicate version '$VERSION' (also at prior row)"
+      [[ -z "$FIRST_CODE" ]] && FIRST_CODE="changelog_duplicate_version"
     fi
 
     # Check date ordering (must be non-increasing — newer at top)
     if [[ -n "$PREV_DATE" ]] && [[ -n "$DATE" ]]; then
       if [[ "$DATE" > "$PREV_DATE" ]]; then
         ERRORS="${ERRORS:+$ERRORS\n}Line $LINE_NUM: date '$DATE' is newer than prior row '$PREV_DATE' — changelog should be newest-first"
+        [[ -z "$FIRST_CODE" ]] && FIRST_CODE="changelog_date_out_of_order"
       fi
     fi
 
@@ -144,17 +153,41 @@ done < "$FILE_PATH"
 if [[ -n "$FM_VERSION" ]] && [[ -n "$FIRST_VERSION" ]]; then
   if [[ "$FM_VERSION" != "$FIRST_VERSION" ]]; then
     ERRORS="${ERRORS:+$ERRORS\n}Frontmatter version '$FM_VERSION' != top changelog version '$FIRST_VERSION'"
+    [[ -z "$FIRST_CODE" ]] && FIRST_CODE="changelog_frontmatter_mismatch"
   fi
 fi
 
 if [[ -n "$ERRORS" ]]; then
-  _emit type=hook.block hook=validate-changelog-monotonicity matcher=PostToolUse \
-        reason=changelog_not_monotonic file_path="$FILE_PATH"
-  echo "CHANGELOG MONOTONICITY VIOLATION in $(basename "$FILE_PATH"):" >&2
-  echo -e "$ERRORS" | while IFS= read -r line; do
-    echo "  - $line" >&2
-  done
-  exit 2
+  # Determine the most-actionable recommendation based on the first detected code.
+  case "${FIRST_CODE:-changelog_duplicate_version}" in
+    changelog_duplicate_version)
+      _REC="Bump the most recent occurrence to the next semver, or remove the duplicate row"
+      ;;
+    changelog_date_out_of_order)
+      _REC="Reorder rows newest-first, or correct the row's date"
+      ;;
+    changelog_frontmatter_mismatch)
+      _REC="Set frontmatter 'version:' to match the top changelog row"
+      ;;
+    *)
+      _REC="Review the changelog ordering violations listed above"
+      ;;
+  esac
+
+  _REASON="CHANGELOG MONOTONICITY VIOLATION in $(basename "$FILE_PATH"): $(echo -e "$ERRORS" | head -1)"
+
+  if declare -f block_pre >/dev/null 2>&1; then
+    block_pre "validate-changelog-monotonicity" \
+      "$_REASON" \
+      "$_REC" \
+      "${FIRST_CODE:-changelog_duplicate_version}"
+    # block_pre exits 2; unreachable
+  else
+    _emit type=hook.block hook=validate-changelog-monotonicity matcher=PostToolUse \
+          reason="${FIRST_CODE:-changelog_not_monotonic}" file_path="$FILE_PATH"
+    echo "BLOCKED by validate-changelog-monotonicity: ${_REASON}. Fix: ${_REC}. Code: ${FIRST_CODE:-changelog_duplicate_version}." >&2
+    exit 2
+  fi
 fi
 
 exit 0

--- a/plugins/vsdd-factory/hooks/validate-count-propagation.sh
+++ b/plugins/vsdd-factory/hooks/validate-count-propagation.sh
@@ -18,6 +18,19 @@
 
 set -euo pipefail
 
+# Source canonical block-message helper if available (provides block_pre).
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh" ]; then
+  # shellcheck source=lib/block.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh"
+fi
+
+_emit() {
+  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" ]; then
+    "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" "$@" 2>/dev/null || true
+  fi
+  return 0
+}
+
 if ! command -v jq &>/dev/null; then
   exit 0
 fi
@@ -150,10 +163,22 @@ for keyword in "${!SOURCE_COUNTS[@]}"; do
 done
 
 if [[ "$DRIFT_DETECTED" -eq 1 ]]; then
-  for msg in "${DRIFT_MESSAGES[@]}"; do
-    echo "$msg" >&2
-  done
-  exit 2
+  _ALL_DRIFT="${DRIFT_MESSAGES[*]}"
+  _REASON="Count propagation drift detected in $(basename "$FILE_PATH"): ${DRIFT_MESSAGES[0]}"
+  _REC="Update the lagging index to match the source-of-truth count: BC-INDEX total_bcs, ARCH-INDEX subsystem counts, or STORY-INDEX bcs count — see the specific drift cited above"
+
+  if declare -f block_pre >/dev/null 2>&1; then
+    block_pre "validate-count-propagation" \
+      "$_REASON" \
+      "$_REC" \
+      "count_propagation_drift"
+    # block_pre exits 2; unreachable
+  else
+    _emit type=hook.block hook=validate-count-propagation matcher=PostToolUse \
+          reason=count_propagation_drift file_path="$FILE_PATH"
+    echo "BLOCKED by validate-count-propagation: ${_REASON}. Fix: ${_REC}. Code: count_propagation_drift." >&2
+    exit 2
+  fi
 fi
 
 exit 0

--- a/plugins/vsdd-factory/hooks/validate-red-ratio.sh
+++ b/plugins/vsdd-factory/hooks/validate-red-ratio.sh
@@ -17,6 +17,12 @@
 
 set -euo pipefail
 
+# Source canonical block-message helper if available (provides block_pre).
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh" ]; then
+  # shellcheck source=lib/block.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh"
+fi
+
 if ! command -v jq &>/dev/null; then
   exit 0
 fi
@@ -99,9 +105,15 @@ total_effective=$(( total_new_tests - exempt_count ))
 # If total_effective <= 0 and no full_exception_path acknowledgment, block
 if (( total_effective <= 0 )); then
   _emit type=hook.block hook=validate-red-ratio matcher=PostToolUse \
-        reason=red_ratio_below_threshold file_path="$FILE_PATH"
-  echo "RED_RATIO BLOCK: total_effective=0 with no full_exception_path acknowledgment story=${STORY_ID}" >&2
-  exit 2
+        reason=red_ratio_zero_total file_path="$FILE_PATH"
+  _REASON="RED_RATIO BLOCK: total_effective=0 with no full_exception_path acknowledgment story=${STORY_ID}"
+  _REC="Add at least one acceptance criterion to the story, or set full_exception_path: true in story frontmatter with rationale if the story is intentionally implementation-only"
+  if declare -f block_pre >/dev/null 2>&1; then
+    block_pre "validate-red-ratio" "$_REASON" "$_REC" "red_ratio_zero_total"
+  else
+    echo "BLOCKED by validate-red-ratio: ${_REASON}. Fix: ${_REC}. Code: red_ratio_zero_total." >&2
+    exit 2
+  fi
 fi
 
 # Integer-precise RED_RATIO check: red_count * 2 >= total_effective
@@ -114,6 +126,12 @@ else
   # RED_RATIO < 0.5 — block
   _emit type=hook.block hook=validate-red-ratio matcher=PostToolUse \
         reason=red_ratio_below_threshold file_path="$FILE_PATH"
-  echo "RED_RATIO BLOCK: ratio=${red_count}/${total_effective} threshold=0.5 story=${STORY_ID} path=${FILE_PATH}" >&2
-  exit 2
+  _REASON="RED_RATIO BLOCK: ratio=${red_count}/${total_effective} threshold=0.5 story=${STORY_ID}"
+  _REC="Write more failing tests OR mark untested-but-acknowledged ACs with full_exception_path: true in the story frontmatter (with rationale). See per-story-delivery.md section Red Gate"
+  if declare -f block_pre >/dev/null 2>&1; then
+    block_pre "validate-red-ratio" "$_REASON" "$_REC" "red_ratio_below_threshold"
+  else
+    echo "BLOCKED by validate-red-ratio: ${_REASON}. Fix: ${_REC}. Code: red_ratio_below_threshold." >&2
+    exit 2
+  fi
 fi

--- a/tests/integration/hooks/block-helper.bats
+++ b/tests/integration/hooks/block-helper.bats
@@ -1,0 +1,80 @@
+#!/usr/bin/env bats
+# tests/integration/hooks/block-helper.bats
+#
+# Unit tests for plugins/vsdd-factory/hooks/lib/block.sh.
+#
+# Tests:
+#   1. block_pre exits 2
+#   2. block_pre stderr is exactly one line in canonical format
+#   3. block_pre does not duplicate trailing periods
+#   4. block_pre_json exits 0 and emits valid JSON with permissionDecision: "deny"
+#      and permissionDecisionReason matching the canonical line
+#
+# Run: bats tests/integration/hooks/block-helper.bats
+
+setup() {
+    REPO_ROOT="$(git -C "$(dirname "$BATS_TEST_FILENAME")" rev-parse --show-toplevel)"
+    BLOCK_SH="${REPO_ROOT}/plugins/vsdd-factory/hooks/lib/block.sh"
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: block_pre exits 2
+# ---------------------------------------------------------------------------
+
+@test "block_pre exits 2" {
+    run bash -c "source '${BLOCK_SH}'; block_pre my-hook 'Something went wrong' 'Try this fix' 'err_code' 2>/dev/null"
+    [ "$status" -eq 2 ]
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: block_pre stderr is exactly one line in canonical BLOCKED format
+# ---------------------------------------------------------------------------
+
+@test "block_pre emits exactly one stderr line in BLOCKED by X: Y. Fix: Z. Code: W. format" {
+    run bash -c "source '${BLOCK_SH}'; block_pre my-hook 'Something went wrong' 'Try this fix' 'err_code'" 2>&1
+    # Count non-empty lines in the output
+    line_count=$(printf '%s' "$output" | grep -c '.' || true)
+    [ "$line_count" -eq 1 ]
+    # Must match the canonical format
+    echo "$output" | grep -q '^BLOCKED by my-hook: Something went wrong\. Fix: Try this fix\. Code: err_code\.$'
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: block_pre does not duplicate trailing periods on reason/recommendation
+# ---------------------------------------------------------------------------
+
+@test "block_pre strips trailing periods to avoid double-period sequences" {
+    run bash -c "source '${BLOCK_SH}'; block_pre my-hook 'Reason already ends in period.' 'Recommendation already ends.' 'code'" 2>&1
+    # Must not contain any double-period
+    echo "$output" | grep -qv '\.\.'
+    # Must still contain single-period-terminated reason and recommendation
+    echo "$output" | grep -q 'Reason already ends in period\.'
+    echo "$output" | grep -q 'Recommendation already ends\.'
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: block_pre_json exits 0 and emits valid JSON with permissionDecision deny
+# ---------------------------------------------------------------------------
+
+@test "block_pre_json exits 0 and emits JSON with permissionDecision: deny" {
+    if ! command -v jq &>/dev/null; then
+        skip "jq not available"
+    fi
+    run bash -c "source '${BLOCK_SH}'; block_pre_json verify-git-push 'Force push is destructive' 'Use --force-with-lease instead' 'git_force_push'"
+    [ "$status" -eq 0 ]
+    # Output must be valid JSON
+    echo "$output" | jq empty
+    # Must contain permissionDecision: "deny"
+    decision=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecision')
+    [ "$decision" = "deny" ]
+}
+
+@test "block_pre_json permissionDecisionReason matches canonical line format" {
+    if ! command -v jq &>/dev/null; then
+        skip "jq not available"
+    fi
+    run bash -c "source '${BLOCK_SH}'; block_pre_json verify-git-push 'Force push is destructive' 'Use --force-with-lease instead' 'git_force_push'"
+    [ "$status" -eq 0 ]
+    reason=$(echo "$output" | jq -r '.hookSpecificOutput.permissionDecisionReason')
+    [ "$reason" = "BLOCKED by verify-git-push: Force push is destructive. Fix: Use --force-with-lease instead. Code: git_force_push." ]
+}


### PR DESCRIPTION
## Summary

- **Slice 1 — Foundation:** New shared bash helper `plugins/vsdd-factory/hooks/lib/block.sh` (`block_pre` / `block_pre_json`) emitting the canonical single-line `BLOCKED by <hook>: <reason>. Fix: <fix>. Code: <code>.` format. Fixed `legacy-bash-adapter` to capture **full stderr** (4 KiB cap) on exit 2 instead of only the first line — closes the truncation bug that dropped multi-line diagnostic content before it reached Claude Code. Added `HookResult::block_with_fix()` to hook-sdk as the canonical WASM constructor.
- **Slice 2 — User-visible fixes:** Migrated 3 Tier B bash hooks (`validate-changelog-monotonicity`, `validate-count-propagation`, `validate-red-ratio`) to use `block_pre` with per-failure-mode Fix recommendations and structured codes. Sharpened `purity-check` advisory message (still non-blocking). Rewrote `block-ai-attribution` WASM plugin to return `Attribution { reason, recommendation, code }` struct and use `HookResult::block_with_fix`.

## What changed

| File | Change |
|------|--------|
| `plugins/vsdd-factory/hooks/lib/block.sh` | New shared helper (Slice 1) |
| `tests/integration/hooks/block-helper.bats` | 5 bats unit tests for block.sh |
| `crates/hook-plugins/legacy-bash-adapter/src/lib.rs` | Full-stderr capture on exit 2, 2 new unit tests |
| `crates/hook-sdk/src/result.rs` | `block_with_fix()` constructor + 3 unit tests |
| `plugins/vsdd-factory/hooks/validate-changelog-monotonicity.sh` | block_pre with 3 failure codes + Fix lines |
| `plugins/vsdd-factory/hooks/validate-count-propagation.sh` | block_pre with count_propagation_drift + Fix |
| `plugins/vsdd-factory/hooks/validate-red-ratio.sh` | block_pre with zero_total / below_threshold codes + Fix |
| `plugins/vsdd-factory/hooks/purity-check.sh` | Sharpened advisory message (non-blocking, no block_pre) |
| `crates/hook-plugins/block-ai-attribution/src/lib.rs` | Attribution struct + block_with_fix |
| `crates/hook-plugins/block-ai-attribution/tests/contract_pattern_matching.rs` | Updated for Attribution struct fields |

## Test plan

- [x] `cargo test --workspace --no-fail-fast` — all tests pass (0 failures)
- [x] `bats tests/integration/hooks/block-helper.bats` — 5/5 pass
- [x] `bash -n` syntax check on all 4 Tier B hooks — pass
- [x] `bash -n plugins/vsdd-factory/hooks/lib/block.sh` — syntax OK

## Deferred (out of scope for this PR)

- 22 Tier A bash hook migrations to `lib/block.sh`
- Integration test asserting every blocking hook emits the canonical format
- `HOST_ABI.md` doc update

Closes hook-msg-canonical-1.