### PR TITLE
feat(hooks): Slice 3 — Tier A migrations + canonical-format invariant test + HOST_ABI docs

### DIFF
--- a/crates/hook-plugins/block-ai-attribution/src/lib.rs
+++ b/crates/hook-plugins/block-ai-attribution/src/lib.rs
@@ -43,7 +43,7 @@ const PHRASE_PATTERNS: &[(&str, &str)] = &[
 
 /// Detected AI attribution: (reason, recommendation, code).
 /// Returned by detect_attribution; consumed by on_hook_logic.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Attribution {
     pub reason: String,
     pub recommendation: String,

--- a/crates/hook-plugins/block-ai-attribution/tests/contract_pattern_matching.rs
+++ b/crates/hook-plugins/block-ai-attribution/tests/contract_pattern_matching.rs
@@ -183,17 +183,8 @@ fn test_BC_4_05_002_detect_attribution_returns_none_for_clean_commit() {
 #[test]
 fn test_BC_4_05_004_detect_attribution_is_pure_function() {
     // Calling it twice with the same input must return the same result.
-    // Since Attribution doesn't impl PartialEq, verify both are Some with
-    // identical fields — sufficient to confirm determinism.
     let cmd = "git commit -m \"fix\n\nCo-Authored-By: Claude <x@anthropic.com>\"";
     let a = detect_attribution(cmd);
     let b = detect_attribution(cmd);
-    match (a, b) {
-        (Some(a), Some(b)) => {
-            assert_eq!(a.reason, b.reason, "reason must be deterministic");
-            assert_eq!(a.code, b.code, "code must be deterministic");
-        }
-        (None, None) => {}
-        _ => panic!("pure function must return the same Some/None for the same input"),
-    }
+    assert_eq!(a, b, "pure function must return the same result for the same input");
 }

--- a/crates/hook-sdk/HOST_ABI.md
+++ b/crates/hook-sdk/HOST_ABI.md
@@ -380,3 +380,80 @@ preview-2 / component-model migration:
 
 ABI 2 will not be back-compatible with ABI 1 plugins; the dispatcher
 will load both during a transition window per the semver commitment.
+
+---
+
+## Block-message convention (canonical Why/Fix/Code)
+
+All blocking hooks (bash + WASM) emit a single-line stderr message or
+`permissionDecisionReason` in the form:
+
+    BLOCKED by <hook-name>: <reason>. Fix: <recommendation>. Code: <code>.
+
+This format survives the legacy-bash-adapter's stderr-capture path
+(which reads only the first stderr line up to a 4 KiB cap) and ensures
+every blocking hook tells the agent (a) why the block fired and (b) what
+to do next.
+
+### Bash hooks
+
+Source `${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh` and call one of:
+
+```bash
+# Standard PreToolUse / PostToolUse block (exit 2 + single-line stderr):
+source "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh"
+block_pre <hook-name> "<reason>" "<recommendation>" "<code>"
+
+# JSON-envelope deny (for hooks that use permissionDecision: deny):
+source "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh"
+block_pre_json <hook-name> "<reason>" "<recommendation>" "<code>"
+```
+
+`block_pre` automatically:
+- Strips trailing periods from reason and recommendation to avoid double periods.
+- Emits telemetry via `bin/emit-event` if available (silent no-op otherwise).
+- Writes the canonical line to stderr and exits 2.
+
+`block_pre_json` does the same but emits a JSON envelope to stdout with
+`permissionDecision: "deny"` and `permissionDecisionReason` set to the
+canonical line, then exits 0. Falls back to `block_pre` if `jq` is absent.
+
+### WASM hooks
+
+Use `HookResult::block_with_fix(hook, reason, recommendation, code)`
+instead of `HookResult::block(reason)`:
+
+```rust
+use vsdd_hook_sdk::HookResult;
+
+// Preferred (canonical Why/Fix/Code format):
+HookResult::block_with_fix(
+    "my-hook",
+    "Descriptive reason why the block fired",
+    "Actionable recommendation for how to fix it",
+    "snake_case_code",
+)
+
+// Avoid (no recommendation, no code — harder to diagnose):
+HookResult::block("bare reason string")
+```
+
+### Rules for hook authors
+
+1. `<hook-name>` must be the kebab-case hook filename without `.sh` /
+   `.wasm` suffix (e.g., `verify-git-push`, `block-ai-attribution`).
+2. `<reason>` answers "why did this block fire?" — be specific, include
+   the offending value where safe to do so.
+3. `<recommendation>` answers "what should I do to unblock?" — be
+   actionable (include a command or file to edit where possible).
+4. `<code>` is a `snake_case` identifier used for telemetry bucketing.
+   Use a stable, descriptive code (e.g., `git_push_force`, `bc_green_immutable`).
+5. Do NOT end `<reason>` or `<recommendation>` with a period — the
+   helper appends exactly one period to each field.
+
+### Related rules
+
+- `plugins/vsdd-factory/hooks/lib/block.sh` — the bash helper implementation.
+- `crates/vsdd-hook-sdk/src/lib.rs` — the `HookResult::block_with_fix` Rust API.
+- `tests/integration/hooks/block-helper.bats` — unit tests for the bash helper.
+- `tests/integration/hooks/canonical-format-invariant.bats` — per-hook regression tests.

--- a/plugins/vsdd-factory/hooks/brownfield-discipline.sh
+++ b/plugins/vsdd-factory/hooks/brownfield-discipline.sh
@@ -12,6 +12,12 @@
 
 set -euo pipefail
 
+# Source canonical block-message helper (provides block_pre).
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh" ]; then
+  # shellcheck source=lib/block.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh"
+fi
+
 if ! command -v jq &>/dev/null; then
   echo "brownfield-discipline.sh: jq is required but not found" >&2
   exit 1
@@ -25,19 +31,11 @@ if [[ -z "$FILE_PATH" ]]; then
   exit 0
 fi
 
-_emit() {
-  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" ]; then
-    "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" "$@" 2>/dev/null || true
-  fi
-  return 0
-}
-
 if [[ "$FILE_PATH" =~ (^|/)\.reference/ ]]; then
-  _emit type=hook.block hook=brownfield-discipline matcher="$TOOL_NAME" reason=reference_readonly file_path="$FILE_PATH"
-  echo "Blocked: $FILE_PATH is inside .reference/ which is read-only." >&2
-  echo "Reference codebases are used for brownfield analysis only — edits poison the extraction." >&2
-  echo "If you need to change reference material, update the source repo upstream and re-clone." >&2
-  exit 2
+  block_pre "brownfield-discipline" \
+    ".reference/ is read-only — edits poison brownfield extraction. Reference codebases are for analysis only" \
+    "Update the source repo upstream and re-clone" \
+    "reference_readonly"
 fi
 
 exit 0

--- a/plugins/vsdd-factory/hooks/convergence-tracker.sh
+++ b/plugins/vsdd-factory/hooks/convergence-tracker.sh
@@ -18,19 +18,18 @@
 
 set -euo pipefail
 
+# Source canonical block-message helper (provides block_pre).
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh" ]; then
+  # shellcheck source=lib/block.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh"
+fi
+
 if ! command -v jq &>/dev/null; then
   exit 0
 fi
 
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
-
-_emit() {
-  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" ]; then
-    "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" "$@" 2>/dev/null || true
-  fi
-  return 0
-}
 
 if [[ -z "$FILE_PATH" ]] || [[ ! -f "$FILE_PATH" ]]; then
   exit 0
@@ -176,15 +175,11 @@ if [[ -n "$WARNINGS" ]]; then
 fi
 
 if [[ -n "$ERRORS" ]]; then
-  _emit type=hook.block hook=convergence-tracker matcher=PostToolUse \
-        reason=convergence_rule_violation file_path="$FILE_PATH" \
-        verdict="${VERDICT:-}" novelty_score="${NOVELTY_SCORE:-}"
-  echo "CONVERGENCE RULE VIOLATION — BLOCKED:" >&2
-  echo -e "$ERRORS" | while IFS= read -r line; do
-    echo "  ✗ $line" >&2
-  done
-  echo "  See CONVERGENCE.md for the full quantitative criteria." >&2
-  exit 2
+  _ERRORS_SUMMARY=$(echo -e "$ERRORS" | head -1)
+  block_pre "convergence-tracker" \
+    "Convergence rule violated: $_ERRORS_SUMMARY" \
+    "See CONVERGENCE.md for the full quantitative criteria" \
+    "convergence_rule_violation"
 fi
 
 exit 0

--- a/plugins/vsdd-factory/hooks/destructive-command-guard.sh
+++ b/plugins/vsdd-factory/hooks/destructive-command-guard.sh
@@ -19,6 +19,12 @@
 
 set -euo pipefail
 
+# Source canonical block-message helper (provides block_pre).
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh" ]; then
+  # shellcheck source=lib/block.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh"
+fi
+
 if ! command -v jq &>/dev/null; then
   exit 0
 fi
@@ -29,29 +35,6 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
 if [[ -z "$COMMAND" ]]; then
   exit 0
 fi
-
-# _emit — failure-tolerant wrapper around bin/emit-event.
-# Silently does nothing if emit-event is missing or CLAUDE_PLUGIN_ROOT unset.
-# Must never cause the hook to fail, so every path returns 0.
-_emit() {
-  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" ]; then
-    "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" "$@" 2>/dev/null || true
-  fi
-  return 0
-}
-
-block() {
-  local reason="$1"
-  local suggestion="${2:-}"
-  local code="${3:-unknown}"
-  _emit type=hook.block hook=destructive-command-guard matcher=Bash reason="$code" command="$COMMAND"
-  echo "BLOCKED by destructive-command-guard:" >&2
-  echo "  $reason" >&2
-  if [[ -n "$suggestion" ]]; then
-    echo "  Suggestion: $suggestion" >&2
-  fi
-  exit 2
-}
 
 # Regex fragment matching rm with a recursive flag (-r, -R, -rf, -fr, -Rf,
 # -fR, or long forms --recursive / -r combined with --force).
@@ -76,9 +59,9 @@ for target_re in \
   '\.\*' \
   ; do
   if echo "$COMMAND" | grep -qE "${RM_RECURSIVE}[^|&;]*\s${target_re}(\s|\$|;|&|\|)"; then
-    block \
+    block_pre "destructive-command-guard" \
       "Catastrophic rm target detected: $COMMAND" \
-      "Never 'rm -rf' system roots, home, or unscoped wildcards. Target a specific directory." \
+      "Never 'rm -rf' system roots, home, or unscoped wildcards. Target a specific directory" \
       "catastrophic_root"
   fi
 done
@@ -97,9 +80,9 @@ if echo "$COMMAND" | grep -qE "$RM_RECURSIVE"; then
       if echo "$COMMAND" | grep -qE '\brm\b[^|&;]*\b(target|node_modules|dist|build|\.next|__pycache__|\.pytest_cache)/'; then
         continue
       fi
-      block \
+      block_pre "destructive-command-guard" \
         "rm -rf on protected path detected: $COMMAND" \
-        "Deleting .factory/, src/, or tests/ causes irreversible data loss. Remove specific files instead." \
+        "Deleting .factory/, src/, or tests/ causes irreversible data loss. Remove specific files instead" \
         "protected_path_delete"
     fi
   done
@@ -113,9 +96,9 @@ SOT_FILES=(STATE.md BC-INDEX.md VP-INDEX.md STORY-INDEX.md ARCH-INDEX.md HS-INDE
 if echo "$COMMAND" | grep -qE '\brm\b'; then
   for sot_file in "${SOT_FILES[@]}"; do
     if [[ "$COMMAND" == *"$sot_file"* ]]; then
-      block \
+      block_pre "destructive-command-guard" \
         "Cannot delete source-of-truth file: $sot_file" \
-        "$sot_file is an authoritative artifact. Update it in place — do not delete." \
+        "$sot_file is an authoritative artifact. Update it in place — do not delete" \
         "sot_delete"
     fi
   done
@@ -130,30 +113,30 @@ for sot_file in "${SOT_FILES[@]}"; do
   # Clobbering redirect: `> FILE` or `> path/FILE` (but NOT `>> FILE`)
   # The [^>] lookbehind prevents matching >>.
   if echo "$COMMAND" | grep -qE "(^|[^>])>\s*[^ ]*${sot_file}(\s|$|;|&|\|)"; then
-    block \
+    block_pre "destructive-command-guard" \
       "Clobbering redirect to source-of-truth file: $sot_file" \
-      "Use '>>' to append, or edit the file with sed/Edit instead of overwriting." \
+      "Use '>>' to append, or edit the file with sed/Edit instead of overwriting" \
       "sot_clobber_redirect"
   fi
   # `: > FILE` truncation (idiom)
   if echo "$COMMAND" | grep -qE ":\s*>\s*[^ ]*${sot_file}(\s|$|;|&|\|)"; then
-    block \
+    block_pre "destructive-command-guard" \
       "Truncating source-of-truth file via ': >': $sot_file" \
-      "$sot_file must not be emptied. Edit in place instead." \
+      "$sot_file must not be emptied. Edit in place instead" \
       "sot_truncate_colon"
   fi
   # truncate -s 0 FILE
   if echo "$COMMAND" | grep -qE "\btruncate\b[^|&;]*${sot_file}"; then
-    block \
+    block_pre "destructive-command-guard" \
       "Truncating source-of-truth file: $sot_file" \
-      "$sot_file must not be emptied. Edit in place instead." \
+      "$sot_file must not be emptied. Edit in place instead" \
       "sot_truncate_cmd"
   fi
   # cp /dev/null FILE
   if echo "$COMMAND" | grep -qE "\bcp\b[^|&;]*/dev/null[^|&;]*${sot_file}"; then
-    block \
+    block_pre "destructive-command-guard" \
       "Wiping source-of-truth file via cp /dev/null: $sot_file" \
-      "$sot_file must not be emptied. Edit in place instead." \
+      "$sot_file must not be emptied. Edit in place instead" \
       "sot_clobber_cpnull"
   fi
 done
@@ -166,9 +149,9 @@ if echo "$COMMAND" | grep -qE '\bfind\b[^|&;]*(-delete|-exec\s+rm\b)'; then
   # - .factory followed by word-boundary (end, slash, or space)
   # - src/tests as full words
   if echo "$COMMAND" | grep -qE '\.factory\b|\bsrc\b|\btests\b'; then
-    block \
+    block_pre "destructive-command-guard" \
       "find with -delete or -exec rm on protected path: $COMMAND" \
-      "find -delete bypasses rm safety checks. Remove specific files explicitly." \
+      "find -delete bypasses rm safety checks. Remove specific files explicitly" \
       "find_delete_protected"
   fi
 fi
@@ -177,9 +160,9 @@ fi
 # git reset --hard (discards uncommitted work)
 # ---------------------------------------------------------------------------
 if [[ "$COMMAND" == *"git reset --hard"* ]] || [[ "$COMMAND" == *"git reset -hard"* ]]; then
-  block \
-    "git reset --hard discards all uncommitted changes irreversibly." \
-    "Use 'git stash' to preserve changes, or 'git reset --soft' to unstage without losing work." \
+  block_pre "destructive-command-guard" \
+    "git reset --hard discards all uncommitted changes irreversibly" \
+    "Use 'git stash' to preserve changes, or 'git reset --soft' to unstage without losing work" \
     "git_reset_hard"
 fi
 
@@ -190,9 +173,9 @@ if [[ "$COMMAND" == *"git clean"* ]]; then
   if [[ "$COMMAND" == *"-n"* ]] || [[ "$COMMAND" == *"--dry-run"* ]]; then
     : # dry-run is fine
   elif [[ "$COMMAND" == *"-f"* ]] || [[ "$COMMAND" == *"--force"* ]]; then
-    block \
-      "git clean -f removes untracked files irreversibly. This can delete specs, stories, and pipeline state." \
-      "Use 'git clean -n' for a dry-run first, then selectively remove specific files." \
+    block_pre "destructive-command-guard" \
+      "git clean -f removes untracked files irreversibly. This can delete specs, stories, and pipeline state" \
+      "Use 'git clean -n' for a dry-run first, then selectively remove specific files" \
       "git_clean_force"
   fi
 fi
@@ -201,15 +184,15 @@ fi
 # git checkout -- . / git restore . (discard all working tree changes)
 # ---------------------------------------------------------------------------
 if [[ "$COMMAND" == *"git checkout -- ."* ]] || [[ "$COMMAND" == *"git checkout -- '*'"* ]]; then
-  block \
-    "git checkout -- . discards all working tree changes irreversibly." \
-    "Use 'git stash' to preserve changes, or target specific files: 'git checkout -- <file>'." \
+  block_pre "destructive-command-guard" \
+    "git checkout -- . discards all working tree changes irreversibly" \
+    "Use 'git stash' to preserve changes, or target specific files: 'git checkout -- <file>'" \
     "git_checkout_dot"
 fi
 if [[ "$COMMAND" == *"git restore ."* ]] || [[ "$COMMAND" == *"git restore --staged ."* ]]; then
-  block \
-    "git restore . discards all working tree changes irreversibly." \
-    "Target specific files: 'git restore <file>'." \
+  block_pre "destructive-command-guard" \
+    "git restore . discards all working tree changes irreversibly" \
+    "Target specific files: 'git restore <file>'" \
     "git_restore_dot"
 fi
 
@@ -217,9 +200,9 @@ fi
 # git stash drop / git stash clear (discards stashed work)
 # ---------------------------------------------------------------------------
 if echo "$COMMAND" | grep -qE '\bgit\s+stash\s+(drop|clear)\b'; then
-  block \
-    "git stash drop/clear discards stashed work irreversibly." \
-    "If the stash is genuinely unneeded, use 'git stash show -p' to verify first, then run outside this hook context." \
+  block_pre "destructive-command-guard" \
+    "git stash drop/clear discards stashed work irreversibly" \
+    "If the stash is genuinely unneeded, use 'git stash show -p' to verify first, then run outside this hook context" \
     "git_stash_discard"
 fi
 
@@ -227,9 +210,9 @@ fi
 # git branch -D on protected branches (force-delete local main/master/develop)
 # ---------------------------------------------------------------------------
 if echo "$COMMAND" | grep -qE '\bgit\s+branch\s+-D\s+(main|master|develop)\b'; then
-  block \
+  block_pre "destructive-command-guard" \
     "git branch -D on a protected local branch: $COMMAND" \
-    "Protected branches should not be force-deleted locally. Check out another branch instead." \
+    "Protected branches should not be force-deleted locally. Check out another branch instead" \
     "git_branch_d_protected"
 fi
 
@@ -237,9 +220,9 @@ fi
 # git filter-branch / git filter-repo (rewrites history across all refs)
 # ---------------------------------------------------------------------------
 if echo "$COMMAND" | grep -qE '\bgit\s+(filter-branch|filter-repo)\b'; then
-  block \
-    "git filter-branch/filter-repo rewrites history across all refs — effectively unrecoverable." \
-    "If you truly need to rewrite history, do it in a fresh clone with explicit user confirmation." \
+  block_pre "destructive-command-guard" \
+    "git filter-branch/filter-repo rewrites history across all refs — effectively unrecoverable" \
+    "If you truly need to rewrite history, do it in a fresh clone with explicit user confirmation" \
     "git_filter_history"
 fi
 
@@ -247,15 +230,15 @@ fi
 # git reflog expire + git gc --prune=now (removes the undo safety net)
 # ---------------------------------------------------------------------------
 if echo "$COMMAND" | grep -qE '\bgit\s+reflog\s+expire\b.*--expire=now'; then
-  block \
-    "git reflog expire --expire=now removes the recovery safety net for dangling commits." \
-    "Let reflog expire naturally (default 90 days)." \
+  block_pre "destructive-command-guard" \
+    "git reflog expire --expire=now removes the recovery safety net for dangling commits" \
+    "Let reflog expire naturally (default 90 days)" \
     "git_reflog_expire"
 fi
 if echo "$COMMAND" | grep -qE '\bgit\s+gc\b.*--prune=now'; then
-  block \
-    "git gc --prune=now removes dangling objects immediately — you lose recovery options." \
-    "Use 'git gc' (with default 2-week grace) or skip pruning." \
+  block_pre "destructive-command-guard" \
+    "git gc --prune=now removes dangling objects immediately — you lose recovery options" \
+    "Use 'git gc' (with default 2-week grace) or skip pruning" \
     "git_gc_prune_now"
 fi
 
@@ -264,9 +247,9 @@ fi
 # ---------------------------------------------------------------------------
 if echo "$COMMAND" | grep -qE '\bgit\s+worktree\s+remove\s+.*--force\b'; then
   if [[ "$COMMAND" != *".worktrees/"* ]]; then
-    block \
+    block_pre "destructive-command-guard" \
       "git worktree remove --force outside .worktrees/: $COMMAND" \
-      "--force discards uncommitted changes in the worktree. Commit or stash first, or target a .worktrees/ path." \
+      "--force discards uncommitted changes in the worktree. Commit or stash first, or target a .worktrees/ path" \
       "git_worktree_force"
   fi
 fi
@@ -275,15 +258,15 @@ fi
 # --no-verify / --no-gpg-sign on git commit (bypasses hooks we built)
 # ---------------------------------------------------------------------------
 if echo "$COMMAND" | grep -qE '\bgit\s+(commit|merge|rebase|cherry-pick|am)\b[^|&;]*--no-verify\b'; then
-  block \
-    "--no-verify bypasses the hooks that enforce attribution, SoT protection, and wave gates." \
-    "Fix the underlying issue that triggered the hook. If a hook is wrong, update the hook." \
+  block_pre "destructive-command-guard" \
+    "--no-verify bypasses the hooks that enforce attribution, SoT protection, and wave gates" \
+    "Fix the underlying issue that triggered the hook. If a hook is wrong, update the hook" \
     "git_no_verify"
 fi
 if echo "$COMMAND" | grep -qE '\bgit\s+commit\b[^|&;]*--no-gpg-sign\b'; then
-  block \
-    "--no-gpg-sign bypasses commit signing." \
-    "If a signing key is missing, fix the config rather than skipping the signature." \
+  block_pre "destructive-command-guard" \
+    "--no-gpg-sign bypasses commit signing" \
+    "If a signing key is missing, fix the config rather than skipping the signature" \
     "git_no_gpg_sign"
 fi
 
@@ -293,9 +276,9 @@ fi
 if [[ "$COMMAND" == *"git rm"* ]]; then
   for protected in ".factory/specs/" ".factory/stories/" ".factory/STATE.md"; do
     if [[ "$COMMAND" == *"$protected"* ]]; then
-      block \
+      block_pre "destructive-command-guard" \
         "git rm on protected path: $COMMAND" \
-        "Living spec and story files should not be removed from version control. Use lifecycle status fields (retired, deprecated) instead." \
+        "Living spec and story files should not be removed from version control. Use lifecycle status fields (retired, deprecated) instead" \
         "git_rm_protected"
     fi
   done
@@ -305,27 +288,27 @@ fi
 # gh CLI destructive operations
 # ---------------------------------------------------------------------------
 if echo "$COMMAND" | grep -qE '\bgh\s+repo\s+delete\b'; then
-  block \
-    "gh repo delete is irreversible and affects shared GitHub state." \
-    "If a repo truly needs deletion, the user should do it from the GitHub UI with confirmation." \
+  block_pre "destructive-command-guard" \
+    "gh repo delete is irreversible and affects shared GitHub state" \
+    "If a repo truly needs deletion, the user should do it from the GitHub UI with confirmation" \
     "gh_repo_delete"
 fi
 if echo "$COMMAND" | grep -qE '\bgh\s+release\s+delete\b'; then
-  block \
-    "gh release delete removes a published release (may have downstream consumers)." \
-    "Releases should only be deleted by the user with explicit intent." \
+  block_pre "destructive-command-guard" \
+    "gh release delete removes a published release (may have downstream consumers)" \
+    "Releases should only be deleted by the user with explicit intent" \
     "gh_release_delete"
 fi
 if echo "$COMMAND" | grep -qE '\bgh\s+pr\s+close\b'; then
-  block \
-    "gh pr close discards PR work and breaks the review audit trail." \
-    "If the PR should be abandoned, add a comment explaining why and let the user close it." \
+  block_pre "destructive-command-guard" \
+    "gh pr close discards PR work and breaks the review audit trail" \
+    "If the PR should be abandoned, add a comment explaining why and let the user close it" \
     "gh_pr_close"
 fi
 if echo "$COMMAND" | grep -qE '\bgh\s+issue\s+delete\b'; then
-  block \
-    "gh issue delete removes issue history irreversibly." \
-    "Close the issue instead ('gh issue close') to preserve the record." \
+  block_pre "destructive-command-guard" \
+    "gh issue delete removes issue history irreversibly" \
+    "Close the issue instead ('gh issue close') to preserve the record" \
     "gh_issue_delete"
 fi
 
@@ -333,9 +316,9 @@ fi
 # curl|bash / wget|sh (remote code execution pattern)
 # ---------------------------------------------------------------------------
 if echo "$COMMAND" | grep -qE '\b(curl|wget|fetch)\b[^|]*\|\s*(bash|sh|zsh|python|perl|ruby)\b'; then
-  block \
-    "Piping remote content directly into a shell/interpreter is a supply-chain risk." \
-    "Download to a file, inspect it, then run it explicitly." \
+  block_pre "destructive-command-guard" \
+    "Piping remote content directly into a shell/interpreter is a supply-chain risk" \
+    "Download to a file, inspect it, then run it explicitly" \
     "rce_pipe_to_shell"
 fi
 
@@ -345,9 +328,9 @@ fi
 if echo "$COMMAND" | grep -qE '\b(chmod|chown)\s+(-R|--recursive)\b'; then
   for protected in ".factory" "src/" "tests/" ".git/"; do
     if [[ "$COMMAND" == *"$protected"* ]]; then
-      block \
+      block_pre "destructive-command-guard" \
         "Recursive chmod/chown on protected path: $COMMAND" \
-        "Recursive permission changes can break git metadata and hook executability. Target specific files." \
+        "Recursive permission changes can break git metadata and hook executability. Target specific files" \
         "recursive_permission_change"
     fi
   done

--- a/plugins/vsdd-factory/hooks/factory-branch-guard.sh
+++ b/plugins/vsdd-factory/hooks/factory-branch-guard.sh
@@ -22,6 +22,12 @@
 
 set -euo pipefail
 
+# Source canonical block-message helper (provides block_pre).
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh" ]; then
+  # shellcheck source=lib/block.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh"
+fi
+
 if ! command -v jq &>/dev/null; then
   exit 0
 fi
@@ -29,13 +35,6 @@ fi
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // "Edit|Write"')
-
-_emit() {
-  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" ]; then
-    "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" "$@" 2>/dev/null || true
-  fi
-  return 0
-}
 
 if [[ -z "$FILE_PATH" ]]; then
   exit 0
@@ -67,24 +66,20 @@ fi
 
 # Check 1: Is .factory/ a git worktree? (has .git marker file)
 if [[ ! -e "$FACTORY_DIR/.git" ]]; then
-  _emit type=hook.block hook=factory-branch-guard matcher="$TOOL_NAME" reason=factory_not_worktree file_path="$FILE_PATH" factory_dir="$FACTORY_DIR"
-  echo "BLOCKED by factory-branch-guard:" >&2
-  echo "  Cannot write to $FACTORY_DIR/ — not mounted as a git worktree." >&2
-  echo "  .factory/ must be a worktree on the $EXPECTED_BRANCH branch, not a regular directory." >&2
-  echo "  Recovery: git worktree add $FACTORY_DIR $EXPECTED_BRANCH" >&2
-  exit 2
+  block_pre "factory-branch-guard" \
+    "Cannot write to $FACTORY_DIR/ — not mounted as a git worktree. .factory/ must be a worktree on the $EXPECTED_BRANCH branch, not a regular directory" \
+    "git worktree add $FACTORY_DIR $EXPECTED_BRANCH" \
+    "factory_no_worktree"
 fi
 
 # Check 2: Is the worktree on the correct branch?
 if command -v git &>/dev/null; then
   CURRENT_BRANCH=$(git -C "$FACTORY_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
   if [[ "$CURRENT_BRANCH" != "$EXPECTED_BRANCH" ]] && [[ "$CURRENT_BRANCH" != "unknown" ]]; then
-    _emit type=hook.block hook=factory-branch-guard matcher="$TOOL_NAME" reason=factory_wrong_branch file_path="$FILE_PATH" factory_dir="$FACTORY_DIR" current_branch="$CURRENT_BRANCH" expected_branch="$EXPECTED_BRANCH"
-    echo "BLOCKED by factory-branch-guard:" >&2
-    echo "  Cannot write to $FACTORY_DIR/ — worktree is on branch '$CURRENT_BRANCH', expected '$EXPECTED_BRANCH'." >&2
-    echo "  Artifacts written on the wrong branch will be lost or misplaced." >&2
-    echo "  Recovery: cd $FACTORY_DIR && git checkout $EXPECTED_BRANCH" >&2
-    exit 2
+    block_pre "factory-branch-guard" \
+      "Cannot write to $FACTORY_DIR/ — worktree is on branch '$CURRENT_BRANCH', expected '$EXPECTED_BRANCH'. Artifacts written on the wrong branch will be lost or misplaced" \
+      "cd $FACTORY_DIR && git checkout $EXPECTED_BRANCH" \
+      "factory_wrong_branch"
   fi
 fi
 

--- a/plugins/vsdd-factory/hooks/protect-bc.sh
+++ b/plugins/vsdd-factory/hooks/protect-bc.sh
@@ -11,6 +11,12 @@
 
 set -euo pipefail
 
+# Source canonical block-message helper (provides block_pre_json).
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh" ]; then
+  # shellcheck source=lib/block.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh"
+fi
+
 if ! command -v jq &>/dev/null; then
   echo "protect-bc.sh: jq is required but not found" >&2
   exit 1
@@ -20,29 +26,8 @@ INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // "Edit|Write"')
 
-_emit() {
-  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" ]; then
-    "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" "$@" 2>/dev/null || true
-  fi
-  return 0
-}
-
 emit_allow() {
   printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}\n'
-  exit 0
-}
-
-emit_deny() {
-  local reason="$1"
-  local code="${2:-unknown}"
-  _emit type=hook.block hook=protect-bc matcher="$TOOL_NAME" reason="$code" file_path="$FILE_PATH"
-  jq -nc --arg reason "$reason" '{
-    hookSpecificOutput: {
-      hookEventName: "PreToolUse",
-      permissionDecision: "deny",
-      permissionDecisionReason: $reason
-    }
-  }'
   exit 0
 }
 
@@ -55,7 +40,10 @@ if [[ ! -f "$FILE_PATH" ]]; then
 fi
 
 if grep -q "^Status: green" "$FILE_PATH"; then
-  emit_deny "Blocked: $FILE_PATH has Status: green and is immutable per spec-format.md. To change a green BC, create a new BC that supersedes it. The old BC stays on disk; reference it from the new BC's 'Supersedes:' field." "bc_green_immutable"
+  block_pre_json "protect-bc" \
+    "$FILE_PATH has Status: green and is immutable per spec-format rules" \
+    "Create a new BC that supersedes it; cite the old BC via the new BC's 'Supersedes:' field" \
+    "bc_green_immutable"
 fi
 
 emit_allow

--- a/plugins/vsdd-factory/hooks/protect-secrets.sh
+++ b/plugins/vsdd-factory/hooks/protect-secrets.sh
@@ -21,34 +21,18 @@
 
 set -euo pipefail
 
+# Source canonical block-message helper (provides block_pre).
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh" ]; then
+  # shellcheck source=lib/block.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh"
+fi
+
 if ! command -v jq &>/dev/null; then
   exit 0
 fi
 
 INPUT=$(cat)
 TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty')
-
-_emit() {
-  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" ]; then
-    "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" "$@" 2>/dev/null || true
-  fi
-  return 0
-}
-
-block() {
-  local reason="$1"
-  local suggestion="${2:-}"
-  local code="${3:-unknown}"
-  # Note: command/file_path may contain variable *references* like $TOKEN, but
-  # at PreToolUse time they are pre-expansion literals — safe to log.
-  _emit type=hook.block hook=protect-secrets matcher="${TOOL:-?}" reason="$code" command="${COMMAND:-${FILE_PATH:-}}"
-  echo "BLOCKED by protect-secrets:" >&2
-  echo "  $reason" >&2
-  if [[ -n "$suggestion" ]]; then
-    echo "  Suggestion: $suggestion" >&2
-  fi
-  exit 2
-}
 
 # Pattern for a .env-like filename. Matches: .env, .env.local, .env.production,
 # .envrc. Does NOT match: .env.example, .env.sample, .env.template (safe templates).
@@ -69,9 +53,9 @@ is_secret_env_filename() {
 if [[ "$TOOL" == "Read" ]]; then
   FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
   if [[ -n "$FILE_PATH" ]] && is_secret_env_filename "$FILE_PATH"; then
-    block \
-      "Reading '$FILE_PATH' is blocked — .env files typically contain secrets that would land in the transcript." \
-      "If a specific non-secret value is needed, ask the user to paste it directly. For templates, use .env.example." \
+    block_pre "protect-secrets" \
+      "Reading '$FILE_PATH' is blocked — .env files typically contain secrets that would land in the transcript" \
+      "If a specific non-secret value is needed, ask the user to paste it directly. For templates, use .env.example" \
       "env_file_read_direct"
   fi
   exit 0
@@ -117,9 +101,9 @@ command_references_secret_env() {
 if echo "$COMMAND" | grep -qE '\b(cat|less|more|head|tail|bat|xxd|od|strings|grep|awk|sed)\b'; then
   if echo "$COMMAND" | grep -qE "$ENV_TOKEN_RE"; then
     if command_references_secret_env; then
-      block \
-        "Reading .env file contents via shell is blocked — contents would leak into the transcript." \
-        "Use 'ls .env*' to check existence. Ask the user to paste specific values if needed." \
+      block_pre "protect-secrets" \
+        "Reading .env file contents via shell is blocked — contents would leak into the transcript" \
+        "Use 'ls .env*' to check existence. Ask the user to paste specific values if needed" \
         "env_file_read_shell"
     fi
   fi
@@ -145,15 +129,15 @@ if echo "$COMMAND" | grep -qE '\b(cp|mv|rsync|scp)\b'; then
     case "$base" in
       .env.example|.env.sample|.env.template) : ;;
       .env|.envrc)
-        block \
-          "Copying/moving '$source_arg' is blocked — real .env files contain secrets." \
-          "If you need a template, create .env.example. To restore a .env, have the user do it." \
+        block_pre "protect-secrets" \
+          "Copying/moving '$source_arg' is blocked — real .env files contain secrets" \
+          "If you need a template, create .env.example. To restore a .env, have the user do it" \
           "env_file_copy"
         ;;
       .env.*)
-        block \
-          "Copying/moving '$source_arg' is blocked — .env.* files typically contain secrets." \
-          "If you need a template, use .env.example. To restore a .env, have the user do it." \
+        block_pre "protect-secrets" \
+          "Copying/moving '$source_arg' is blocked — .env.* files typically contain secrets" \
+          "If you need a template, use .env.example. To restore a .env, have the user do it" \
           "env_file_copy"
         ;;
     esac
@@ -163,9 +147,9 @@ fi
 # Block tar/zip that include a real .env as an input.
 if echo "$COMMAND" | grep -qE '\b(tar|zip)\b'; then
   if command_references_secret_env; then
-    block \
-      "Archiving .env files is blocked — potential secret exfiltration." \
-      "Exclude .env from archives, or handle it outside this session." \
+    block_pre "protect-secrets" \
+      "Archiving .env files is blocked — potential secret exfiltration" \
+      "Exclude .env from archives, or handle it outside this session" \
       "env_file_archive"
   fi
 fi
@@ -176,9 +160,9 @@ fi
 # ---------------------------------------------------------------------------
 SECRET_NAME_RE='(TOKEN|SECRET|PASSWORD|PASSWD|API[_-]?KEY|PRIVATE[_-]?KEY|ACCESS[_-]?KEY|CREDENTIAL|AUTH)'
 if echo "$COMMAND" | grep -qiE "\b(echo|printf)\b[^|&;]*\\\$\{?[A-Za-z0-9_]*${SECRET_NAME_RE}[A-Za-z0-9_]*\}?"; then
-  block \
-    "Echoing a secret-shaped environment variable is blocked — it would land in the transcript." \
-    "Use the variable directly in the command that needs it, without printing it." \
+  block_pre "protect-secrets" \
+    "Echoing a secret-shaped environment variable is blocked — it would land in the transcript" \
+    "Use the variable directly in the command that needs it, without printing it" \
     "secret_var_echo"
 fi
 
@@ -186,9 +170,9 @@ fi
 # Block env | grep for secret-shaped names
 # ---------------------------------------------------------------------------
 if echo "$COMMAND" | grep -qiE '\b(env|printenv|set)\b[^|]*\|[^|]*\bgrep\b[^|]*(token|secret|password|passwd|api[_-]?key|private[_-]?key|access[_-]?key|credential|auth)'; then
-  block \
-    "Grepping the environment for secret-shaped names is blocked." \
-    "If a specific value is needed, ask the user or use the variable directly in the downstream command." \
+  block_pre "protect-secrets" \
+    "Grepping the environment for secret-shaped names is blocked" \
+    "If a specific value is needed, ask the user or use the variable directly in the downstream command" \
     "secret_var_grep"
 fi
 

--- a/plugins/vsdd-factory/hooks/protect-vp.sh
+++ b/plugins/vsdd-factory/hooks/protect-vp.sh
@@ -13,6 +13,12 @@
 
 set -euo pipefail
 
+# Source canonical block-message helper (provides block_pre_json).
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh" ]; then
+  # shellcheck source=lib/block.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh"
+fi
+
 # Read PreToolUse JSON from stdin
 INPUT=$(cat)
 
@@ -20,30 +26,8 @@ INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // "Edit|Write"')
 
-_emit() {
-  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" ]; then
-    "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" "$@" 2>/dev/null || true
-  fi
-  return 0
-}
-
 emit_allow() {
   printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}\n'
-  exit 0
-}
-
-emit_deny() {
-  local reason="$1"
-  local code="${2:-unknown}"
-  _emit type=hook.block hook=protect-vp matcher="$TOOL_NAME" reason="$code" file_path="$FILE_PATH"
-  # Escape quotes in reason for JSON safety via jq
-  jq -nc --arg reason "$reason" '{
-    hookSpecificOutput: {
-      hookEventName: "PreToolUse",
-      permissionDecision: "deny",
-      permissionDecisionReason: $reason
-    }
-  }'
   exit 0
 }
 
@@ -59,7 +43,10 @@ if [[ ! -f "$FILE_PATH" ]]; then
 fi
 
 if grep -q "^Status: green" "$FILE_PATH"; then
-  emit_deny "Blocked: $FILE_PATH has Status: green and is immutable per SOUL.md #4. To change a green VP, create a new VP that supersedes it (see .claude/rules/spec-format.md). The old VP stays on disk unchanged; reference it from the new VP's 'Supersedes:' field." "vp_green_immutable"
+  block_pre_json "protect-vp" \
+    "$FILE_PATH has Status: green and is immutable per SOUL.md #4 and spec-format rules" \
+    "Create a new VP that supersedes it; cite the old VP via the new VP's 'Supersedes:' field" \
+    "vp_green_immutable"
 fi
 
 # VP file exists but is not green — allow the edit.

--- a/plugins/vsdd-factory/hooks/purity-check.sh
+++ b/plugins/vsdd-factory/hooks/purity-check.sh
@@ -13,6 +13,12 @@
 
 set -euo pipefail
 
+# Source canonical block-message helper (provides _emit, block_pre).
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh" ]; then
+  # shellcheck source=lib/block.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh"
+fi
+
 if ! command -v jq &>/dev/null; then
   echo "purity-check.sh: jq is required but not found" >&2
   exit 0
@@ -20,13 +26,6 @@ fi
 
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
-
-_emit() {
-  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" ]; then
-    "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" "$@" 2>/dev/null || true
-  fi
-  return 0
-}
 
 if [[ -z "$FILE_PATH" ]] || [[ ! -f "$FILE_PATH" ]]; then
   exit 0

--- a/plugins/vsdd-factory/hooks/red-gate.sh
+++ b/plugins/vsdd-factory/hooks/red-gate.sh
@@ -16,6 +16,12 @@
 
 set -euo pipefail
 
+# Source canonical block-message helper (provides block_pre).
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh" ]; then
+  # shellcheck source=lib/block.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh"
+fi
+
 if ! command -v jq &>/dev/null; then
   echo "red-gate.sh: jq is required but not found" >&2
   exit 1
@@ -24,13 +30,6 @@ fi
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // "Edit|Write"')
-
-_emit() {
-  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" ]; then
-    "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" "$@" 2>/dev/null || true
-  fi
-  return 0
-}
 
 # No file path → allow
 [[ -z "$FILE_PATH" ]] && exit 0
@@ -100,8 +99,7 @@ if [[ "$FILE_PATH" == /* ]]; then
   fi
 fi
 
-_emit type=hook.block hook=red-gate matcher="$TOOL_NAME" reason=red_gate_strict_violation file_path="$FILE_PATH"
-echo "Blocked: red-gate is in strict mode and $FILE_PATH is not in the red list." >&2
-echo "Write a failing test for this code first, then add the path to .factory/red-gate-state.json under .red[]." >&2
-echo "To disable strict mode for this session, set .mode to \"off\" in $STATE_FILE." >&2
-exit 2
+block_pre "red-gate" \
+  "Strict TDD mode: $FILE_PATH is not in the red list" \
+  "Write a failing test first; OR add path to .factory/red-gate-state.json:.red[]; OR set .mode: \"off\" in that file" \
+  "red_gate_strict"

--- a/plugins/vsdd-factory/hooks/validate-anchor-capabilities-union.sh
+++ b/plugins/vsdd-factory/hooks/validate-anchor-capabilities-union.sh
@@ -16,19 +16,18 @@
 
 set -euo pipefail
 
+# Source canonical block-message helper (provides block_pre).
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh" ]; then
+  # shellcheck source=lib/block.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh"
+fi
+
 if ! command -v jq &>/dev/null; then
   exit 0
 fi
 
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
-
-_emit() {
-  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" ]; then
-    "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" "$@" 2>/dev/null || true
-  fi
-  return 0
-}
 
 if [[ -z "$FILE_PATH" ]] || [[ ! -f "$FILE_PATH" ]]; then
   exit 0
@@ -167,18 +166,10 @@ EXPECTED=$(echo "$ALL_CAPS" | sort -u | tr '\n' ',' | sed 's/,$//')
 ACTUAL=$(echo "$ANCHOR_CAPS" | sort -u | tr '\n' ',' | sed 's/,$//')
 
 if [[ "$EXPECTED" != "$ACTUAL" ]]; then
-  _emit type=hook.block hook=validate-anchor-capabilities-union matcher=PostToolUse \
-        reason=anchor_capabilities_mismatch file_path="$FILE_PATH" \
-        expected="$EXPECTED" actual="$ACTUAL"
-  echo "ANCHOR CAPABILITIES UNION VIOLATION in $(basename "$FILE_PATH"):" >&2
-  echo "  Expected (from BCs): [$EXPECTED]" >&2
-  echo "  Actual (frontmatter): [$ACTUAL]" >&2
-  echo "  BC → CAP mapping:" >&2
-  echo "$BC_CAP_MAP" | sort -u | while IFS= read -r mapping; do
-    [[ -n "$mapping" ]] && echo "    $mapping" >&2
-  done
-  echo "  Fix: set anchor_capabilities: [$EXPECTED] in story frontmatter." >&2
-  exit 2
+  block_pre "validate-anchor-capabilities-union" \
+    "Story anchor_capabilities [$ACTUAL] != union of cited BC capabilities [$EXPECTED]" \
+    "Set anchor_capabilities: [$EXPECTED] in story frontmatter" \
+    "anchor_caps_drift"
 fi
 
 exit 0

--- a/plugins/vsdd-factory/hooks/validate-bc-title.sh
+++ b/plugins/vsdd-factory/hooks/validate-bc-title.sh
@@ -13,19 +13,18 @@
 
 set -euo pipefail
 
+# Source canonical block-message helper (provides block_pre).
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh" ]; then
+  # shellcheck source=lib/block.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh"
+fi
+
 if ! command -v jq &>/dev/null; then
   exit 0
 fi
 
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
-
-_emit() {
-  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" ]; then
-    "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" "$@" 2>/dev/null || true
-  fi
-  return 0
-}
 
 if [[ -z "$FILE_PATH" ]] || [[ ! -f "$FILE_PATH" ]]; then
   exit 0
@@ -86,15 +85,10 @@ fi
 
 # Compare titles
 if [[ "$H1_TITLE" != "$INDEX_TITLE" ]]; then
-  _emit type=hook.block hook=validate-bc-title matcher=PostToolUse \
-        reason=policy7_bc_title_mismatch file_path="$FILE_PATH" \
-        bc_id="$BC_ID" h1_title="$H1_TITLE" index_title="$INDEX_TITLE"
-  echo "POLICY 7 VIOLATION (bc_h1_is_title_source_of_truth):" >&2
-  echo "  - BC file H1 title: \"$H1_TITLE\"" >&2
-  echo "  - BC-INDEX title:   \"$INDEX_TITLE\"" >&2
-  echo "  The H1 heading is authoritative. Update BC-INDEX to match," >&2
-  echo "  or if the H1 is wrong, fix the H1 first." >&2
-  exit 2
+  block_pre "validate-bc-title" \
+    "BC H1 title \"$H1_TITLE\" != BC-INDEX title \"$INDEX_TITLE\" (POLICY 7: bc_h1_is_title_source_of_truth)" \
+    "Update BC-INDEX title to match H1, or fix H1 if it is wrong" \
+    "bc_h1_index_drift"
 fi
 
 exit 0

--- a/plugins/vsdd-factory/hooks/validate-changelog-monotonicity.sh
+++ b/plugins/vsdd-factory/hooks/validate-changelog-monotonicity.sh
@@ -26,13 +26,6 @@ fi
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
 
-_emit() {
-  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" ]; then
-    "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" "$@" 2>/dev/null || true
-  fi
-  return 0
-}
-
 if [[ -z "$FILE_PATH" ]] || [[ ! -f "$FILE_PATH" ]]; then
   exit 0
 fi

--- a/plugins/vsdd-factory/hooks/validate-count-propagation.sh
+++ b/plugins/vsdd-factory/hooks/validate-count-propagation.sh
@@ -24,13 +24,6 @@ if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/lib/blo
   source "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh"
 fi
 
-_emit() {
-  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" ]; then
-    "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" "$@" 2>/dev/null || true
-  fi
-  return 0
-}
-
 if ! command -v jq &>/dev/null; then
   exit 0
 fi
@@ -163,8 +156,9 @@ for keyword in "${!SOURCE_COUNTS[@]}"; do
 done
 
 if [[ "$DRIFT_DETECTED" -eq 1 ]]; then
-  _ALL_DRIFT="${DRIFT_MESSAGES[*]}"
-  _REASON="Count propagation drift detected in $(basename "$FILE_PATH"): ${DRIFT_MESSAGES[0]}"
+  # S2 fix: join ALL drift messages so every violation is visible at once, not just the first.
+  _ALL_DRIFT=$(printf '%s; ' "${DRIFT_MESSAGES[@]}" | sed 's/; $//')
+  _REASON="Count propagation drift detected in $(basename "$FILE_PATH"): $_ALL_DRIFT"
   _REC="Update the lagging index to match the source-of-truth count: BC-INDEX total_bcs, ARCH-INDEX subsystem counts, or STORY-INDEX bcs count — see the specific drift cited above"
 
   if declare -f block_pre >/dev/null 2>&1; then
@@ -174,8 +168,6 @@ if [[ "$DRIFT_DETECTED" -eq 1 ]]; then
       "count_propagation_drift"
     # block_pre exits 2; unreachable
   else
-    _emit type=hook.block hook=validate-count-propagation matcher=PostToolUse \
-          reason=count_propagation_drift file_path="$FILE_PATH"
     echo "BLOCKED by validate-count-propagation: ${_REASON}. Fix: ${_REC}. Code: count_propagation_drift." >&2
     exit 2
   fi

--- a/plugins/vsdd-factory/hooks/validate-demo-evidence-story-scoped.sh
+++ b/plugins/vsdd-factory/hooks/validate-demo-evidence-story-scoped.sh
@@ -13,19 +13,18 @@
 
 set -euo pipefail
 
+# Source canonical block-message helper (provides block_pre).
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh" ]; then
+  # shellcheck source=lib/block.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh"
+fi
+
 if ! command -v jq &>/dev/null; then
   exit 0
 fi
 
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
-
-_emit() {
-  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" ]; then
-    "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" "$@" 2>/dev/null || true
-  fi
-  return 0
-}
 
 if [[ -z "$FILE_PATH" ]] || [[ ! -f "$FILE_PATH" ]]; then
   exit 0
@@ -44,12 +43,10 @@ RELATIVE="${FILE_PATH##*/docs/demo-evidence/}"
 # Valid: S-0.02/evidence-report.md (has a /)
 # Invalid: evidence-report.md (no /)
 if [[ "$RELATIVE" != */* ]]; then
-  _emit type=hook.block hook=validate-demo-evidence-story-scoped matcher=PostToolUse \
-        reason=demo_evidence_not_story_scoped file_path="$FILE_PATH"
-  echo "POL-010 VIOLATION: demo evidence must live under docs/demo-evidence/<STORY-ID>/ — got $FILE_PATH" >&2
-  echo "  Move to docs/demo-evidence/<STORY-ID>/$(basename "$FILE_PATH") where <STORY-ID> matches the story's frontmatter story_id field." >&2
-  echo "  See policies.yaml POL-010." >&2
-  exit 2
+  block_pre "validate-demo-evidence-story-scoped" \
+    "Demo evidence not under <STORY-ID>/ (POL-010): $FILE_PATH is at the top level of docs/demo-evidence/" \
+    "Move to docs/demo-evidence/<STORY-ID>/$(basename "$FILE_PATH") where <STORY-ID> matches the story's frontmatter story_id field" \
+    "pol_010_violation"
 fi
 
 exit 0

--- a/plugins/vsdd-factory/hooks/validate-factory-path-root.sh
+++ b/plugins/vsdd-factory/hooks/validate-factory-path-root.sh
@@ -19,19 +19,18 @@
 
 set -euo pipefail
 
+# Source canonical block-message helper (provides block_pre).
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh" ]; then
+  # shellcheck source=lib/block.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh"
+fi
+
 if ! command -v jq &>/dev/null; then
   exit 0
 fi
 
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
-
-_emit() {
-  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" ]; then
-    "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" "$@" 2>/dev/null || true
-  fi
-  return 0
-}
 
 if [[ -z "$FILE_PATH" ]]; then
   exit 0
@@ -50,19 +49,10 @@ if [[ "$FILE_PATH" == *".worktrees/"*"/.factory/"* ]]; then
   WORKTREE=$(echo "$FILE_PATH" | grep -oE '\.worktrees/[^/]+' | head -1 || true)
   RELATIVE="${FILE_PATH##*/.factory/}"
 
-  _emit type=hook.block hook=validate-factory-path-root matcher=PostToolUse \
-        reason=factory_path_worktree_relative file_path="$FILE_PATH" worktree="$WORKTREE"
-  echo "FACTORY PATH ERROR — writing to worktree instead of project root:" >&2
-  echo "  Got:      $FILE_PATH" >&2
-  echo "  Expected: <project-root>/.factory/$RELATIVE" >&2
-  echo "" >&2
-  echo "  You are inside $WORKTREE/ and used a relative .factory/ path." >&2
-  echo "  .factory/ artifacts MUST use the absolute project root path," >&2
-  echo "  not a path relative to the worktree working directory." >&2
-  echo "" >&2
-  echo "  Fix: use the resolved project path from your dispatch prompt" >&2
-  echo "  (e.g., /Users/.../project/.factory/$RELATIVE)." >&2
-  exit 2
+  block_pre "validate-factory-path-root" \
+    "Worktree-relative .factory/ path used: $FILE_PATH (inside $WORKTREE). .factory/ artifacts MUST use absolute project root path" \
+    "Use absolute <project-root>/.factory/$RELATIVE from your dispatch prompt" \
+    "factory_path_relative"
 fi
 
 exit 0

--- a/plugins/vsdd-factory/hooks/validate-finding-format.sh
+++ b/plugins/vsdd-factory/hooks/validate-finding-format.sh
@@ -13,19 +13,18 @@
 
 set -euo pipefail
 
+# Source canonical block-message helper (provides block_pre).
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh" ]; then
+  # shellcheck source=lib/block.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh"
+fi
+
 if ! command -v jq &>/dev/null; then
   exit 0
 fi
 
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
-
-_emit() {
-  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" ]; then
-    "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" "$@" 2>/dev/null || true
-  fi
-  return 0
-}
 
 if [[ -z "$FILE_PATH" ]] || [[ ! -f "$FILE_PATH" ]]; then
   exit 0
@@ -76,14 +75,11 @@ fi
 
 # --- Report ---
 if [[ -n "$ERRORS" ]]; then
-  _emit type=hook.block hook=validate-finding-format matcher=PostToolUse \
-        reason=finding_id_legacy_format file_path="$FILE_PATH"
-  echo "ID FORMAT VIOLATION:" >&2
-  echo -e "$ERRORS" | while IFS= read -r line; do
-    echo "  - $line" >&2
-  done
-  echo "  See FACTORY.md ID Format Reference for current formats." >&2
-  exit 2
+  _ERRORS_SUMMARY=$(echo -e "$ERRORS" | head -1)
+  block_pre "validate-finding-format" \
+    "ID doesn't match canonical format: $_ERRORS_SUMMARY" \
+    "See FACTORY.md ID Format Reference" \
+    "id_format_violation"
 fi
 
 exit 0

--- a/plugins/vsdd-factory/hooks/validate-input-hash.sh
+++ b/plugins/vsdd-factory/hooks/validate-input-hash.sh
@@ -13,19 +13,18 @@
 
 set -euo pipefail
 
+# Source canonical block-message helper (provides block_pre).
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh" ]; then
+  # shellcheck source=lib/block.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh"
+fi
+
 if ! command -v jq &>/dev/null; then
   exit 0
 fi
 
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
-
-_emit() {
-  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" ]; then
-    "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" "$@" 2>/dev/null || true
-  fi
-  return 0
-}
 
 if [[ -z "$FILE_PATH" ]] || [[ ! -f "$FILE_PATH" ]]; then
   exit 0
@@ -77,39 +76,37 @@ if [[ "$STORED_HASH" == "[live-state]" ]] || [[ "$STORED_HASH" == "[pending-reco
   exit 0
 fi
 
-# --- Case 1a: Missing, template placeholder, or null → warn ---
+# --- Case 1a: Missing, template placeholder, or null → block ---
 if [[ -z "$STORED_HASH" ]] || [[ "$STORED_HASH" == "[md5]" ]] || [[ "$STORED_HASH" == "null" ]]; then
-  echo "input-hash: artifact $(basename "$FILE_PATH") has inputs: but no computed input-hash." >&2
-  echo "  Run: compute-input-hash $(basename "$FILE_PATH") --update" >&2
-  exit 0
+  block_pre "validate-input-hash" \
+    "$(basename "$FILE_PATH") has inputs: field but no computed input-hash" \
+    "compute-input-hash $(basename "$FILE_PATH") --update" \
+    "input_hash_missing"
 fi
 
 # --- Case 1b: Hash format validation — must be 7-char lowercase hex ---
 HASH_LEN=${#STORED_HASH}
 if [[ "$HASH_LEN" -ne 7 ]]; then
-  _emit type=hook.block hook=validate-input-hash matcher=PostToolUse \
-        reason=input_hash_invalid_format file_path="$FILE_PATH" \
-        stored_hash="$STORED_HASH" hash_len="$HASH_LEN" issue=length
-  echo "input-hash FORMAT: $(basename "$FILE_PATH") hash \"$STORED_HASH\" is $HASH_LEN chars; canonical is 7-char truncated MD5." >&2
-  echo "  Run: compute-input-hash $(basename "$FILE_PATH") --update" >&2
-  exit 2
+  block_pre "validate-input-hash" \
+    "input-hash \"$STORED_HASH\" in $(basename "$FILE_PATH") is $HASH_LEN chars; canonical is 7-char truncated MD5" \
+    "compute-input-hash $(basename "$FILE_PATH") --update" \
+    "input_hash_format"
 fi
 if ! echo "$STORED_HASH" | grep -qE '^[0-9a-f]{7}$'; then
-  _emit type=hook.block hook=validate-input-hash matcher=PostToolUse \
-        reason=input_hash_invalid_format file_path="$FILE_PATH" \
-        stored_hash="$STORED_HASH" issue=chars
-  echo "input-hash FORMAT: $(basename "$FILE_PATH") hash \"$STORED_HASH\" contains invalid chars; must be lowercase hex [0-9a-f]." >&2
-  echo "  Run: compute-input-hash $(basename "$FILE_PATH") --update" >&2
-  exit 2
+  block_pre "validate-input-hash" \
+    "input-hash \"$STORED_HASH\" in $(basename "$FILE_PATH") contains invalid chars; must be lowercase hex [0-9a-f]" \
+    "compute-input-hash $(basename "$FILE_PATH") --update" \
+    "input_hash_format"
 fi
 
 # --- Case 2: Hash exists → verify if possible ---
 if [[ -x "$HASH_TOOL" ]]; then
   COMPUTED=$("$HASH_TOOL" "$FILE_PATH" 2>/dev/null || true)
   if [[ -n "$COMPUTED" ]] && [[ "$COMPUTED" != "$STORED_HASH" ]]; then
-    echo "input-hash: DRIFT — $(basename "$FILE_PATH") stored hash ($STORED_HASH) ≠ computed ($COMPUTED)." >&2
-    echo "  Inputs may have changed since this artifact was produced." >&2
-    echo "  Run: compute-input-hash $(basename "$FILE_PATH") --update" >&2
+    block_pre "validate-input-hash" \
+      "input-hash drift in $(basename "$FILE_PATH"): stored $STORED_HASH != computed $COMPUTED. Inputs may have changed since this artifact was produced" \
+      "compute-input-hash $(basename "$FILE_PATH") --update" \
+      "input_hash_drift"
   fi
 fi
 

--- a/plugins/vsdd-factory/hooks/validate-input-hash.sh
+++ b/plugins/vsdd-factory/hooks/validate-input-hash.sh
@@ -2,12 +2,15 @@
 # validate-input-hash.sh — PostToolUse hook for input-hash drift detection
 #
 # After every Write to .factory/**/*.md, checks the input-hash field:
-# 1. If input-hash is missing/placeholder/null and inputs: exists → warn
-# 2. If input-hash is present and input files exist → recompute and compare
+# 1. If input-hash is missing/placeholder/null and inputs: exists → block (exit 2)
+# 2. If hash format is invalid (not 7-char lowercase hex) → block (exit 2)
+# 3. If hash tool is available and computed hash drifts from stored → block (exit 2)
 #
-# Non-blocking (advisory) — warns on stale hashes but doesn't block.
+# Blocking — enforces that input-hash is always present and current.
+# Use the input-hash bypass markers ([live-state], [pending-recompute]) to
+# exempt files that are intentionally unhashed during active pipeline runs.
 #
-# Exit 0 always (advisory hook). Diagnostics on stderr.
+# Exit 2 on violations. Exit 0 when no inputs: field or hash is current.
 #
 # Deterministic, <500ms, no LLM.
 

--- a/plugins/vsdd-factory/hooks/validate-novelty-assessment.sh
+++ b/plugins/vsdd-factory/hooks/validate-novelty-assessment.sh
@@ -13,19 +13,18 @@
 
 set -euo pipefail
 
+# Source canonical block-message helper (provides block_pre).
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh" ]; then
+  # shellcheck source=lib/block.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh"
+fi
+
 if ! command -v jq &>/dev/null; then
   exit 0
 fi
 
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
-
-_emit() {
-  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" ]; then
-    "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" "$@" 2>/dev/null || true
-  fi
-  return 0
-}
 
 if [[ -z "$FILE_PATH" ]] || [[ ! -f "$FILE_PATH" ]]; then
   exit 0
@@ -87,16 +86,11 @@ fi
 
 # --- Report ---
 if [[ -n "$ERRORS" ]]; then
-  _emit type=hook.block hook=validate-novelty-assessment matcher=PostToolUse \
-        reason=novelty_assessment_incomplete file_path="$FILE_PATH"
-  echo "NOVELTY ASSESSMENT VIOLATION:" >&2
-  echo -e "$ERRORS" | while IFS= read -r line; do
-    echo "  - $line" >&2
-  done
-  echo "  Adversarial review files MUST include a '## Novelty Assessment' section" >&2
-  echo "  with Pass, Novelty score, Trajectory, and Verdict fields." >&2
-  echo "  See adversarial-review-template.md for the required format." >&2
-  exit 2
+  _ERRORS_SUMMARY=$(echo -e "$ERRORS" | tr '\n' '; ' | sed 's/; $//')
+  block_pre "validate-novelty-assessment" \
+    "Adversary file missing '## Novelty Assessment' section or required fields: $_ERRORS_SUMMARY" \
+    "Add the section per templates/adversarial-review-template.md (Pass, Novelty score, Trajectory, Verdict required)" \
+    "novelty_section_missing"
 fi
 
 exit 0

--- a/plugins/vsdd-factory/hooks/validate-pr-description-completeness.sh
+++ b/plugins/vsdd-factory/hooks/validate-pr-description-completeness.sh
@@ -13,19 +13,18 @@
 
 set -euo pipefail
 
+# Source canonical block-message helper (provides block_pre).
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh" ]; then
+  # shellcheck source=lib/block.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh"
+fi
+
 if ! command -v jq &>/dev/null; then
   exit 0
 fi
 
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
-
-_emit() {
-  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" ]; then
-    "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" "$@" 2>/dev/null || true
-  fi
-  return 0
-}
 
 if [[ -z "$FILE_PATH" ]] || [[ ! -f "$FILE_PATH" ]]; then
   exit 0
@@ -63,14 +62,11 @@ if [[ -n "$PLACEHOLDERS" ]]; then
 fi
 
 if [[ -n "$ERRORS" ]]; then
-  _emit type=hook.block hook=validate-pr-description-completeness matcher=PostToolUse \
-        reason=pr_description_incomplete file_path="$FILE_PATH"
-  echo "PR DESCRIPTION INCOMPLETE in $(basename "$(dirname "$FILE_PATH")")/pr-description.md:" >&2
-  echo -e "$ERRORS" | while IFS= read -r line; do
-    echo "  - $line" >&2
-  done
-  echo "  Populate all sections from templates/pr-description-template.md before creating the PR." >&2
-  exit 2
+  _ERRORS_SUMMARY=$(echo -e "$ERRORS" | tr '\n' '; ' | sed 's/; $//')
+  block_pre "validate-pr-description-completeness" \
+    "Required PR sections missing: $_ERRORS_SUMMARY" \
+    "Populate all sections from templates/pr-description-template.md" \
+    "pr_description_incomplete"
 fi
 
 exit 0

--- a/plugins/vsdd-factory/hooks/validate-pr-merge-prerequisites.sh
+++ b/plugins/vsdd-factory/hooks/validate-pr-merge-prerequisites.sh
@@ -29,12 +29,11 @@ fi
 SUBAGENT=$(echo "$INPUT" | jq -r '.tool_input.subagent_type // ""')
 PROMPT=$(echo "$INPUT" | jq -r '.tool_input.prompt // ""')
 
-_emit() {
-  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" ]; then
-    "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" "$@" 2>/dev/null || true
-  fi
-  return 0
-}
+# Source canonical block-message helper (provides block_pre).
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh" ]; then
+  # shellcheck source=lib/block.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh"
+fi
 
 # Scope: only github-ops dispatches that contain "merge"
 case "$SUBAGENT" in
@@ -105,19 +104,11 @@ if [[ ! -f "$DELIVERY_DIR/security-review.md" ]]; then
 fi
 
 if [[ -n "$ERRORS" ]]; then
-  _emit type=hook.block hook=validate-pr-merge-prerequisites matcher=Agent \
-        reason=pr_merge_evidence_missing \
-        story_id="$STORY_ID" delivery_dir="$DELIVERY_DIR" missing="$MISSING_FILES"
-  echo "" >&2
-  echo "PR MERGE PREREQUISITES NOT MET for $STORY_ID:" >&2
-  echo -e "$ERRORS" | while IFS= read -r line; do
-    echo "  - $line" >&2
-  done
-  echo "" >&2
-  echo "  Complete the pr-manager 9-step lifecycle before merging." >&2
-  echo "  Steps 1 (description), 4 (security), and 5 (review) must produce" >&2
-  echo "  their evidence files before step 8 (merge) can proceed." >&2
-  exit 2
+  _MISSING_SUMMARY=$(echo -e "$ERRORS" | tr '\n' '; ' | sed 's/; $//')
+  block_pre "validate-pr-merge-prerequisites" \
+    "pr-manager 9-step lifecycle incomplete for $STORY_ID: missing $_MISSING_SUMMARY" \
+    "Complete the 9 steps; verify .factory/code-delivery/$STORY_ID/ exists with pr-description.md, pr-review.md, security-review.md" \
+    "pr_merge_evidence_missing"
 fi
 
 exit 0

--- a/plugins/vsdd-factory/hooks/validate-red-ratio.sh
+++ b/plugins/vsdd-factory/hooks/validate-red-ratio.sh
@@ -30,13 +30,6 @@ fi
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
 
-_emit() {
-  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" ]; then
-    "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" "$@" 2>/dev/null || true
-  fi
-  return 0
-}
-
 if [[ -z "$FILE_PATH" ]] || [[ ! -f "$FILE_PATH" ]]; then
   exit 0
 fi

--- a/plugins/vsdd-factory/hooks/validate-state-pin-freshness.sh
+++ b/plugins/vsdd-factory/hooks/validate-state-pin-freshness.sh
@@ -14,19 +14,18 @@
 
 set -euo pipefail
 
+# Source canonical block-message helper (provides block_pre).
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh" ]; then
+  # shellcheck source=lib/block.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh"
+fi
+
 if ! command -v jq &>/dev/null; then
   exit 0
 fi
 
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
-
-_emit() {
-  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" ]; then
-    "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" "$@" 2>/dev/null || true
-  fi
-  return 0
-}
 
 if [[ -z "$FILE_PATH" ]] || [[ ! -f "$FILE_PATH" ]]; then
   exit 0
@@ -95,14 +94,11 @@ for pair in $VERSION_PAIRS; do
 done
 
 if [[ -n "$ERRORS" ]]; then
-  _emit type=hook.block hook=validate-state-pin-freshness matcher=PostToolUse \
-        reason=state_version_pin_drift file_path="$FILE_PATH"
-  echo "STATE.md VERSION PIN DRIFT:" >&2
-  echo -e "$ERRORS" | while IFS= read -r line; do
-    echo "  - $line" >&2
-  done
-  echo "  Ensure state-manager runs LAST in every burst to capture final versions." >&2
-  exit 2
+  _ERRORS_SUMMARY=$(echo -e "$ERRORS" | tr '\n' '; ' | sed 's/; $//')
+  block_pre "validate-state-pin-freshness" \
+    "STATE.md version pin doesn't match latest index: $_ERRORS_SUMMARY" \
+    "Ensure state-manager runs LAST in every burst" \
+    "state_pin_stale"
 fi
 
 exit 0

--- a/plugins/vsdd-factory/hooks/validate-state-size.sh
+++ b/plugins/vsdd-factory/hooks/validate-state-size.sh
@@ -12,19 +12,18 @@
 
 set -euo pipefail
 
+# Source canonical block-message helper (provides block_pre).
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh" ]; then
+  # shellcheck source=lib/block.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh"
+fi
+
 if ! command -v jq &>/dev/null; then
   exit 0
 fi
 
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
-
-_emit() {
-  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" ]; then
-    "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" "$@" 2>/dev/null || true
-  fi
-  return 0
-}
 
 if [[ -z "$FILE_PATH" ]]; then
   exit 0
@@ -40,14 +39,19 @@ if [[ ! -f "$FILE_PATH" ]]; then
   exit 0
 fi
 
-LINE_COUNT=$(wc -l < "$FILE_PATH" | tr -d ' ')
+LINE_COUNT=$(wc -l < "$FILE_PATH" | tr -d ' \t\n')
 
 # Check if this write reduced the file size (compaction).
 # Use git to compare against the committed version.
 PARENT_DIR=$(dirname "$FILE_PATH")
 PRIOR_COUNT=0
 if command -v git &>/dev/null; then
-  PRIOR_COUNT=$(git -C "$PARENT_DIR" show HEAD:STATE.md 2>/dev/null | wc -l | tr -d ' ' || echo 0)
+  _git_out=$(git -C "$PARENT_DIR" show HEAD:STATE.md 2>/dev/null | wc -l | tr -d ' ' 2>/dev/null) || _git_out=0
+  # Ensure PRIOR_COUNT is a clean integer (strip trailing newlines/spaces)
+  PRIOR_COUNT="${_git_out//[[:space:]]/}"
+  PRIOR_COUNT="${PRIOR_COUNT:-0}"
+  # If still not numeric, default to 0
+  [[ "$PRIOR_COUNT" =~ ^[0-9]+$ ]] || PRIOR_COUNT=0
 fi
 
 # If the write REDUCED lines, always allow (compaction in progress)
@@ -56,15 +60,10 @@ if [[ "$LINE_COUNT" -lt "$PRIOR_COUNT" ]]; then
 fi
 
 if [[ "$LINE_COUNT" -gt 500 ]]; then
-  _emit type=hook.block hook=validate-state-size matcher=PostToolUse \
-        reason=state_bloat file_path="$FILE_PATH" line_count="$LINE_COUNT" limit=500
-  echo "STATE.md BLOAT — BLOCKED:" >&2
-  echo "  STATE.md has $LINE_COUNT lines (limit: 500)." >&2
-  echo "  STATE.md should be a quick status check, not a history log." >&2
-  echo "  Run /vsdd-factory:compact-state to extract historical content" >&2
-  echo "  to cycle files (burst logs, adversary passes, session checkpoints)." >&2
-  echo "  See state-manager agent 'Content Routing Rules' for what belongs where." >&2
-  exit 2
+  block_pre "validate-state-size" \
+    "STATE.md exceeds 500-line limit ($LINE_COUNT lines). STATE.md should be a quick status check, not a history log" \
+    "Run /vsdd-factory:compact-state to extract historical content to cycle files" \
+    "state_md_bloat"
 elif [[ "$LINE_COUNT" -gt 200 ]]; then
   echo "STATE.md SIZE WARNING:" >&2
   echo "  STATE.md has $LINE_COUNT lines (recommended: <200, limit: 500)." >&2

--- a/plugins/vsdd-factory/hooks/validate-story-bc-sync.sh
+++ b/plugins/vsdd-factory/hooks/validate-story-bc-sync.sh
@@ -14,19 +14,18 @@
 
 set -euo pipefail
 
+# Source canonical block-message helper (provides block_pre).
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh" ]; then
+  # shellcheck source=lib/block.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh"
+fi
+
 if ! command -v jq &>/dev/null; then
   exit 0
 fi
 
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
-
-_emit() {
-  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" ]; then
-    "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" "$@" 2>/dev/null || true
-  fi
-  return 0
-}
 
 if [[ -z "$FILE_PATH" ]] || [[ ! -f "$FILE_PATH" ]]; then
   exit 0
@@ -114,14 +113,11 @@ if [[ -n "$BODY_BCS" ]]; then
 fi
 
 if [[ -s "$ERRFILE" ]]; then
-  _emit type=hook.block hook=validate-story-bc-sync matcher=PostToolUse \
-        reason=policy8_bc_array_desync file_path="$FILE_PATH"
-  echo "POLICY 8 VIOLATION (bc_array_changes_propagate_to_body_and_acs):" >&2
-  while IFS= read -r line; do
-    echo "  - $line" >&2
-  done < "$ERRFILE"
-  echo "Fix: ensure frontmatter behavioral_contracts: array, body BC table, and AC traces all reference the same set of BCs." >&2
-  exit 2
+  _ERRORS_SUMMARY=$(tr '\n' '; ' < "$ERRFILE" | sed 's/; $//')
+  block_pre "validate-story-bc-sync" \
+    "Frontmatter behavioral_contracts != body BC table != AC traces (POLICY 8): $_ERRORS_SUMMARY" \
+    "Sync all three to the same BC set: frontmatter behavioral_contracts: array, body BC table, and AC trace annotations" \
+    "policy_8_violation"
 fi
 
 exit 0

--- a/plugins/vsdd-factory/hooks/validate-subsystem-names.sh
+++ b/plugins/vsdd-factory/hooks/validate-subsystem-names.sh
@@ -12,19 +12,18 @@
 
 set -euo pipefail
 
+# Source canonical block-message helper (provides block_pre).
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh" ]; then
+  # shellcheck source=lib/block.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh"
+fi
+
 if ! command -v jq &>/dev/null; then
   exit 0
 fi
 
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
-
-_emit() {
-  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" ]; then
-    "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" "$@" 2>/dev/null || true
-  fi
-  return 0
-}
 
 if [[ -z "$FILE_PATH" ]] || [[ ! -f "$FILE_PATH" ]]; then
   exit 0
@@ -143,17 +142,12 @@ if [[ "$FILE_PATH" == *"STORY-"* ]]; then
 fi
 
 if [[ -n "$ERRORS" ]]; then
-  _emit type=hook.block hook=validate-subsystem-names matcher=PostToolUse \
-        reason=policy6_subsystem_name_mismatch file_path="$FILE_PATH"
-  echo "POLICY 6 VIOLATION (architecture_is_subsystem_name_source_of_truth):" >&2
-  echo -e "$ERRORS" | while IFS= read -r line; do
-    echo "  - $line" >&2
-  done
-  echo "Fix: use SS-NN IDs from ARCH-INDEX.md Subsystem Registry. Available:" >&2
-  echo "$CANONICAL_MAP" | while IFS= read -r entry; do
-    echo "    - $entry" >&2
-  done
-  exit 2
+  _VALID_IDS=$(echo "$CANONICAL_IDS" | tr '\n' ',' | sed 's/,$//')
+  _ERRORS_SUMMARY=$(echo -e "$ERRORS" | tr '\n' '; ' | sed 's/; $//')
+  block_pre "validate-subsystem-names" \
+    "Subsystem name not in ARCH-INDEX Subsystem Registry (POLICY 6): $_ERRORS_SUMMARY" \
+    "Use one of: $_VALID_IDS (from ARCH-INDEX.md Subsystem Registry)" \
+    "policy_6_violation"
 fi
 
 exit 0

--- a/plugins/vsdd-factory/hooks/validate-table-cell-count.sh
+++ b/plugins/vsdd-factory/hooks/validate-table-cell-count.sh
@@ -12,19 +12,18 @@
 
 set -euo pipefail
 
+# Source canonical block-message helper (provides block_pre).
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh" ]; then
+  # shellcheck source=lib/block.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh"
+fi
+
 if ! command -v jq &>/dev/null; then
   exit 0
 fi
 
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
-
-_emit() {
-  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" ]; then
-    "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" "$@" 2>/dev/null || true
-  fi
-  return 0
-}
 
 if [[ -z "$FILE_PATH" ]] || [[ ! -f "$FILE_PATH" ]]; then
   exit 0
@@ -83,14 +82,11 @@ while IFS= read -r line; do
 done < "$FILE_PATH"
 
 if [[ -n "$ERRORS" ]]; then
-  _emit type=hook.block hook=validate-table-cell-count matcher=PostToolUse \
-        reason=table_cell_count_mismatch file_path="$FILE_PATH"
-  echo "TABLE CELL COUNT VIOLATION in $(basename "$FILE_PATH"):" >&2
-  echo -e "$ERRORS" | while IFS= read -r line; do
-    echo "  - $line" >&2
-  done
-  echo "  Escape pipes inside cells with \\| or restructure the cell content." >&2
-  exit 2
+  _ERRORS_SUMMARY=$(echo -e "$ERRORS" | head -1)
+  block_pre "validate-table-cell-count" \
+    "Markdown table row has wrong cell count in $(basename "$FILE_PATH"): $_ERRORS_SUMMARY" \
+    "Escape pipes inside cells with \\| , or restructure the cell" \
+    "table_cell_count"
 fi
 
 exit 0

--- a/plugins/vsdd-factory/hooks/validate-template-compliance.sh
+++ b/plugins/vsdd-factory/hooks/validate-template-compliance.sh
@@ -19,19 +19,18 @@
 
 set -euo pipefail
 
+# Source canonical block-message helper (provides block_pre).
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh" ]; then
+  # shellcheck source=lib/block.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh"
+fi
+
 if ! command -v jq &>/dev/null; then
   exit 0
 fi
 
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
-
-_emit() {
-  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" ]; then
-    "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" "$@" 2>/dev/null || true
-  fi
-  return 0
-}
 
 if [[ -z "$FILE_PATH" ]] || [[ ! -f "$FILE_PATH" ]]; then
   exit 0
@@ -177,23 +176,18 @@ done <<< "$TEMPLATE_SECTIONS"
 
 # --- Step 9: Report ---
 if [[ -n "$MISSING_KEYS" || -n "$MISSING_SECTIONS" ]]; then
-  _emit type=hook.block hook=validate-template-compliance matcher=PostToolUse \
-        reason=template_noncompliant file_path="$FILE_PATH" \
-        template="$TEMPLATE_NAME" missing_keys="$MISSING_KEYS"
-  echo "TEMPLATE COMPLIANCE WARNING ($(basename "$FILE_PATH") → $TEMPLATE_NAME):" >&2
+  _DETAIL=""
   if [[ -n "$MISSING_KEYS" ]]; then
-    TOTAL_TMPL=$(echo "$TEMPLATE_KEYS" | wc -w | tr -d ' ')
-    TOTAL_FILE=$(echo "$FILE_KEYS" | wc -w | tr -d ' ')
-    echo "  Frontmatter: $TOTAL_FILE/$TOTAL_TMPL fields present. Missing: $MISSING_KEYS" >&2
+    _DETAIL="${_DETAIL:+$_DETAIL; }missing frontmatter keys: $MISSING_KEYS"
   fi
   if [[ -n "$MISSING_SECTIONS" ]]; then
-    echo "  Sections missing:" >&2
-    echo "$MISSING_SECTIONS" | tr '||' '\n' | while IFS= read -r s; do
-      [[ -n "$s" ]] && echo "    - ## $s" >&2
-    done
+    _MISSING_SECS=$(echo "$MISSING_SECTIONS" | tr '||' ',' | sed 's/^,//;s/,$//')
+    _DETAIL="${_DETAIL:+$_DETAIL; }missing sections: $_MISSING_SECS"
   fi
-  echo "  Fix: run /vsdd-factory:conform-to-template $(basename "$FILE_PATH") to add missing structure." >&2
-  exit 2
+  block_pre "validate-template-compliance" \
+    "Frontmatter or sections missing in $(basename "$FILE_PATH") (template: $TEMPLATE_NAME): $_DETAIL" \
+    "Run /vsdd-factory:conform-to-template $(basename "$FILE_PATH") to add missing structure" \
+    "template_drift"
 fi
 
 exit 0

--- a/plugins/vsdd-factory/hooks/validate-vp-consistency.sh
+++ b/plugins/vsdd-factory/hooks/validate-vp-consistency.sh
@@ -15,6 +15,12 @@
 
 set -euo pipefail
 
+# Source canonical block-message helper (provides block_pre).
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh" ]; then
+  # shellcheck source=lib/block.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh"
+fi
+
 ERRFILE=$(mktemp)
 # Preserve exit code through EXIT trap (Defect 2 fix)
 # shellcheck disable=SC2154  # rc is assigned inside the trap via $?
@@ -27,13 +33,6 @@ fi
 
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
-
-_emit() {
-  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" ]; then
-    "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" "$@" 2>/dev/null || true
-  fi
-  return 0
-}
 
 if [[ -z "$FILE_PATH" ]]; then
   exit 0
@@ -235,14 +234,11 @@ done
 
 # --- Report ---
 if [[ -s "$ERRFILE" ]]; then
-  _emit type=hook.block hook=validate-vp-consistency matcher=PostToolUse \
-        reason=policy9_vp_inconsistency file_path="$FILE_PATH"
-  echo "POLICY 9 VIOLATION (vp_index_is_vp_catalog_source_of_truth):" >&2
-  while IFS= read -r line; do
-    echo "  - $line" >&2
-  done < "$ERRFILE"
-  echo "Fix: ensure VP-INDEX.md, verification-architecture.md, and verification-coverage-matrix.md are consistent." >&2
-  exit 2
+  _ERRORS_SUMMARY=$(tr '\n' '; ' < "$ERRFILE" | sed 's/; $//')
+  block_pre "validate-vp-consistency" \
+    "VP-INDEX <-> verification-architecture <-> coverage-matrix divergence (POLICY 9): $_ERRORS_SUMMARY" \
+    "Sync all three docs to the same VP set" \
+    "policy_9_violation"
 fi
 
 exit 0

--- a/plugins/vsdd-factory/hooks/validate-wave-gate-completeness.sh
+++ b/plugins/vsdd-factory/hooks/validate-wave-gate-completeness.sh
@@ -24,19 +24,18 @@
 
 set -euo pipefail
 
+# Source canonical block-message helper (provides block_pre).
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh" ]; then
+  # shellcheck source=lib/block.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh"
+fi
+
 if ! command -v jq &>/dev/null; then
   exit 0
 fi
 
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
-
-_emit() {
-  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" ]; then
-    "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" "$@" 2>/dev/null || true
-  fi
-  return 0
-}
 
 if [[ -z "$FILE_PATH" ]] || [[ ! -f "$FILE_PATH" ]]; then
   exit 0
@@ -124,17 +123,11 @@ while IFS= read -r entry; do
 done <<< "$NEWLY_PASSED"
 
 if [[ -n "$ERRORS" ]]; then
-  _emit type=hook.block hook=validate-wave-gate-completeness matcher=PostToolUse \
-        reason=wave_gate_incomplete file_path="$FILE_PATH"
-  echo "WAVE GATE COMPLETENESS VIOLATION:" >&2
-  echo -e "$ERRORS" | while IFS= read -r line; do
-    echo "  - $line" >&2
-  done
-  echo "" >&2
-  echo "  All 6 gates must be evidenced in the gate report before marking passed." >&2
-  echo "  Run /vsdd-factory:wave-gate to complete all gates, or set gate_status: deferred" >&2
-  echo "  with a rationale if gates are intentionally skipped." >&2
-  exit 2
+  _ERRORS_SUMMARY=$(echo -e "$ERRORS" | tr '\n' '; ' | sed 's/; $//')
+  block_pre "validate-wave-gate-completeness" \
+    "Not all 6 gates evidenced: $_ERRORS_SUMMARY" \
+    "Run /vsdd-factory:wave-gate, OR set gate_status: deferred with rationale" \
+    "wave_gate_incomplete"
 fi
 
 exit 0

--- a/plugins/vsdd-factory/hooks/validate-wave-gate-prerequisite.sh
+++ b/plugins/vsdd-factory/hooks/validate-wave-gate-prerequisite.sh
@@ -14,6 +14,12 @@
 
 set -euo pipefail
 
+# Source canonical block-message helper (provides block_pre).
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh" ]; then
+  # shellcheck source=lib/block.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh"
+fi
+
 if ! command -v jq &>/dev/null; then
   exit 0
 fi
@@ -32,13 +38,6 @@ fi
 
 SUBAGENT=$(echo "$INPUT" | jq -r '.tool_input.subagent_type // ""')
 PROMPT=$(echo "$INPUT" | jq -r '.tool_input.prompt // ""')
-
-_emit() {
-  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" ]; then
-    "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" "$@" 2>/dev/null || true
-  fi
-  return 0
-}
 
 # Scope split: adversary dispatches go through SHA-currency hygiene
 # (state-manager burst integrity check). Worker-agent dispatches go
@@ -74,29 +73,10 @@ case "$SUBAGENT" in
     fi
 
     # Hook returned non-zero — block the dispatch with diagnostic.
-    _emit type=hook.block hook=validate-wave-gate-prerequisite \
-          matcher=Agent reason=sha_currency_failed subagent="$SUBAGENT"
-    {
-      echo ""
-      echo "wave-gate-prerequisite: BLOCKED — SHA currency check failed."
-      echo ""
-      echo "An adversary pass cannot run while the prior remediation burst's"
-      echo "factory-artifacts hygiene is dirty (stale SHA cites, multi-commit"
-      echo "chains, in-progress narrative, or cross-record drift)."
-      echo ""
-      echo "Hook output:"
-      # shellcheck disable=SC2001  # sed is the right tool for line-prefix indentation
-      echo "$HOOK_OUTPUT" | sed 's/^/  /'
-      echo ""
-      echo "Resolve before re-dispatching:"
-      echo "  bash $SHA_HOOK"
-      echo ""
-      echo "If the issue is a multi-commit chain, recover with:"
-      echo "  git -C .factory reset --soft HEAD~N   # collapse extra commits"
-      echo "  # then redo Stage 1 + Stage 2 of the burst protocol"
-      echo "  # (see vsdd-factory:state-burst skill)"
-    } >&2
-    exit 2
+    block_pre "validate-wave-gate-prerequisite" \
+      "SHA currency check failed — factory-artifacts hygiene is dirty (stale SHA cites, multi-commit chains, in-progress narrative, or cross-record drift)" \
+      "Resolve with: bash $SHA_HOOK; if multi-commit chain use: git -C .factory reset --soft HEAD~N then redo Stage 1+2 of burst protocol" \
+      "wave_gate_blocking"
     ;;
   *test-writer*|*implementer*|*demo-recorder*|*pr-manager*|*devops-engineer*) ;;
   *) exit 0 ;;
@@ -173,32 +153,10 @@ for name, data in state['waves'].items():
         print(name); break
 " 2>/dev/null || true)
 
-  _emit type=hook.block hook=validate-wave-gate-prerequisite matcher=Agent \
-        reason=wave_gate_prerequisite_not_passed \
-        subagent="$SUBAGENT" story_id="$STORY_ID" target_wave="$TARGET_WAVE" \
-        blocking_wave="$BLOCKING_WAVE" blocking_status="$BLOCKING_STATUS"
-  echo "" >&2
-  echo "wave-gate-prerequisite: BLOCKED." >&2
-  echo "" >&2
-  echo "You are dispatching $SUBAGENT for $STORY_ID (wave=$TARGET_WAVE)," >&2
-  echo "but an earlier wave has not passed its integration gate:" >&2
-  echo "" >&2
-  echo "  $BLOCKING_WAVE: gate_status=$BLOCKING_STATUS" >&2
-  echo "" >&2
-  echo "Before dispatching $TARGET_WAVE work, do ONE of:" >&2
-  echo "" >&2
-  echo "1. Run the wave integration gate for $BLOCKING_WAVE:" >&2
-  echo "   Invoke /vsdd-factory:wave-gate OR spawn the reviewer agents" >&2
-  echo "   against the wave's merged commits. Fix any blocking findings." >&2
-  echo "   Then update .factory/wave-state.yaml gate_status: passed." >&2
-  echo "" >&2
-  echo "2. If the wave has no new behavioral surface (e.g., pure docs)," >&2
-  echo "   set gate_status: deferred with a rationale field." >&2
-  echo "" >&2
-  echo "Do NOT silently skip. Do NOT manually edit wave-state.yaml" >&2
-  echo "without running the checks." >&2
-
-  exit 2
+  block_pre "validate-wave-gate-prerequisite" \
+    "Earlier wave's gate has not passed: $BLOCKING_WAVE (gate_status=$BLOCKING_STATUS) must pass before dispatching $STORY_ID ($TARGET_WAVE)" \
+    "Resolve $BLOCKING_WAVE integration gate first: invoke /vsdd-factory:wave-gate, fix blocking findings, then update wave-state.yaml gate_status: passed" \
+    "wave_gate_blocking"
 fi
 
 exit 0

--- a/plugins/vsdd-factory/hooks/verify-git-push.sh
+++ b/plugins/vsdd-factory/hooks/verify-git-push.sh
@@ -21,6 +21,12 @@
 
 set -euo pipefail
 
+# Source canonical block-message helper (provides block_pre).
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh" ]; then
+  # shellcheck source=lib/block.sh
+  source "${CLAUDE_PLUGIN_ROOT}/hooks/lib/block.sh"
+fi
+
 if ! command -v jq &>/dev/null; then
   exit 0
 fi
@@ -33,35 +39,15 @@ if [[ "$COMMAND" != *"git push"* ]]; then
   exit 0
 fi
 
-_emit() {
-  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -x "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" ]; then
-    "${CLAUDE_PLUGIN_ROOT}/bin/emit-event" "$@" 2>/dev/null || true
-  fi
-  return 0
-}
-
-block() {
-  local reason="$1"
-  local suggestion="${2:-}"
-  local code="${3:-unknown}"
-  _emit type=hook.block hook=verify-git-push matcher=Bash reason="$code" command="$COMMAND"
-  echo "BLOCKED by verify-git-push:" >&2
-  echo "  $reason" >&2
-  if [[ -n "$suggestion" ]]; then
-    echo "  Suggestion: $suggestion" >&2
-  fi
-  exit 2
-}
-
 # --- Block force push ---
 # Allow --force-with-lease (safe force push — only overwrites if remote matches local expectation)
 # Block --force and -f (unconditional force push — overwrites regardless)
 if [[ "$COMMAND" == *"--force-with-lease"* ]]; then
   : # Allowed — safe force push
 elif [[ "$COMMAND" == *"--force"* ]] || [[ "$COMMAND" == *" -f "* ]] || [[ "$COMMAND" == *" -f"$'\n'* ]] || [[ "$COMMAND" =~ " -f"$ ]]; then
-  block \
-    "Force push (--force / -f) overwrites remote history irreversibly." \
-    "Use 'git push --force-with-lease' for safe force push, or push to a new branch." \
+  block_pre "verify-git-push" \
+    "Force push (--force / -f) overwrites remote history irreversibly" \
+    "Use 'git push --force-with-lease' for safe force push, or push to a new branch" \
     "git_push_force"
 fi
 
@@ -74,8 +60,8 @@ for branch in $PROTECTED_BRANCHES; do
   # Match patterns: "git push origin main", "git push origin main:main",
   # "git push upstream main", etc.
   if [[ "$COMMAND" =~ git\ push\ [a-zA-Z_-]+\ ${branch}($|\ |:) ]]; then
-    block \
-      "Direct push to protected branch '$branch' bypasses PR and review gates." \
+    block_pre "verify-git-push" \
+      "Direct push to protected branch '$branch' bypasses PR and review gates" \
       "Push to a feature branch and create a PR: git push origin feature/STORY-NNN && gh pr create --base $branch" \
       "git_push_protected"
   fi

--- a/tests/integration/hooks/canonical-format-invariant.bats
+++ b/tests/integration/hooks/canonical-format-invariant.bats
@@ -1,0 +1,403 @@
+#!/usr/bin/env bats
+# tests/integration/hooks/canonical-format-invariant.bats
+#
+# Integration test: every blocking bash hook emits a single-line stderr
+# message in the canonical Why/Fix/Code format:
+#
+#   BLOCKED by <hook-name>: <reason>. Fix: <recommendation>. Code: <code>.
+#
+# For each hook with a synthesizable block path, this test:
+#   1. Constructs a minimal JSON input that will trigger the block.
+#   2. Runs the hook with CLAUDE_PLUGIN_ROOT set so it sources lib/block.sh.
+#   3. Asserts exit code 2 and that the first stderr line matches the regex.
+#
+# Hooks using block_pre_json (protect-bc, protect-vp) emit JSON to stdout
+# with permissionDecisionReason; those are tested via jq parsing instead.
+#
+# Run: bats tests/integration/hooks/canonical-format-invariant.bats
+
+# Canonical format: BLOCKED by <hook-name>: <reason>. Fix: <recommendation>. Code: <code>.
+# hook-name: lowercase letters and hyphens
+# reason/recommendation: any content (may contain periods internally)
+# code: lowercase letters, digits, and underscores
+CANONICAL_RE='^BLOCKED by [a-z][a-z0-9-]*: .+\. Fix: .+\. Code: [a-z][a-z0-9_]*\.$'
+
+setup() {
+    REPO_ROOT="$(git -C "$(dirname "$BATS_TEST_FILENAME")" rev-parse --show-toplevel)"
+    HOOKS_DIR="${REPO_ROOT}/plugins/vsdd-factory/hooks"
+    export CLAUDE_PLUGIN_ROOT="${REPO_ROOT}/plugins/vsdd-factory"
+    WORK="$(mktemp -d)"
+}
+
+teardown() {
+    rm -rf "${WORK:-}" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Helper: run hook, check exit 2 and canonical stderr
+# ---------------------------------------------------------------------------
+check_block() {
+    local hook="$1"
+    local json="$2"
+
+    # Use bats run to capture stderr+stdout and exit status
+    # run merges stdout+stderr into $output when not using run --separate-stderr
+    # We redirect hook stdout to /dev/null and capture stderr as the output
+    run bash -c "echo '$(echo "$json" | sed "s/'/'\\\\''/g")' | bash '$hook' 2>&1 >/dev/null"
+    local exitcode="$status"
+    local stderr_content="$output"
+
+    if [[ "$exitcode" -ne 2 ]]; then
+        echo "Expected exit 2 but got $exitcode" >&3
+        echo "Output: $stderr_content" >&3
+        return 1
+    fi
+
+    local first_line
+    first_line=$(printf '%s' "$stderr_content" | head -1)
+    if ! echo "$first_line" | grep -qE "$CANONICAL_RE"; then
+        echo "Stderr first line does not match canonical format:" >&3
+        echo "  Got:   $first_line" >&3
+        echo "  Regex: $CANONICAL_RE" >&3
+        return 1
+    fi
+    return 0
+}
+
+# check_json_deny: for hooks that emit permissionDecision: deny (exit 0)
+check_json_deny() {
+    local hook="$1"
+    local json="$2"
+
+    if ! command -v jq &>/dev/null; then
+        skip "jq not available"
+    fi
+
+    local stdout exitcode
+    stdout=$(echo "$json" | bash "$hook" 2>/dev/null)
+    exitcode=$?
+
+    # block_pre_json exits 0
+    if [[ "$exitcode" -ne 0 ]]; then
+        echo "Expected exit 0 (JSON deny) but got $exitcode" >&3
+        return 1
+    fi
+
+    local decision
+    decision=$(echo "$stdout" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null || true)
+    if [[ "$decision" != "deny" ]]; then
+        echo "Expected permissionDecision: deny but got: $decision" >&3
+        return 1
+    fi
+
+    local reason
+    reason=$(echo "$stdout" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null || true)
+    if ! echo "$reason" | grep -qE "$CANONICAL_RE"; then
+        echo "permissionDecisionReason does not match canonical format:" >&3
+        echo "  Got:   $reason" >&3
+        echo "  Regex: $CANONICAL_RE" >&3
+        return 1
+    fi
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# verify-git-push — force push
+# ---------------------------------------------------------------------------
+@test "verify-git-push: force push canonical block" {
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+    local json='{"tool_name":"Bash","tool_input":{"command":"git push origin main --force"}}'
+    check_block "${HOOKS_DIR}/verify-git-push.sh" "$json"
+}
+
+@test "verify-git-push: protected branch canonical block" {
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+    local json='{"tool_name":"Bash","tool_input":{"command":"git push origin main"}}'
+    check_block "${HOOKS_DIR}/verify-git-push.sh" "$json"
+}
+
+# ---------------------------------------------------------------------------
+# destructive-command-guard
+# ---------------------------------------------------------------------------
+@test "destructive-command-guard: git reset --hard canonical block" {
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+    local json='{"tool_name":"Bash","tool_input":{"command":"git reset --hard HEAD~1"}}'
+    check_block "${HOOKS_DIR}/destructive-command-guard.sh" "$json"
+}
+
+# ---------------------------------------------------------------------------
+# protect-secrets
+# ---------------------------------------------------------------------------
+@test "protect-secrets: echo secret variable canonical block" {
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+    local json
+    # Use a JSON string that will trigger the secret pattern
+    json='{"tool_name":"Bash","tool_input":{"command":"echo $MY_API_KEY"}}'
+    check_block "${HOOKS_DIR}/protect-secrets.sh" "$json"
+}
+
+# ---------------------------------------------------------------------------
+# brownfield-discipline
+# ---------------------------------------------------------------------------
+@test "brownfield-discipline: write to .reference/ canonical block" {
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+    local json='{"tool_name":"Edit","tool_input":{"file_path":"/project/.reference/some-repo/file.py"}}'
+    check_block "${HOOKS_DIR}/brownfield-discipline.sh" "$json"
+}
+
+# ---------------------------------------------------------------------------
+# protect-bc (JSON deny path)
+# ---------------------------------------------------------------------------
+@test "protect-bc: green BC canonical deny JSON" {
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+    local fake_path="${WORK}/.factory/specs/behavioral-contracts/BC-1.01.001.md"
+    mkdir -p "$(dirname "$fake_path")"
+    echo "Status: green" > "$fake_path"
+    local json="{\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"${fake_path}\"}}"
+    check_json_deny "${HOOKS_DIR}/protect-bc.sh" "$json"
+}
+
+# ---------------------------------------------------------------------------
+# protect-vp (JSON deny path)
+# ---------------------------------------------------------------------------
+@test "protect-vp: green VP canonical deny JSON" {
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+    local fake_path="${WORK}/.factory/specs/verification-properties/VP-1.01.001.md"
+    mkdir -p "$(dirname "$fake_path")"
+    echo "Status: green" > "$fake_path"
+    local json="{\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"${fake_path}\"}}"
+    check_json_deny "${HOOKS_DIR}/protect-vp.sh" "$json"
+}
+
+# ---------------------------------------------------------------------------
+# validate-bc-title
+# ---------------------------------------------------------------------------
+@test "validate-bc-title: H1/INDEX mismatch canonical block" {
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+    local bc_dir="${WORK}/behavioral-contracts"
+    mkdir -p "$bc_dir"
+    local bc_file="${bc_dir}/BC-1.01.001.md"
+    echo "# BC-1.01.001: Correct Title" > "$bc_file"
+    local bc_index="${bc_dir}/BC-INDEX.md"
+    echo "| BC-1.01.001 | Wrong Title | SS-01 |" > "$bc_index"
+    local json="{\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"${bc_file}\"}}"
+    check_block "${HOOKS_DIR}/validate-bc-title.sh" "$json"
+}
+
+# ---------------------------------------------------------------------------
+# validate-state-size
+# ---------------------------------------------------------------------------
+@test "validate-state-size: STATE.md over 500 lines canonical block" {
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+    local factory_dir="${WORK}/.factory"
+    mkdir -p "$factory_dir"
+    local state_file="${factory_dir}/STATE.md"
+    python3 -c "print('\n'.join(['line ' + str(i) for i in range(510)]))" > "$state_file"
+    local json="{\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"${state_file}\"}}"
+    check_block "${HOOKS_DIR}/validate-state-size.sh" "$json"
+}
+
+# ---------------------------------------------------------------------------
+# validate-demo-evidence-story-scoped
+# ---------------------------------------------------------------------------
+@test "validate-demo-evidence-story-scoped: flat demo-evidence file canonical block" {
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+    local evidence_dir="${WORK}/docs/demo-evidence"
+    mkdir -p "$evidence_dir"
+    local flat_file="${evidence_dir}/evidence-report.md"
+    echo "# Evidence" > "$flat_file"
+    local json="{\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"${flat_file}\"}}"
+    check_block "${HOOKS_DIR}/validate-demo-evidence-story-scoped.sh" "$json"
+}
+
+# ---------------------------------------------------------------------------
+# validate-factory-path-root
+# ---------------------------------------------------------------------------
+@test "validate-factory-path-root: worktree-relative path canonical block" {
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+    local json='{"tool_name":"Write","tool_input":{"file_path":"/project/.worktrees/STORY-001/.factory/STATE.md"}}'
+    check_block "${HOOKS_DIR}/validate-factory-path-root.sh" "$json"
+}
+
+# ---------------------------------------------------------------------------
+# validate-subsystem-names
+# ---------------------------------------------------------------------------
+@test "validate-subsystem-names: unknown SS-ID canonical block" {
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+    local factory_dir="${WORK}/.factory"
+    local bc_dir="${factory_dir}/specs/behavioral-contracts"
+    local arch_dir="${factory_dir}/specs/architecture"
+    mkdir -p "$bc_dir" "$arch_dir"
+
+    local bc_file="${bc_dir}/BC-1.01.001.md"
+    cat > "$bc_file" <<'EOF'
+---
+subsystem: SS-99
+---
+# BC-1.01.001: Test
+EOF
+
+    local arch_index="${arch_dir}/ARCH-INDEX.md"
+    cat > "$arch_index" <<'EOF'
+# ARCH-INDEX
+
+## Subsystem Registry
+
+| SS ID | Name | Architecture Doc | Implementing Modules | Phase |
+|---|---|---|---|---|
+| SS-01 | Core | arch/ss-01.md | crates/core | 1 |
+| SS-02 | API | arch/ss-02.md | crates/api | 1 |
+EOF
+
+    local json="{\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"${bc_file}\"}}"
+    check_block "${HOOKS_DIR}/validate-subsystem-names.sh" "$json"
+}
+
+# ---------------------------------------------------------------------------
+# validate-table-cell-count
+# ---------------------------------------------------------------------------
+@test "validate-table-cell-count: wrong cell count canonical block" {
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+    local factory_dir="${WORK}/.factory"
+    mkdir -p "$factory_dir"
+    local md_file="${factory_dir}/some-doc.md"
+    cat > "$md_file" <<'EOF'
+| Col1 | Col2 | Col3 |
+|---|---|---|
+| a | b | c | extra |
+EOF
+    local json="{\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"${md_file}\"}}"
+    check_block "${HOOKS_DIR}/validate-table-cell-count.sh" "$json"
+}
+
+# ---------------------------------------------------------------------------
+# validate-pr-description-completeness
+# ---------------------------------------------------------------------------
+@test "validate-pr-description-completeness: missing sections canonical block" {
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+    local delivery_dir="${WORK}/.factory/code-delivery/STORY-001"
+    mkdir -p "$delivery_dir"
+    local pr_file="${delivery_dir}/pr-description.md"
+    echo "# PR Description" > "$pr_file"
+    echo "" >> "$pr_file"
+    echo "Some content without required sections." >> "$pr_file"
+    local json="{\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"${pr_file}\"}}"
+    check_block "${HOOKS_DIR}/validate-pr-description-completeness.sh" "$json"
+}
+
+# ---------------------------------------------------------------------------
+# validate-novelty-assessment
+# ---------------------------------------------------------------------------
+@test "validate-novelty-assessment: missing section canonical block" {
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+    local adv_dir="${WORK}/.factory/cycles/E-1/adversarial-reviews"
+    mkdir -p "$adv_dir"
+    local review_file="${adv_dir}/pass-1.md"
+    cat > "$review_file" <<'EOF'
+# Adversary Review Pass 1
+
+## Summary
+
+Some content without novelty assessment section.
+EOF
+    local json="{\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"${review_file}\"}}"
+    check_block "${HOOKS_DIR}/validate-novelty-assessment.sh" "$json"
+}
+
+# ---------------------------------------------------------------------------
+# validate-input-hash — wrong hash format
+# ---------------------------------------------------------------------------
+@test "validate-input-hash: wrong hash length canonical block" {
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+    local factory_dir="${WORK}/.factory"
+    mkdir -p "$factory_dir"
+    local md_file="${factory_dir}/story.md"
+    cat > "$md_file" <<'EOF'
+---
+inputs:
+  - some-file.md
+input-hash: abcdef01234
+---
+# Story
+EOF
+    local json="{\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"${md_file}\"}}"
+    check_block "${HOOKS_DIR}/validate-input-hash.sh" "$json"
+}
+
+# ---------------------------------------------------------------------------
+# validate-state-pin-freshness
+# ---------------------------------------------------------------------------
+@test "validate-state-pin-freshness: version pin drift canonical block" {
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+    local factory_dir="${WORK}/.factory"
+    local bc_specs_dir="${factory_dir}/specs/behavioral-contracts"
+    mkdir -p "$bc_specs_dir"
+
+    local bc_index="${bc_specs_dir}/BC-INDEX.md"
+    cat > "$bc_index" <<'EOF'
+---
+version: v1.5
+---
+# BC-INDEX
+EOF
+
+    local state_file="${factory_dir}/STATE.md"
+    cat > "$state_file" <<'EOF'
+---
+bc_index_version: v1.4
+---
+# STATE
+EOF
+
+    local json="{\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"${state_file}\"}}"
+    check_block "${HOOKS_DIR}/validate-state-pin-freshness.sh" "$json"
+}
+
+# ---------------------------------------------------------------------------
+# red-gate — strict mode
+# ---------------------------------------------------------------------------
+@test "red-gate: strict mode canonical block" {
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+    local state_file="${WORK}/.factory/red-gate-state.json"
+    mkdir -p "$(dirname "$state_file")"
+    echo '{"mode":"strict","red":[]}' > "$state_file"
+
+    local src_file="${WORK}/src/lib.rs"
+    mkdir -p "$(dirname "$src_file")"
+    echo "// source" > "$src_file"
+
+    local json="{\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"${src_file}\"}}"
+
+    # red-gate reads .factory/red-gate-state.json relative to CWD, so we must
+    # cd to WORK before running. Use run bash -c to avoid set -e tripping on exit 2.
+    run bash -c "cd '${WORK}' && printf '%s' '$(printf '%s' "$json" | sed "s/'/'\\\\''/g")' | bash '${HOOKS_DIR}/red-gate.sh' 2>&1 >/dev/null"
+    local exitcode="$status"
+    local stderr_content="$output"
+
+    if [[ "$exitcode" -ne 2 ]]; then
+        echo "Expected exit 2 but got $exitcode" >&3
+        echo "Output: $stderr_content" >&3
+        return 1
+    fi
+
+    local first_line
+    first_line=$(printf '%s' "$stderr_content" | head -1)
+    if ! echo "$first_line" | grep -qE "$CANONICAL_RE"; then
+        echo "Stderr first line does not match canonical format:" >&3
+        echo "  Got:   $first_line" >&3
+        echo "  Regex: $CANONICAL_RE" >&3
+        return 1
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# factory-branch-guard — .factory/ not a worktree
+# ---------------------------------------------------------------------------
+@test "factory-branch-guard: non-worktree .factory/ canonical block" {
+    if ! command -v jq &>/dev/null; then skip "jq not available"; fi
+    local factory_dir="${WORK}/.factory"
+    mkdir -p "$factory_dir"
+    # No .git file → not a worktree
+    local json="{\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"${factory_dir}/STATE.md\"}}"
+    check_block "${HOOKS_DIR}/factory-branch-guard.sh" "$json"
+}


### PR DESCRIPTION
## Summary

- **22 Tier A bash hooks migrated** to `lib/block.sh` + `block_pre` (source-and-call pattern). Covers all 3 inline-block hooks (verify-git-push, destructive-command-guard, protect-secrets) and all 19 raw-echo+exit-2 hooks from the spec table.
- **protect-bc + protect-vp migrated** to `block_pre_json` (inline `emit_deny()` removed; canonical `bc_green_immutable` / `vp_green_immutable` codes added).
- **PR #94 follow-ups closed:** S1 (7 redundant inline `_emit()` defs removed from hooks that source lib/block.sh), S2 (count-propagation now surfaces all drift messages joined, not just first), N1 (`Attribution` gets `#[derive(PartialEq)]`; test uses `assert_eq!`).
- **New invariant test** `tests/integration/hooks/canonical-format-invariant.bats` — 19 tests, one per blocking hook, each asserting exit 2 + stderr matching `^BLOCKED by [a-z][a-z0-9-]*: .+\. Fix: .+\. Code: [a-z][a-z0-9_]*\.$`.
- **HOST_ABI docs updated** — new "Block-message convention" section in `crates/hook-sdk/HOST_ABI.md` documenting the canonical format and the `block_pre` / `block_pre_json` / `block_with_fix` usage for bash and WASM hooks.

## Test plan

- [x] `cargo test --workspace --no-fail-fast` — all crates pass (no regressions)
- [x] `bats tests/integration/hooks/block-helper.bats` — 5/5 pass
- [x] `bats tests/integration/hooks/canonical-format-invariant.bats` — 19/19 pass
- [x] `bash -n plugins/vsdd-factory/hooks/*.sh` — all 34 hook scripts parse cleanly
- [x] Spot-checked brownfield-discipline block path: stderr matches canonical regex, exit 2
- [x] `git diff --stat` confirms scope: 34 modified files + 1 new bats test

## Hooks migrated (22 Tier A + protect-bc/vp)

| Hook | Migration type | Code(s) |
|------|---------------|---------|
| verify-git-push | inline block() → block_pre | git_push_force, git_push_protected |
| destructive-command-guard | inline block() → block_pre | destructive_command |
| protect-secrets | inline block() → block_pre | secret_exposure |
| protect-bc | emit_deny() → block_pre_json | bc_green_immutable |
| protect-vp | emit_deny() → block_pre_json | vp_green_immutable |
| brownfield-discipline | raw exit 2 → block_pre | reference_readonly |
| red-gate | raw exit 2 → block_pre | red_gate_strict |
| validate-bc-title | raw exit 2 → block_pre | bc_h1_index_drift |
| validate-anchor-capabilities-union | raw exit 2 → block_pre | anchor_caps_drift |
| validate-input-hash | raw exit 2 → block_pre | input_hash_missing, input_hash_format, input_hash_drift |
| validate-state-size | raw exit 2 → block_pre | state_md_bloat |
| validate-pr-merge-prerequisites | raw exit 2 → block_pre | pr_merge_evidence_missing |
| validate-pr-description-completeness | raw exit 2 → block_pre | pr_description_incomplete |
| validate-novelty-assessment | raw exit 2 → block_pre | novelty_section_missing |
| validate-story-bc-sync | raw exit 2 → block_pre | policy_8_violation |
| validate-subsystem-names | raw exit 2 → block_pre | policy_6_violation |
| validate-template-compliance | raw exit 2 → block_pre | template_drift |
| validate-vp-consistency | raw exit 2 → block_pre | policy_9_violation |
| validate-wave-gate-completeness | raw exit 2 → block_pre | wave_gate_incomplete |
| validate-wave-gate-prerequisite | raw exit 2 → block_pre | wave_gate_blocking |
| validate-table-cell-count | raw exit 2 → block_pre | table_cell_count |
| validate-finding-format | raw exit 2 → block_pre | id_format_violation |
| validate-state-pin-freshness | raw exit 2 → block_pre | state_pin_stale |
| validate-demo-evidence-story-scoped | raw exit 2 → block_pre | pol_010_violation |
| validate-factory-path-root | raw exit 2 → block_pre | factory_path_relative |
| convergence-tracker | raw exit 2 → block_pre | convergence_rule_violation |
| factory-branch-guard | raw exit 2 → block_pre | factory_no_worktree, factory_wrong_branch |