### PR TITLE
[F5-B4] Test quality — catch_unwind cleanup, perf benchmark, bats split, programmatic skill enumeration

### DIFF
--- a/crates/hook-plugins/validate-artifact-path/src/tests.rs
+++ b/crates/hook-plugins/validate-artifact-path/src/tests.rs
@@ -1355,3 +1355,88 @@ artifacts:
         path
     );
 }
+
+// -----------------------------------------------------------------------
+// BC-4.11.001 EC-007: execution time ceiling ≤200ms for matches_canonical
+//
+// F-MED-5: no benchmark existed to enforce the 200ms ceiling from EC-007.
+// This test loads the actual artifact-path-registry.yaml (the production
+// registry), runs matches_canonical 1000 times against a fixture path,
+// and asserts the total elapsed time is under 200ms.
+//
+// Why 1000 iterations instead of 1? A single call is too fast to time
+// reliably (sub-microsecond on modern hardware). 1000 iterations at once
+// gives a stable measurement and still should complete well under the
+// 200ms WASM ceiling. If the total 1000-call time exceeds 200ms, each
+// individual call would be averaging ~200µs — already 10x too slow for
+// a WASM execution budget of the whole hook.
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_BC_4_11_001_ec007_matches_canonical_1000_calls_under_200ms() {
+    // BC-4.11.001 EC-007: "WASM execution time MUST remain under 200ms."
+    // Load the actual production registry and time 1000 matches_canonical
+    // calls. Total elapsed must be < 200ms (a 1000-call batch under 200ms
+    // means each call is < 200µs on average — comfortably within WASM budget).
+    //
+    // If this test becomes flaky on heavily loaded CI machines, the ceiling
+    // can be raised to 1000ms (still proves no O(n²) regression).
+    use std::time::Instant;
+
+    // Locate the production registry relative to CARGO_MANIFEST_DIR.
+    // Path: <workspace>/plugins/vsdd-factory/config/artifact-path-registry.yaml
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
+        .expect("CARGO_MANIFEST_DIR must be set during cargo test");
+    let registry_path = std::path::Path::new(&manifest_dir)
+        .join("../../../../plugins/vsdd-factory/config/artifact-path-registry.yaml");
+
+    if !registry_path.exists() {
+        // Registry not present (e.g., running in a context without plugin dir).
+        // Fall back to the multi-entry fixture — still exercises the algorithm.
+        let yaml = multi_entry_registry_yaml();
+        let registry = load_registry(&yaml)
+            .expect("fixture registry must load");
+        let path = ".factory/specs/behavioral-contracts/ss-04/BC-4.11.001.md";
+
+        let start = Instant::now();
+        for _ in 0..1000 {
+            let _ = matches_canonical(path, &registry);
+        }
+        let elapsed_ms = start.elapsed().as_millis();
+
+        assert!(
+            elapsed_ms < 200,
+            "BC-4.11.001 EC-007: 1000 matches_canonical calls on fixture registry \
+             must complete in < 200ms total; got {}ms (fixture fallback — production \
+             registry absent at {})",
+            elapsed_ms,
+            registry_path.display()
+        );
+        return;
+    }
+
+    let yaml = std::fs::read_to_string(&registry_path)
+        .unwrap_or_else(|e| panic!("failed to read registry at {}: {}", registry_path.display(), e));
+
+    let registry = load_registry(&yaml)
+        .expect("production registry must load");
+
+    // Use an unregistered path to exercise the full scan (worst case: no early match).
+    let path = ".factory/cycles/v1.0-feature-engine-discipline-pass-1/S-99.99/implementation/red-gate-log.md";
+
+    let start = Instant::now();
+    for _ in 0..1000 {
+        let _ = matches_canonical(path, &registry);
+    }
+    let elapsed_ms = start.elapsed().as_millis();
+
+    assert!(
+        elapsed_ms < 200,
+        "BC-4.11.001 EC-007: 1000 matches_canonical calls on production registry \
+         ({} entries) must complete in < 200ms total; got {}ms. \
+         A regression in pattern_matches complexity (e.g., O(n²)) would cause \
+         this to exceed the budget.",
+        registry.artifacts.len(),
+        elapsed_ms
+    );
+}

--- a/crates/hook-plugins/validate-per-story-adversary-convergence/src/lib.rs
+++ b/crates/hook-plugins/validate-per-story-adversary-convergence/src/lib.rs
@@ -670,17 +670,12 @@ mod kani_proofs {
 }
 
 // ---------------------------------------------------------------------------
-// Unit tests (Step 3 — test-writer; all tests use catch_unwind pattern per
-// orchestrator Red Gate requirements: compile OK, fail with behavioral context)
+// Unit tests — production is implemented; tests assert correct behavior directly.
 // ---------------------------------------------------------------------------
 //
-// Pattern: std::panic::catch_unwind calls the production stub (todo!()), then
-// asserts the result is Ok with a behavioral message. Since todo!() always
-// panics, catch_unwind returns Err, so the outer assert!(result.is_ok(), ...)
-// fails with the behavioral message — NOT a raw "not yet implemented" panic.
-//
-// This satisfies BC-8.29.001 RED_RATIO >= 0.5 and the Red Gate assertion-style
-// failure requirement from the S-12.02 dispatch instructions.
+// Pattern (post-Red Gate cleanup, F-HIGH-11): each test calls the production
+// function directly and asserts the expected HookResult. The catch_unwind
+// scaffolding has been removed — it was only needed when production was todo!().
 
 #[cfg(test)]
 mod tests {
@@ -818,18 +813,6 @@ mod tests {
         .to_string()
     }
 
-    /// Non-NITPICK_ONLY classification state (BC-4.10.001 test vector row 4).
-    fn high_classification_json() -> String {
-        json!({
-            "passes_clean": 3,
-            "last_classification": "HIGH",
-            "last_finding_count": 2,
-            "last_timestamp": "2026-05-06T00:00:00Z",
-            "deferred_findings": []
-        })
-        .to_string()
-    }
-
     // -----------------------------------------------------------------------
     // AC-001 traces to BC-4.10.001 PC1: parse_convergence_state reads OQ3
     // schema fields; hook_logic returns Continue when state is cleared.
@@ -845,23 +828,13 @@ mod tests {
         let callbacks =
             FakeCallbacks::new_with_story(Some(cleared_state_json()), vec!["S-A".to_string()]);
 
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            hook_logic(&payload, &callbacks)
-        }));
+        let hook_result = hook_logic(&payload, &callbacks);
 
         assert!(
-            result.is_ok(),
-            "BC-4.10.001 PC1+PC5: hook_logic with a cleared story (passes_clean=3, \
-             last_classification=NITPICK_ONLY) MUST return HookResult::Continue — \
-             production function is not yet implemented (AC-001)"
+            matches!(hook_result, HookResult::Continue),
+            "BC-4.10.001 PC5: cleared story must produce HookResult::Continue, got {:?}",
+            hook_result
         );
-        if let Ok(hook_result) = result {
-            assert!(
-                matches!(hook_result, HookResult::Continue),
-                "BC-4.10.001 PC5: cleared story must produce HookResult::Continue, got {:?}",
-                hook_result
-            );
-        }
     }
 
     // -----------------------------------------------------------------------
@@ -876,17 +849,9 @@ mod tests {
         // last_timestamp, deferred_findings.
         let json = cleared_state_json();
 
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            parse_convergence_state(&json)
-        }));
+        let parse_result = parse_convergence_state(&json);
 
-        assert!(
-            result.is_ok(),
-            "BC-4.10.001 PC1: parse_convergence_state MUST successfully parse a valid \
-             OQ3 schema JSON string with all five fields — production function is \
-             not yet implemented (AC-001)"
-        );
-        if let Ok(parse_result) = result {
+        {
             let state = parse_result.expect("BC-4.10.001 PC1: valid JSON must parse without error");
             assert_eq!(
                 state.passes_clean, 3,
@@ -917,16 +882,9 @@ mod tests {
         // BC-4.10.001 canonical test vector: [S-A] | S-A file absent → BLOCK.
         let state: Option<&ConvergenceState> = None;
 
-        let result =
-            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| hook_result_for(state)));
+        let hook_result = hook_result_for(state);
 
-        assert!(
-            result.is_ok(),
-            "BC-4.10.001 PC2: hook_result_for(None) MUST return \
-             HookResult::block_with_fix with code CONVERGENCE_STATE_MISSING — \
-             production function is not yet implemented (AC-002 branch 1)"
-        );
-        if let Ok(hook_result) = result {
+        {
             match &hook_result {
                 HookResult::Block { reason } => {
                     assert!(
@@ -955,16 +913,9 @@ mod tests {
     fn test_BC_4_10_001_vp071_equiv_missing_state_file_always_blocks() {
         // AC-002 traces to BC-4.10.001 PC2; VP-071 kani harness cargo-test
         // equivalent. hook_result_for(None) must return HookResult::Block.
-        let result =
-            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| hook_result_for(None)));
+        let r = hook_result_for(None);
 
-        assert!(
-            result.is_ok(),
-            "VP-071 proof_missing_state_file_always_blocks (cargo-test equivalent): \
-             hook_result_for(None) must return HookResult::Block (not panic) — \
-             production function is not yet implemented"
-        );
-        if let Ok(r) = result {
+        {
             assert!(
                 matches!(r, HookResult::Block { .. }),
                 "VP-071: missing state file must return HookResult::Block (block_with_fix form), \
@@ -992,17 +943,9 @@ mod tests {
             deferred_findings: vec![],
         };
 
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            hook_result_for(Some(&state))
-        }));
+        let hook_result = hook_result_for(Some(&state));
 
-        assert!(
-            result.is_ok(),
-            "BC-4.10.001 PC3: hook_result_for(state with passes_clean=2) MUST return \
-             HookResult::Block with code CONVERGENCE_PASSES_INSUFFICIENT — \
-             production function is not yet implemented (AC-002 branch 2)"
-        );
-        if let Ok(hook_result) = result {
+        {
             match &hook_result {
                 HookResult::Block { reason } => {
                     assert!(
@@ -1041,15 +984,8 @@ mod tests {
                 last_timestamp: None,
                 deferred_findings: vec![],
             };
-            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                hook_result_for(Some(&state))
-            }));
-            assert!(
-                result.is_ok(),
-                "VP-071 proof_insufficient_passes_always_blocks (passes={passes}): \
-                 hook_result_for must return Block, not panic"
-            );
-            if let Ok(r) = result {
+            let r = hook_result_for(Some(&state));
+            {
                 assert!(
                     matches!(r, HookResult::Block { .. }),
                     "VP-071: passes_clean={passes} < 3 must return HookResult::Block, got {:?}",
@@ -1079,17 +1015,9 @@ mod tests {
             deferred_findings: vec![],
         };
 
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            hook_result_for(Some(&state))
-        }));
+        let hook_result = hook_result_for(Some(&state));
 
-        assert!(
-            result.is_ok(),
-            "BC-4.10.001 PC4: hook_result_for(state with last_classification=HIGH) MUST \
-             return HookResult::Block with code CONVERGENCE_CLASSIFICATION_INSUFFICIENT — \
-             production function is not yet implemented (AC-002 branch 3)"
-        );
-        if let Ok(hook_result) = result {
+        {
             match &hook_result {
                 HookResult::Block { reason } => {
                     assert!(
@@ -1128,22 +1056,14 @@ mod tests {
             last_timestamp: None,
             deferred_findings: vec![],
         };
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            hook_result_for(Some(&state))
-        }));
+        let r = hook_result_for(Some(&state));
+
         assert!(
-            result.is_ok(),
-            "VP-071 proof_non_nitpick_classification_always_blocks: \
-             hook_result_for must return Block, not panic"
+            matches!(r, HookResult::Block { .. }),
+            "VP-071: last_classification=HIGH with passes_clean=3 must return \
+             HookResult::Block, got {:?}",
+            r
         );
-        if let Ok(r) = result {
-            assert!(
-                matches!(r, HookResult::Block { .. }),
-                "VP-071: last_classification=HIGH with passes_clean=3 must return \
-                 HookResult::Block, got {:?}",
-                r
-            );
-        }
     }
 
     // -----------------------------------------------------------------------
@@ -1161,22 +1081,14 @@ mod tests {
             last_timestamp: None,
             deferred_findings: vec![],
         };
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            hook_result_for(Some(&state))
-        }));
+        let r = hook_result_for(Some(&state));
+
         assert!(
-            result.is_ok(),
-            "VP-071 proof_null_classification_blocks (cargo-test equivalent): \
-             hook_result_for with null last_classification must return Block, not panic"
+            matches!(r, HookResult::Block { .. }),
+            "VP-071: None last_classification (JSON null) must return HookResult::Block, \
+             got {:?}",
+            r
         );
-        if let Ok(r) = result {
-            assert!(
-                matches!(r, HookResult::Block { .. }),
-                "VP-071: None last_classification (JSON null) must return HookResult::Block, \
-                 got {:?}",
-                r
-            );
-        }
     }
 
     // -----------------------------------------------------------------------
@@ -1188,14 +1100,9 @@ mod tests {
         // AC-002 traces to BC-4.10.001 PC2+PC8; VP-071 proof E cargo-test equivalent.
         // Missing state file (guaranteed block path). Verifies canonical
         // block_with_fix form: HOOK_NAME in reason, code in reason, non-empty.
-        let result =
-            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| hook_result_for(None)));
-        assert!(
-            result.is_ok(),
-            "VP-071 proof_block_with_fix_fields_populated: hook_result_for(None) must \
-             return Block with populated fields, not panic"
-        );
-        if let Ok(r) = result {
+        let r = hook_result_for(None);
+
+        {
             match r {
                 HookResult::Block { reason } => {
                     assert!(!reason.is_empty(), "VP-071: block reason must not be empty");
@@ -1244,15 +1151,9 @@ mod tests {
                 last_timestamp: None,
                 deferred_findings: vec![],
             };
-            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                hook_result_for(Some(&state))
-            }));
-            assert!(
-                result.is_ok(),
-                "VP-071 proof_converged_story_produces_continue (passes={passes}): \
-                 hook_result_for must return Continue, not panic"
-            );
-            if let Ok(r) = result {
+            let r = hook_result_for(Some(&state));
+
+            {
                 assert!(
                     matches!(r, HookResult::Continue),
                     "VP-071: fully converged story (passes_clean={passes}, NITPICK_ONLY) \
@@ -1278,24 +1179,14 @@ mod tests {
         let callbacks =
             FakeCallbacks::new_with_story(Some(cleared_state_json()), vec!["S-A".to_string()]);
 
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            hook_logic(&payload, &callbacks)
-        }));
+        let hook_result = hook_logic(&payload, &callbacks);
 
         assert!(
-            result.is_ok(),
-            "BC-4.10.002 PC1: hook_logic with no wave-gate context indicator (no agent_type) \
-             MUST return HookResult::Continue (graceful degrade) without blocking — \
-             production function is not yet implemented (AC-003)"
+            matches!(hook_result, HookResult::Continue),
+            "BC-4.10.002 PC1: no wave-gate context must produce HookResult::Continue, \
+             got {:?}",
+            hook_result
         );
-        if let Ok(hook_result) = result {
-            assert!(
-                matches!(hook_result, HookResult::Continue),
-                "BC-4.10.002 PC1: no wave-gate context must produce HookResult::Continue, \
-                 got {:?}",
-                hook_result
-            );
-        }
     }
 
     // -----------------------------------------------------------------------
@@ -1312,24 +1203,14 @@ mod tests {
         let callbacks =
             FakeCallbacks::new_with_story(Some(cleared_state_json()), vec!["S-A".to_string()]);
 
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            hook_logic(&payload, &callbacks)
-        }));
+        let _hook_result = hook_logic(&payload, &callbacks);
 
+        // Verify no I/O occurred (graceful degrade exits before file reads):
         assert!(
-            result.is_ok(),
-            "BC-4.10.002 inv-2: hook_logic must exit before any read_file call when \
-             wave-gate context is absent — production function is not yet implemented \
-             (AC-003 + AC-004)"
+            !callbacks.was_read_called(),
+            "BC-4.10.002 invariant 2: read_file MUST NOT be called before context check \
+             — graceful degrade must exit before any file I/O"
         );
-        // After production is implemented, also verify no I/O occurred:
-        if result.is_ok() {
-            assert!(
-                !callbacks.was_read_called(),
-                "BC-4.10.002 invariant 2: read_file MUST NOT be called before context check \
-                 — graceful degrade must exit before any file I/O"
-            );
-        }
     }
 
     // -----------------------------------------------------------------------
@@ -1345,24 +1226,14 @@ mod tests {
         let payload = make_payload(Some("wave-gate-dispatch")); // wave-gate context present
         let callbacks = FakeCallbacks::new_no_context(); // cycle dir absent
 
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            hook_logic(&payload, &callbacks)
-        }));
+        let hook_result = hook_logic(&payload, &callbacks);
 
         assert!(
-            result.is_ok(),
-            "BC-4.10.002 inv-3: hook_logic with absent cycle directory MUST return \
-             HookResult::Continue (graceful degrade), not block or error — \
-             production function is not yet implemented (AC-004)"
+            matches!(hook_result, HookResult::Continue),
+            "BC-4.10.002 inv-3: absent cycle dir must produce HookResult::Continue, \
+             got {:?}",
+            hook_result
         );
-        if let Ok(hook_result) = result {
-            assert!(
-                matches!(hook_result, HookResult::Continue),
-                "BC-4.10.002 inv-3: absent cycle dir must produce HookResult::Continue, \
-                 got {:?}",
-                hook_result
-            );
-        }
     }
 
     // -----------------------------------------------------------------------
@@ -1379,22 +1250,13 @@ mod tests {
             vec![], // zero stories in wave
         );
 
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            hook_logic(&payload, &callbacks)
-        }));
+        let hook_result = hook_logic(&payload, &callbacks);
 
         assert!(
-            result.is_ok(),
-            "BC-4.10.001 EC-001: hook_logic with zero-story wave MUST return \
-             HookResult::Continue — production function is not yet implemented"
+            matches!(hook_result, HookResult::Continue),
+            "BC-4.10.001 EC-001: empty wave must produce HookResult::Continue, got {:?}",
+            hook_result
         );
-        if let Ok(hook_result) = result {
-            assert!(
-                matches!(hook_result, HookResult::Continue),
-                "BC-4.10.001 EC-001: empty wave must produce HookResult::Continue, got {:?}",
-                hook_result
-            );
-        }
     }
 
     // -----------------------------------------------------------------------
@@ -1413,24 +1275,14 @@ mod tests {
             vec!["S-A".to_string(), "S-B".to_string()],
         );
 
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            hook_logic(&payload, &callbacks)
-        }));
+        let hook_result = hook_logic(&payload, &callbacks);
 
         assert!(
-            result.is_ok(),
-            "BC-4.10.001 PC6: hook_logic with cleared stories having non-empty \
-             deferred_findings MUST return HookResult::Continue (deferred findings \
-             do not block) — production function is not yet implemented (AC-005)"
+            matches!(hook_result, HookResult::Continue),
+            "BC-4.10.001 PC6: converged story with deferred_findings must produce \
+             HookResult::Continue, got {:?}",
+            hook_result
         );
-        if let Ok(hook_result) = result {
-            assert!(
-                matches!(hook_result, HookResult::Continue),
-                "BC-4.10.001 PC6: converged story with deferred_findings must produce \
-                 HookResult::Continue, got {:?}",
-                hook_result
-            );
-        }
     }
 
     // -----------------------------------------------------------------------
@@ -1451,24 +1303,14 @@ mod tests {
             vec!["S-A".to_string(), "S-B".to_string()],
         );
 
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            hook_logic(&payload, &callbacks)
-        }));
+        let hook_result = hook_logic(&payload, &callbacks);
 
         assert!(
-            result.is_ok(),
-            "BC-4.10.001 EC-005: hook_logic with multiple failing stories MUST block \
-             on the FIRST failure and return immediately (not enumerate all failures) — \
-             production function is not yet implemented (AC-006)"
+            matches!(hook_result, HookResult::Block { .. }),
+            "BC-4.10.001 EC-005: multiple failing stories must produce HookResult::Block \
+             (on first failure), got {:?}",
+            hook_result
         );
-        if let Ok(hook_result) = result {
-            assert!(
-                matches!(hook_result, HookResult::Block { .. }),
-                "BC-4.10.001 EC-005: multiple failing stories must produce HookResult::Block \
-                 (on first failure), got {:?}",
-                hook_result
-            );
-        }
     }
 
     // -----------------------------------------------------------------------
@@ -1488,17 +1330,9 @@ mod tests {
             vec!["S-A".to_string()],
         );
 
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            hook_logic(&payload, &callbacks)
-        }));
+        let hook_result = hook_logic(&payload, &callbacks);
 
-        assert!(
-            result.is_ok(),
-            "BC-4.10.001 EC-002: hook_logic with malformed JSON state file MUST return \
-             HookResult::Block with code CONVERGENCE_STATE_MALFORMED (not panic) — \
-             production function is not yet implemented (AC-007)"
-        );
-        if let Ok(hook_result) = result {
+        {
             match &hook_result {
                 HookResult::Block { reason } => {
                     assert!(
@@ -1520,21 +1354,12 @@ mod tests {
     fn test_BC_4_10_001_parse_convergence_state_malformed_json_returns_err() {
         // AC-007 traces to BC-4.10.001 EC-002: parse_convergence_state MUST return
         // Err(ParseError) when given malformed JSON, not panic.
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            parse_convergence_state("{ this is not json ")
-        }));
+        let parse_result = parse_convergence_state("{ this is not json ");
 
         assert!(
-            result.is_ok(),
-            "BC-4.10.001 EC-002: parse_convergence_state with malformed JSON MUST return \
-             Err(ParseError) without panicking — production function not yet implemented"
+            parse_result.is_err(),
+            "BC-4.10.001 EC-002: malformed JSON must return Err(ParseError), got Ok"
         );
-        if let Ok(parse_result) = result {
-            assert!(
-                parse_result.is_err(),
-                "BC-4.10.001 EC-002: malformed JSON must return Err(ParseError), got Ok"
-            );
-        }
     }
 
     // -----------------------------------------------------------------------
@@ -1565,17 +1390,9 @@ mod tests {
             vec!["S-A".to_string()],
         );
 
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            hook_logic(&payload, &callbacks)
-        }));
+        let hook_result = hook_logic(&payload, &callbacks);
 
-        assert!(
-            result.is_ok(),
-            "BC-4.10.001 EC-003: hook_logic with missing last_classification field MUST \
-             return HookResult::Block with code CONVERGENCE_STATE_SCHEMA_INVALID — \
-             production function is not yet implemented (AC-008)"
-        );
-        if let Ok(hook_result) = result {
+        {
             match &hook_result {
                 HookResult::Block { reason } => {
                     // The block code should be either SCHEMA_INVALID (EC-003: field absent)
@@ -1622,24 +1439,14 @@ mod tests {
             ],
         };
 
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            hook_result_for(Some(&state))
-        }));
+        let hook_result = hook_result_for(Some(&state));
 
         assert!(
-            result.is_ok(),
-            "BC-4.10.001 EC-004: hook_result_for with converged state + non-empty \
-             deferred_findings MUST return HookResult::Continue (deferred findings \
-             do not block) — production function is not yet implemented (AC-009)"
+            matches!(hook_result, HookResult::Continue),
+            "BC-4.10.001 EC-004: passes_clean=3, NITPICK_ONLY, non-empty deferred_findings \
+             must produce HookResult::Continue, got {:?}",
+            hook_result
         );
-        if let Ok(hook_result) = result {
-            assert!(
-                matches!(hook_result, HookResult::Continue),
-                "BC-4.10.001 EC-004: passes_clean=3, NITPICK_ONLY, non-empty deferred_findings \
-                 must produce HookResult::Continue, got {:?}",
-                hook_result
-            );
-        }
     }
 
     // -----------------------------------------------------------------------
@@ -1661,16 +1468,8 @@ mod tests {
 
         // The fact that this compiles and runs natively (not under WASM) proves
         // the injectable-callback pattern is correctly implemented.
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            hook_logic(&payload, &callbacks)
-        }));
-
-        assert!(
-            result.is_ok(),
-            "BC-4.10.001 inv-3: hook_logic MUST be exercisable without a WASM runtime \
-             via the injectable-callback pattern — production function not yet \
-             implemented (AC-010)"
-        );
+        let _result = hook_logic(&payload, &callbacks);
+        // If the above call compiles and runs without a WASM runtime, the pattern is verified.
     }
 
     // -----------------------------------------------------------------------
@@ -1762,24 +1561,14 @@ mod tests {
         let callbacks =
             FakeCallbacks::new_with_story(Some(cleared_state_json()), vec!["S-A".to_string()]);
 
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            hook_logic(&payload, &callbacks)
-        }));
+        let hook_result = hook_logic(&payload, &callbacks);
 
         assert!(
-            result.is_ok(),
-            "BC-4.10.002 EC-001: hook_logic fired on per-story SubagentStop (agent_type=implementer) \
-             MUST return HookResult::Continue (graceful degrade) — \
-             production function is not yet implemented"
+            matches!(hook_result, HookResult::Continue),
+            "BC-4.10.002 EC-001: per-story SubagentStop must produce HookResult::Continue, \
+             got {:?}",
+            hook_result
         );
-        if let Ok(hook_result) = result {
-            assert!(
-                matches!(hook_result, HookResult::Continue),
-                "BC-4.10.002 EC-001: per-story SubagentStop must produce HookResult::Continue, \
-                 got {:?}",
-                hook_result
-            );
-        }
     }
 
     // -----------------------------------------------------------------------
@@ -1794,23 +1583,14 @@ mod tests {
         let callbacks =
             FakeCallbacks::new_with_story(Some(cleared_state_json()), vec!["S-A".to_string()]);
 
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            hook_logic(&payload, &callbacks)
-        }));
+        let hook_result = hook_logic(&payload, &callbacks);
 
         assert!(
-            result.is_ok(),
-            "BC-4.10.002 EC-004: hook_logic with missing agent fields MUST return \
-             HookResult::Continue (graceful degrade) — production function not yet implemented"
+            matches!(hook_result, HookResult::Continue),
+            "BC-4.10.002 EC-004: missing agent fields must produce HookResult::Continue, \
+             got {:?}",
+            hook_result
         );
-        if let Ok(hook_result) = result {
-            assert!(
-                matches!(hook_result, HookResult::Continue),
-                "BC-4.10.002 EC-004: missing agent fields must produce HookResult::Continue, \
-                 got {:?}",
-                hook_result
-            );
-        }
     }
 
     // -----------------------------------------------------------------------
@@ -1824,18 +1604,14 @@ mod tests {
         // Inversely: the function signals "not wave-gate" → hook degrades.
         let payload = make_payload(None);
 
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            graceful_degrade_outside_wave_gate(&payload)
-        }));
+        let should_degrade = graceful_degrade_outside_wave_gate(&payload);
 
+        // For a no-context payload (no agent_type), the function must signal degrade.
         assert!(
-            result.is_ok(),
+            should_degrade,
             "BC-4.10.002 PC1: graceful_degrade_outside_wave_gate with no wave-gate \
-             indicator MUST return without panicking — production function not yet \
-             implemented (AC-003)"
+             indicator MUST return true (degrade) for no-context payload (AC-003)"
         );
-        // When implemented: must signal degrade (true = should degrade) for no-context payload.
-        // The exact bool semantics depend on implementation, but the function must not panic.
     }
 
     // -----------------------------------------------------------------------
@@ -1855,23 +1631,14 @@ mod tests {
             deferred_findings: vec![],
         };
 
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            hook_result_for(Some(&state))
-        }));
+        let r = hook_result_for(Some(&state));
 
         assert!(
-            result.is_ok(),
-            "BC-4.10.001 boundary: hook_result_for with passes_clean=3 (exact threshold) \
-             MUST return HookResult::Continue — production function not yet implemented"
+            matches!(r, HookResult::Continue),
+            "BC-4.10.001 boundary: passes_clean=3 (exact threshold) must produce \
+             HookResult::Continue, got {:?}",
+            r
         );
-        if let Ok(r) = result {
-            assert!(
-                matches!(r, HookResult::Continue),
-                "BC-4.10.001 boundary: passes_clean=3 (exact threshold) must produce \
-                 HookResult::Continue, got {:?}",
-                r
-            );
-        }
     }
 
     // -----------------------------------------------------------------------
@@ -1920,22 +1687,13 @@ mod tests {
             deferred_findings: vec![],
         };
 
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            hook_result_for(Some(&state))
-        }));
+        let r = hook_result_for(Some(&state));
 
         assert!(
-            result.is_ok(),
-            "BC-4.10.001 boundary: hook_result_for with passes_clean=2 MUST return \
-             HookResult::Block — production function not yet implemented"
+            matches!(r, HookResult::Block { .. }),
+            "BC-4.10.001 boundary: passes_clean=2 must produce HookResult::Block, \
+             got {:?}",
+            r
         );
-        if let Ok(r) = result {
-            assert!(
-                matches!(r, HookResult::Block { .. }),
-                "BC-4.10.001 boundary: passes_clean=2 must produce HookResult::Block, \
-                 got {:?}",
-                r
-            );
-        }
     }
 }

--- a/plugins/vsdd-factory/tests/per-story-adversary-convergence-hook.bats
+++ b/plugins/vsdd-factory/tests/per-story-adversary-convergence-hook.bats
@@ -149,20 +149,44 @@ teardown() {
 # AC-002 traces to BC-4.10.001 PC8: canonical block_with_fix format
 #
 # Structural: source must use block_with_fix (canonical Why/Fix/Code form per
-# HOST_ABI.md §WASM hooks). Registry must set on_error = "continue" (advisory-block mode).
+# HOST_ABI.md §WASM hooks).
 # Behavioral correctness: test_BC_4_10_001_vp071_equiv_block_with_fix_fields_populated
+#
+# Note: this test was previously merged with the on_error=continue registry check
+# (F-HIGH-2 fix). The two assertions are orthogonal:
+#   - block_with_fix governs the BLOCK MESSAGE FORMAT (BC-4.10.001 PC8).
+#   - on_error governs what happens when the HOOK ITSELF CRASHES (BC-4.10.002).
+# Separating them prevents false failures if the operator policy on on_error changes.
 # ---------------------------------------------------------------------------
 
-@test "structural: source uses block_with_fix and registry sets on_error=continue (AC-002, BC-4.10.001 PC8)" {
-    # Production code must call block_with_fix (canonical HOST_ABI block pattern)
+@test "structural: source uses block_with_fix canonical Why/Fix/Code form (AC-002, BC-4.10.001 PC8)" {
+    # Production code must call block_with_fix (canonical HOST_ABI block pattern).
+    # This verifies BC-4.10.001 PC8: the block reason string must embed hook name,
+    # reason, fix recommendation, and block code in canonical Why/Fix/Code format.
     grep -q 'block_with_fix(' "$LIB_RS" || {
         echo "BC-4.10.001 PC8: src/lib.rs must use HookResult::block_with_fix canonical form"
         return 1
     }
-    # Registry must declare on_error = "continue" (advisory-block mode)
+}
+
+# ---------------------------------------------------------------------------
+# Operator policy: on_error = "continue" in hooks-registry.toml
+#
+# This is a separate operational decision from block_with_fix format (F-HIGH-2 fix).
+# on_error = "continue" means a hook CRASH does not block the tool call.
+# This aligns with BC-4.10.002: graceful degrade on hook failure.
+# Rationale: the hook is a monitoring/enforcement gate, not a build gate.
+# A hook crash (OOM, WASM trap) should not halt developer workflow.
+# ---------------------------------------------------------------------------
+
+@test "structural: registry sets on_error=continue for hook crash policy (BC-4.10.002 graceful degrade)" {
+    # on_error = "continue" is the hook-crash policy (separate from block_with_fix format).
+    # BC-4.10.002: if the hook itself crashes, the dispatcher continues (graceful degrade).
+    # This is NOT related to advisory-block mode (retired per D-349/OQ-9).
     grep -A 20 'name = "validate-per-story-adversary-convergence"' "$REGISTRY" |
         grep -q 'on_error = "continue"' || {
-        echo 'BC-4.10.001 PC8: hooks-registry.toml must set on_error = "continue" for this hook'
+        echo 'BC-4.10.002: hooks-registry.toml must set on_error = "continue" for hook-crash policy'
+        echo 'Note: this is the hook CRASH policy, not the block signal format.'
         return 1
     }
 }

--- a/plugins/vsdd-factory/tests/relocate-artifact.bats
+++ b/plugins/vsdd-factory/tests/relocate-artifact.bats
@@ -256,3 +256,81 @@ EOF
   grep -q "document_type field absent" "$SKILL_FILE"
   grep -q "EC-002" "$SKILL_FILE"
 }
+
+# ============================================================================
+# BC-6.22.001 invariant 4: git mv history preservation (F-HIGH-7)
+#
+# The skill mandates "git mv is the ONLY mechanism for moving files. Direct
+# file copy + delete is PROHIBITED because it breaks `git log --follow`."
+#
+# This test verifies that a `git mv`-based relocation preserves the rename
+# chain in git history so that `git log --follow <new_path>` reports the
+# original commit. A copy+delete would break this and yield an empty log.
+#
+# The test simulates the invariant at the git level: after a `git mv`, git
+# log --follow on the new path must show the commit that created the file.
+# ============================================================================
+
+@test "BC-6.22.001 invariant 4: SKILL.md documents git mv as only move mechanism" {
+  # BC-6.22.001 invariant 4: skill must document that git mv is required and
+  # that direct file copy + delete is PROHIBITED (to preserve git log --follow).
+  # Verified structurally: SKILL.md must contain both the git mv mandate and
+  # the PROHIBITED keyword so that any agent following the skill cannot miss it.
+  grep -q "git mv" "$SKILL_FILE"
+  grep -q "PROHIBITED" "$SKILL_FILE"
+}
+
+@test "BC-6.22.001 invariant 4: git mv preserves git log --follow history (git semantics)" {
+  # BC-6.22.001 invariant 4: git mv (rename) must produce a rename entry in git
+  # history so that `git log --follow <new_path>` shows the original commit.
+  # A copy+delete would yield an add+delete pair, breaking --follow.
+  #
+  # This test verifies the git property that the skill MUST use.
+  # If this git-level property holds, then a correct implementation of the skill
+  # (using git mv) will pass. An incorrect implementation (cp + rm) would NOT
+  # show the original commit in git log --follow output.
+
+  local old_path="$WORK/.factory/WRONG-LOCATION/BC-4.11.001.md"
+  local new_dir="$WORK/.factory/specs/behavioral-contracts/ss-04"
+  local new_path="$new_dir/BC-4.11.001.md"
+
+  # Create a file and commit it at the old location
+  mkdir -p "$WORK/.factory/WRONG-LOCATION"
+  cat > "$old_path" << 'EOF'
+---
+document_type: behavioral-contract
+bc_id: BC-4.11.001
+---
+# Test BC for git mv history verification
+EOF
+  git -C "$WORK" add "$old_path"
+  git -C "$WORK" commit --quiet -m "add BC at wrong location (pre-move)"
+
+  local original_sha
+  original_sha=$(git -C "$WORK" log --oneline --follow "$old_path" | head -1 | awk '{print $1}')
+
+  # Perform git mv (the ONLY mechanism permitted by BC-6.22.001 invariant 4)
+  mkdir -p "$new_dir"
+  git -C "$WORK" mv "$old_path" "$new_path"
+  git -C "$WORK" commit --quiet -m "relocate BC to canonical path (git mv)"
+
+  # `git log --follow <new_path>` must show the original commit
+  local follow_log
+  follow_log=$(git -C "$WORK" log --oneline --follow "$new_path")
+
+  # The log must contain the original commit SHA
+  echo "$follow_log" | grep -q "$original_sha" || {
+    echo "BC-6.22.001 invariant 4: git log --follow must show original commit after git mv"
+    echo "Original SHA: $original_sha"
+    echo "git log --follow output:"
+    echo "$follow_log"
+    echo "A copy+delete would break --follow; only git mv preserves rename history."
+    return 1
+  }
+
+  # The old path must no longer exist (confirming the move, not a copy)
+  [ ! -f "$old_path" ] || {
+    echo "BC-6.22.001 invariant 4: old path must not exist after git mv"
+    return 1
+  }
+}

--- a/plugins/vsdd-factory/tests/vp-072-sot-invariant.bats
+++ b/plugins/vsdd-factory/tests/vp-072-sot-invariant.bats
@@ -258,3 +258,82 @@ setup() {
   # it reads the registry at runtime.
   grep -q "artifact-path-registry.yaml" "$SKILLS_DIR/relocate-artifact/SKILL.md"
 }
+
+# ============================================================================
+# F-MED-3: Programmatic enumeration — all create-* / scaffold-* / register-*
+# skills must reference artifact-path-registry.yaml (VP-072 / BC-4.11.001 PC8)
+#
+# The named-skill tests above only catch skills known at S-13.01 implementation
+# time. This enumeration test catches NEW creation skills added in future cycles
+# that forget the registry-read preamble. F1 OQ-4 flagged this gap explicitly.
+#
+# Exemptions: skills that provably write ONLY outside .factory/ (e.g., to
+# .claude/, crates/, plugins/) are exempt because their writes are not governed
+# by the artifact-path registry. Exemptions are listed explicitly in the
+# EXEMPT_SKILLS array below so the omission is intentional and reviewable,
+# not accidental.
+# ============================================================================
+
+@test "VP-072 F-MED-3: all create-* / scaffold-* / register-* skills reference artifact-path-registry.yaml (or are explicitly exempted)" {
+  # VP-072 / BC-4.11.001 PC8: every creation skill must read the artifact-path
+  # registry before writing to .factory/. This test enumerates the skill directory
+  # programmatically so that future cycles adding new create-* skills are caught
+  # automatically — without requiring a manual addition to the named-skill list above.
+  #
+  # Exemptions: skills that only write to non-.factory/ targets.
+  # scaffold-claude-md: writes .claude/CLAUDE.md (not a .factory/ artifact).
+  local -a EXEMPT_SKILLS=("scaffold-claude-md")
+
+  local violations=0
+  local checked=0
+
+  while IFS= read -r -d '' skill_dir; do
+    local skill_name
+    skill_name=$(basename "$skill_dir")
+    local skill_file="$skill_dir/SKILL.md"
+
+    # Skip if SKILL.md doesn't exist yet (pre-implementation stubs)
+    [ -f "$skill_file" ] || continue
+
+    # Check if this skill is in the exemption list
+    local exempt=0
+    for ex in "${EXEMPT_SKILLS[@]}"; do
+      if [ "$skill_name" = "$ex" ]; then
+        exempt=1
+        break
+      fi
+    done
+    [ "$exempt" -eq 1 ] && continue
+
+    # Check for registry reference
+    checked=$((checked + 1))
+    if ! grep -q "artifact-path-registry.yaml" "$skill_file"; then
+      echo "VIOLATION: $skill_name/SKILL.md does not reference artifact-path-registry.yaml"
+      echo "  VP-072 / BC-4.11.001 PC8: creation skills must read the registry before writing"
+      echo "  to .factory/. Add a registry-read preamble or add to EXEMPT_SKILLS if this"
+      echo "  skill only writes outside .factory/."
+      violations=$((violations + 1))
+    fi
+  done < <(find "$SKILLS_DIR" -maxdepth 1 -type d \( \
+    -name "create-*" -o \
+    -name "scaffold-*" -o \
+    -name "register-*" \
+  \) -print0 2>/dev/null | sort -z)
+
+  if [ "$violations" -gt 0 ]; then
+    echo ""
+    echo "Total violations: $violations (checked $checked skills, ${#EXEMPT_SKILLS[@]} exempted)"
+    return 1
+  fi
+
+  # Sanity check: we must have checked at least the 8 known create-*/scaffold-*/register-*
+  # skills (create-adr, create-architecture, create-brief, create-domain-spec,
+  # create-excalidraw, create-prd, create-story, register-artifact).
+  # Note: conform-to-template is also a creation skill but doesn't match the name
+  # patterns above — it is covered by the named test at line 130.
+  [ "$checked" -ge 8 ] || {
+    echo "SANITY FAIL: only checked $checked skills; expected >= 8 create-*/scaffold-*/register-* skills"
+    echo "Skills dir: $SKILLS_DIR"
+    return 1
+  }
+}


### PR DESCRIPTION
F5 pass-1 fix burst, batch B4.

## Findings closed
- F-HIGH-11: 30+ catch_unwind test wrappers removed (production no longer todo!()); orphaned helper deleted.
- F-HIGH-2: bats test split (block_with_fix format vs on_error policy); D-349/OQ-9 advisory-block wording removed.
- F-HIGH-7: 2 new bats tests for git mv invariant in relocate-artifact.
- F-MED-3: vp-072 now programmatically enumerates create-/scaffold-/register- skills with explicit exemption list.
- F-MED-5: New cargo perf test enforces BC-4.11.001 EC-007 ≤200ms ceiling for 1000 matches_canonical calls.

5 commits: bcce4cd → c87fd27. Test count 1055→1056. No production code touched (all changes in #[cfg(test)] modules + bats files).

Cycle: v1.0-feature-engine-discipline-pass-1 F5 pass-1.