### PR TITLE
fix(test): regression-v1.0 test 7 accepts trace_id OR dispatcher_trace_id (TD #66)

### DIFF
--- a/plugins/vsdd-factory/tests/regression-v1.0.bats
+++ b/plugins/vsdd-factory/tests/regression-v1.0.bats
@@ -111,7 +111,11 @@ setup() {
   log="$(ls "$WORK/.factory/logs/dispatcher-internal-"*.jsonl 2>/dev/null | head -1)"
   [ -n "$log" ]
   total="$(wc -l < "$log")"
-  with_trace="$(grep -c '"dispatcher_trace_id":"' "$log" || true)"
+  # S-15.01 (T-3a) renamed the per-event field from `dispatcher_trace_id` to
+  # `trace_id` (canonical naming aligned with OTel-style tracing conventions).
+  # Accept either name so this test is robust across the rename — the
+  # specific canonicalization is tracked under TD #66 and S-15.02.
+  with_trace="$(grep -cE '"(dispatcher_)?trace_id":"' "$log" || true)"
   with_session="$(grep -c '"session_id":"trace-test"' "$log" || true)"
   [ "$total" -gt 0 ]
   [ "$with_trace" -eq "$total" ]


### PR DESCRIPTION
## Summary

Quick TD #66 fix to unblock the v1.0.0-rc.14 Release workflow `validate` job: `regression-v1.0` test 7 was hard-coded to grep for `dispatcher_trace_id`, but S-15.01 (T-3a, commit `9c0acebe`) renamed that per-event log field to `trace_id` to align with OTel-style tracing conventions. The bats assertion was never updated, so the test now panics with `[ "$with_trace" -eq "$total" ]` failing once the dispatcher binary is present.

The test was previously masked: release.yml's `validate` job doesn't `cargo build` before running bats, so `[ ! -x "$DISPATCHER" ]` triggered `skip "preflight artifacts missing"`. PR #112 fixed `perf-baseline.bats`'s `setup_file()` path resolution — that setup_file builds the dispatcher mid-suite when missing, which now leaves the binary on disk by the time `regression-v1.0.bats` runs. Test 7 actually executes and fails.

## Root cause

S-15.01 renamed:
```rust
// Before (pre-S-15.01)
"dispatcher_trace_id": "..."

// After (S-15.01 T-3a)
"trace_id": "..."
```

Test 7 in `tests/regression-v1.0.bats:114` grepped for the legacy name verbatim:
```bash
with_trace="$(grep -c '"dispatcher_trace_id":"' "$log" || true)"
[ "$with_trace" -eq "$total" ]   # always 0 in dispatcher output now
```

Since the dispatcher emits `trace_id` consistently and `with_trace=0 != total>0`, test 7 panics on every invocation where the binary actually runs.

## Fix

Relax the grep to accept either field name (backward-compatible):
```bash
# After
with_trace="$(grep -cE '"(dispatcher_)?trace_id":"' "$log" || true)"
```

This unblocks rc.14 immediately. The canonical name decision (rename test → `trace_id` only, OR add a `dispatcher_trace_id` serde alias on the dispatcher side) is tracked under TD #66 and S-15.02.

## Architecture Changes

None — test-only change.

## Story Dependencies

```mermaid
graph LR
    PR112["PR #112\nrelease-CI unblock"] --> PR113["PR #113\nthis fix"]
    PR113 --> RETAG["Re-tag v1.0.0-rc.14"]
    RETAG --> MARKETPLACE["bump-marketplace\nclaude-mp PR opens"]
    S15_01["S-15.01 T-3a\ndispatcher_trace_id → trace_id"] -.regression.-> PR113
```

## Spec Traceability

```mermaid
flowchart LR
    TD66["TD #66\nfield-name canonicalization"] --> AC1["AC: regression-v1.0 test 7\npasses on dispatcher output"]
    AC1 --> T1["regression-v1.0.bats:114\ngrep -E '(dispatcher_)?trace_id'"]
```

## Tests

- `bats tests/regression-v1.0.bats` — 9/9 pass locally (was 8 ok + 1 fail)
- PR's `validate` ci.yml job ✅ confirmed (cycle 1)
- PR's `cargo-host` (×2) ✅ confirmed
- 4/5 build-dispatcher matrix ✅; darwin-x64 still building (~50min historically)

## Security Review

N/A — single-line test assertion relaxation. No production code path touched.

## Risk Assessment

- **Blast radius:** test-only change. No production behavior modified.
- **Affected behavior:** `regression-v1.0` test 7 now correctly validates that EVERY internal-log event carries a trace identifier (under either name). The semantic invariant is preserved.
- **Performance impact:** None.
- **Regression risk:** Minimal. Worst case: the dispatcher temporarily emits BOTH names during a future serde-alias rollout — `grep -c` would over-count, but the comparison is `>= total` not `== total`, so it stays robust.
  
  Wait — the assertion IS `with_trace == total`. If the dispatcher were to emit both names on the same line, grep -c would still report `1` per line (single match per pattern alternation). Still robust.

## Affected behavior

Operators running release.yml or ci.yml's bats suite: test 7 now passes instead of blocking the entire suite. No runtime hook behavior changes.

## Demo Evidence

N/A — test-only fix. Local run output:
```
1..9
ok 1 regression-v1.0: dispatcher binary exists (cargo build --workspace --release)
...
ok 7 regression-v1.0: every internal-log event has dispatcher_trace_id and session_id
ok 8 regression-v1.0: legacy adapter exits 0 (Continue) for a matched bash hook that exited 0
ok 9 regression-v1.0: bash-side events land in events-*.jsonl when routed through the adapter
```

## AI Pipeline Metadata

- Pipeline mode: fix-pr (release-blocker)
- Autonomy level: 4 (auto-merge if CI passes)
- No AI attribution per project policy.

## Refs

- TD #66 — `dispatcher_trace_id` / `trace_id` field-name canonicalization
- S-15.01 T-3a (commit `9c0acebe`, 2026-05-07) — original rename
- PR #112 — release-CI unblock that exposed this latent regression
- v1.0.0-rc.14 release run (failed): https://github.com/drbothen/vsdd-factory/actions/runs/25611757167

## Pre-Merge Checklist

- [x] PR created with structured description
- [x] Local bats verification: 9/9 regression-v1.0 tests pass
- [x] Validate job ✅ on PR ci.yml
- [x] cargo-host (ubuntu + macos) ✅
- [ ] All build-dispatcher matrix jobs ✅ (4/5 done at time of writing)
- [ ] Squash merge → re-tag v1.0.0-rc.14 (force-move) → release.yml flows through bump-marketplace

## Follow-up

Once rc.14 marketplace publish completes:
- Mark TD #66 resolved (or upgrade to a proper rename in a future S-15.02 cycle)
- Marketplace.json now reads `1.0.0-rc.14` (operators jump rc.10 → rc.14)