### PR TITLE
release: v1.0.0-rc.16 — RELEASING.md procedural infrastructure + TD #69 guardrail

### DIFF
--- a/.github/workflows/release-branch-guardrail.yml
+++ b/.github/workflows/release-branch-guardrail.yml
@@ -1,0 +1,65 @@
+name: release-branch-guardrail
+
+# Enforce the canonical rc.X release-branch convention: branches matching
+# `release/*` MUST target `main`, never `develop`.
+#
+# History: PR #111 (rc.13 release-prep) accidentally targeted `develop`
+# instead of `main`. That single PR broke the develop → main sync chain
+# that was working through rc.11. Source-file drift accumulated for 3
+# release cycles (92 files, 3954 ins / 880 del) until rc.14 shipped a
+# marketplace tarball with `hooks-registry.toml schema_version = 1`
+# against a dispatcher binary built from develop expecting `schema_version
+# = 2` — every operator on `/plugin update vsdd-factory@claude-mp` hit
+# `E-REG-001` fail-closed on every tool call until manually patching the
+# cache. PR #115 (rc.15) restored the convention by backfilling main with
+# the missing develop content.
+#
+# This workflow makes that drift impossible to re-introduce: any PR with
+# a `release/*` head branch that targets anything other than `main` fails
+# the gate and cannot be merged.
+#
+# See CHANGELOG.md `1.0.0-rc.15` and TD #69.
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  enforce-release-branch-target:
+    name: Reject release/* PRs not targeting main
+    runs-on: ubuntu-latest
+    if: startsWith(github.head_ref, 'release/')
+    steps:
+      - name: Reject when base_ref != main
+        if: github.base_ref != 'main'
+        run: |
+          echo "::error title=Release branch must target main::"\
+"PR head '${{ github.head_ref }}' targets '${{ github.base_ref }}', "\
+"but release/* branches MUST target 'main'. Re-target this PR to main "\
+"or rename the branch if it isn't actually a release-prep PR."
+          echo ""
+          echo "Why this matters:"
+          echo "  release/v1.0.0-rc.X → main is the canonical sync point that"
+          echo "  brings develop's source content onto main. PRs landed on"
+          echo "  develop instead leave main behind, and release.yml's"
+          echo "  commit-binaries job (which checks out main) ships the"
+          echo "  marketplace tarball with stale source against fresh binaries."
+          echo ""
+          echo "  This is exactly what produced the rc.14 marketplace E-REG-001"
+          echo "  fail-closed bug. See CHANGELOG.md v1.0.0-rc.15 + TD #69 for the"
+          echo "  full root-cause writeup."
+          echo ""
+          echo "Canonical release procedure: RELEASING.md (project root)."
+          echo "  https://github.com/drbothen/vsdd-factory/blob/main/RELEASING.md"
+          echo ""
+          echo "Fix: re-target this PR to main:"
+          echo "  gh pr edit ${{ github.event.pull_request.number }} --base main"
+          exit 1
+
+      - name: Acknowledge correct target
+        if: github.base_ref == 'main'
+        run: |
+          echo "::notice::release/* branch correctly targets main. ✓"

--- a/.github/workflows/release-branch-guardrail.yml
+++ b/.github/workflows/release-branch-guardrail.yml
@@ -35,11 +35,18 @@ jobs:
     steps:
       - name: Reject when base_ref != main
         if: github.base_ref != 'main'
+        # github.head_ref / base_ref / pull_request.number come from PR
+        # metadata, which Semgrep's run-shell-injection rule treats as
+        # untrusted (e.g., a branch name containing backticks could
+        # inject). Channel them through env: so the shell sees plain
+        # variables, not template-interpolated text. Quote every
+        # expansion ("$VAR") to neutralize any embedded whitespace.
+        env:
+          PR_HEAD: ${{ github.head_ref }}
+          PR_BASE: ${{ github.base_ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          echo "::error title=Release branch must target main::"\
-"PR head '${{ github.head_ref }}' targets '${{ github.base_ref }}', "\
-"but release/* branches MUST target 'main'. Re-target this PR to main "\
-"or rename the branch if it isn't actually a release-prep PR."
+          echo "::error title=Release branch must target main::PR head '${PR_HEAD}' targets '${PR_BASE}' but release/* branches MUST target 'main'. Re-target to main or rename the branch."
           echo ""
           echo "Why this matters:"
           echo "  release/v1.0.0-rc.X → main is the canonical sync point that"
@@ -56,7 +63,7 @@ jobs:
           echo "  https://github.com/drbothen/vsdd-factory/blob/main/RELEASING.md"
           echo ""
           echo "Fix: re-target this PR to main:"
-          echo "  gh pr edit ${{ github.event.pull_request.number }} --base main"
+          echo "  gh pr edit ${PR_NUMBER} --base main"
           exit 1
 
       - name: Acknowledge correct target

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,88 @@
 
 ## Unreleased
 
+## 1.0.0-rc.16 — RELEASING.md procedural infrastructure + TD #69 guardrail (2026-05-10)
+
+The headline of rc.16 is procedural infrastructure: it ships
+`RELEASING.md` (the canonical release procedure that will govern every
+future rc.X release), a CI guardrail enforcing the
+`release/v1.0.0-rc.X → main` branch convention, and a release-skill
+update that defers to RELEASING.md (and prompts the human to create
+one when missing). This release is the first to be cut by following
+RELEASING.md step-by-step — dogfooding the very procedure it ships.
+
+Combined with rc.15's source-sync fix, rc.16 closes both halves of
+the "rc.14 marketplace E-REG-001" root cause: rc.15 fixed the content
+drift, rc.16 fixes the procedural drift that allowed the content
+drift to accumulate.
+
+### Added
+
+- **`RELEASING.md`** (project root, ~250 lines) — single source of
+  truth for the release procedure. Captures the two-branch model
+  rationale, mandatory invariants table (8 invariants with violation
+  consequences), step-by-step procedure (Step 0 preflight → Step 9
+  operator install verification), recovery procedures for 5 known
+  failure modes, what-gets-automated breakdown, and explicit rules
+  for AI agents executing a release.
+
+- **`.github/workflows/release-branch-guardrail.yml`** — PR-trigger
+  GitHub Actions workflow that fails any PR with a `release/*` head
+  branch targeting anything other than `main`. Runs on every PR
+  event; skips when head doesn't match `release/*`. Failure
+  annotation includes a one-line `gh pr edit` fix command and links
+  to RELEASING.md.
+
+- **`CLAUDE.md`** (project root) — minimal project conventions
+  auto-loaded by Claude Code at session start. References
+  RELEASING.md, the branching model, commit-message rules, testing
+  commands, and the self-referential nature of this repo (engine
+  and product are the same).
+
+### Changed
+
+- **`plugins/vsdd-factory/skills/release/SKILL.md`** — the release
+  skill now reads `RELEASING.md` first when present and uses it as
+  authoritative. If `RELEASING.md` is missing, the skill prompts the
+  human to either (1) create one before cutting the release
+  (recommended), or (2) proceed with the generic config-driven flow.
+  Generic fallback preserved for projects that explicitly opt in.
+
+### Fixed
+
+- **`release-branch-guardrail.yml` YAML parse error** (PR #117): the
+  initial workflow used bash backslash line continuations inside
+  YAML's literal block scalar, which broke YAML parsing. Every push
+  to develop produced a misleading "failed" run with empty job list.
+  Fixed by collapsing the multi-line bash echo to one line.
+
+- **`release-branch-guardrail.yml` shell-injection hardening**
+  (PR #117): Semgrep flagged direct `${{ github.head_ref }}` /
+  `${{ github.base_ref }}` interpolations inside the `run:` block as
+  a run-shell-injection risk. Channeled through `env:` per the
+  standard GitHub Actions security pattern; no behavior change.
+
+### Operational
+
+- This release is the **live exercise** of the new RELEASING.md
+  procedure. The release branch (`release/v1.0.0-rc.16`) was created
+  from develop, the PR targets `main` (enforced by the guardrail
+  itself, which fires on this very PR), and the merge will use
+  `--merge` (not `--squash`) to preserve develop's commits as
+  ancestors of main.
+
+- Future release branches must follow RELEASING.md or fail the
+  guardrail's check. Operators no longer need to remember the
+  convention from session memory.
+
+### Deferred
+
+- TD #66 — `trace_id` / `dispatcher_trace_id` field-name canonicalization.
+- TD #67 — 4 timing-flaky e2e tests in `full_stack_plugin_invocation.rs`.
+- TD #68 — sync-develop binary auto-resolve (already fixed but watch
+  for any edge cases on the next release where develop has merged
+  new WASM source files since rc.16).
+
 ## 1.0.0-rc.15 — Marketplace source-sync fix (main backfill) (2026-05-10)
 
 The headline of rc.15 is operational: it restores the rc.X release-branch

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,65 @@
+# CLAUDE.md — vsdd-factory project conventions
+
+This file is auto-loaded by Claude Code at session start. It pins
+project-specific conventions that any agent or human operator should
+honor.
+
+## Project identity
+
+- **Self-referential:** vsdd-factory IS the project being onboarded.
+  Engine and product are the same repository. The "don't use
+  dark-factory paths as cwd" rule does NOT apply here. `.factory/`
+  writes target this repo intentionally.
+
+## Branching model
+
+- `develop` — active integration branch. Every feature/fix PR targets here.
+- `main` — released versions only. Receives one merge per release (the
+  `release/v1.0.0-rc.X` branch) plus one bot commit per release (the
+  binary bundle).
+- `factory-artifacts` — orphan branch mounted as a worktree at `.factory/`.
+  Holds spec docs, cycle logs, STATE.md.
+
+## Releases
+
+**Read [`RELEASING.md`](./RELEASING.md) before cutting any release.** It is
+the canonical procedure. The release skill (`/vsdd-factory:release`)
+defers to it.
+
+Critical invariants:
+- Release branches MUST be named `release/v<full-semver>` and MUST target
+  `main` (enforced by `.github/workflows/release-branch-guardrail.yml`).
+- Release PRs MUST be merged with `--merge` (not `--squash`) to preserve
+  develop's commits as ancestors of main.
+- Tag the release at main's new tip after the PR merges.
+
+## Commit messages
+
+- No AI attribution. Never include `Co-Authored-By: Claude` or similar
+  references in commits.
+- Conventional Commits format preferred (`feat:`, `fix:`, `chore:`, etc.)
+  but not enforced by hook.
+
+## Testing
+
+- Bats suite: `cd plugins/vsdd-factory/tests && ./run-all.sh`
+- Cargo workspace: `cargo test --workspace --all-targets`
+- Cargo fmt + clippy: `cargo fmt --check --all && cargo clippy --workspace --all-targets -- -D warnings`
+- Ci.yml runs the same on every PR to develop or main.
+
+## Hooks (this project's own dispatcher)
+
+This project ships the dispatcher binary it consumes. After every
+release, the local plugin cache at
+`/Users/$USER/.claude/plugins/cache/claude-mp/vsdd-factory/<version>/`
+contains the marketplace-tarball version of the dispatcher and registry.
+Edits to source must be released for hooks to pick them up at the
+operator level — develop changes don't affect the cached plugin.
+
+## See also
+
+- [`RELEASING.md`](./RELEASING.md) — canonical release procedure
+- [`CHANGELOG.md`](./CHANGELOG.md) — release history
+- [`.factory/STATE.md`](./.factory/STATE.md) — pipeline state (live)
+- [`.github/workflows/release.yml`](./.github/workflows/release.yml) — release automation
+- [`.github/workflows/release-branch-guardrail.yml`](./.github/workflows/release-branch-guardrail.yml) — TD #69 enforcement

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,325 @@
+# Releasing vsdd-factory
+
+Canonical procedure for cutting a `v1.0.0-rc.X` (or `v1.0.0`, `v1.0.x`) release of vsdd-factory and getting it onto the [drbothen/claude-mp](https://github.com/drbothen/claude-mp) marketplace where operators install it.
+
+This file is the **single source of truth**. The release skill (`/vsdd-factory:release`), the orchestrator agent, and any human operator all defer to this document. If you change the release procedure, change it here first.
+
+## TL;DR for impatient operators
+
+```bash
+git checkout -b release/v1.0.0-rc.X origin/develop
+scripts/bump-version.sh 1.0.0-rc.X "<release title>"
+# Edit CHANGELOG.md to replace the stub with the real release notes
+git add CHANGELOG.md && git commit -m "chore(release): CHANGELOG entry for v1.0.0-rc.X"
+git push -u origin release/v1.0.0-rc.X
+gh pr create --base main --head release/v1.0.0-rc.X \
+  --title "release: v1.0.0-rc.X — <title>" --body "..."
+# Wait for CI green, then:
+gh pr merge <N> --merge --delete-branch     # NOT --squash
+git fetch origin main
+git tag -a v1.0.0-rc.X -m "v1.0.0-rc.X — <title>" origin/main
+git push origin v1.0.0-rc.X
+# Watch release.yml; verify drbothen/claude-mp PR opens; merge it.
+```
+
+If anything in that block confuses you, **read the rest of this document** before proceeding. The shortcuts are recoveries from a known-correct mental model, not a substitute for one.
+
+## Why this procedure exists in this exact shape
+
+vsdd-factory has a **two-branch release model**:
+
+- `develop` — active integration branch. Every feature/fix PR targets here.
+- `main` — released versions only. Receives one merge per release (the `release/v1.0.0-rc.X` branch) plus one bot commit per release (the binary bundle).
+
+The release pipeline (`.github/workflows/release.yml`) fires on tag push and:
+1. Validates against the tag's commit (which sits on `main`)
+2. Builds dispatcher binaries on 5 platforms
+3. Bot checks out **`main`**, stages binaries, force-moves the tag to a new commit on `main`
+4. Creates the GitHub Release as prerelease
+5. Auto-opens a marketplace bump PR at `drbothen/claude-mp`
+
+The pipeline assumes the tag's commit is on `main` and that `main` already has every source-file change for the release. If `main` is behind `develop`, the tarball ships with stale source against fresh binaries — exactly what produced the [v1.0.0-rc.14 marketplace failure](CHANGELOG.md#v1.0.0-rc.14--release-ci-unblocker-supersedes-rc11rc13-2026-05-09) (operators saw `E-REG-001` fail-closed on every tool call).
+
+The `release/v1.0.0-rc.X → main` PR is **the** mechanism that brings develop's source onto main. Skip it or mis-target it, and the marketplace publish breaks.
+
+## Mandatory invariants
+
+The following invariants are non-negotiable. Violating any of them is what historically broke our releases.
+
+| Invariant | What goes wrong if violated |
+|-----------|----------------------------|
+| Release branch is named exactly `release/v<full-semver>` | `.github/workflows/release-branch-guardrail.yml` won't match the pattern; convention drift accelerates |
+| Release branch is **branched from develop**, not main | Source-file fixes from develop never reach main → marketplace ships stale source |
+| Release branch PR **targets `main`**, not develop | Same outcome — main never gets develop's content. **Enforced by `release-branch-guardrail.yml`.** |
+| Release PR is merged with **`--merge`** strategy, not `--squash` | Squash collapses develop's commits; main loses develop ancestry; future releases see false "diverged" warnings and trigger the [TD #68 binary auto-resolve](CHANGELOG.md#v1.0.0-rc.15--marketplace-source-sync-fix-main-backfill-2026-05-10) every time |
+| Tag is created **on `main`** after the merge, at main's new tip | Tag at develop's tip works (the bot will retag) but causes bot to retag onto main's existing commit, missing the merge |
+| Tag name is exactly `v<full-semver>` (no spaces, with `v` prefix) | `release.yml` only fires on `tags: ["v*"]` |
+| `CHANGELOG.md` has a `## <full-semver>` heading at the top | Validate job fails — `release.yml` checks for this |
+| `develop` is the source branch tracker, not `master` | Hardcoded throughout workflows + scripts |
+
+## Step-by-step: cutting a release
+
+### Step 0 — Pre-flight
+
+```bash
+# Be on develop with no local changes
+git checkout develop
+git pull --ff-only origin develop
+git status                          # must be clean
+
+# Verify develop CI is green for the head commit
+gh run list --workflow=ci --branch=develop --limit=1 --json conclusion --jq '.[0].conclusion'
+# Expected: "success"
+```
+
+If develop CI is red, **fix that first**. Cutting a release from a red branch produces a release that fails its own validate job.
+
+### Step 1 — Create the release branch
+
+```bash
+git checkout -b release/v1.0.0-rc.X origin/develop
+```
+
+Branch naming MUST be exactly `release/v<full-semver>`. The guardrail workflow uses `startsWith(github.head_ref, 'release/')` to detect release branches.
+
+### Step 2 — Bump version + draft CHANGELOG
+
+```bash
+scripts/bump-version.sh 1.0.0-rc.X "<release title>"
+```
+
+This prepends a CHANGELOG.md stub with today's date. **Do not commit yet** — the stub is a placeholder.
+
+Open `CHANGELOG.md` and replace the stub with real release notes. Required sections (keep-a-changelog format):
+
+- Headline paragraph (2-4 sentences) — what shipped, why it matters
+- `### Added` (if applicable)
+- `### Fixed` (if applicable)
+- `### Refactored` (if applicable)
+- `### Operational` — anything operators need to know (breaking? marketplace impact? cache fixes?)
+- `### Deferred` — known follow-ups, TD links
+
+Then:
+
+```bash
+git add CHANGELOG.md
+git commit -m "chore(release): CHANGELOG entry for v1.0.0-rc.X"
+```
+
+### Step 3 — Push branch + open PR
+
+```bash
+git push -u origin release/v1.0.0-rc.X
+gh pr create --base main --head release/v1.0.0-rc.X \
+  --title "release: v1.0.0-rc.X — <release title>" \
+  --body "$(cat <<'EOF'
+## Summary
+
+[2-4 sentences: what this release ships, biggest changes]
+
+## Carried forward
+
+[bullet list of cumulative changes since previous release on main, by source PR if useful]
+
+## Pre-Merge Checklist
+
+- [x] Branched from develop
+- [x] Targets main
+- [x] CHANGELOG entry on this branch
+- [ ] CI passes
+- [ ] Squash merge is FORBIDDEN — use --merge to preserve develop ancestry
+- [ ] Post-merge: tag at main's new tip, watch release.yml chain
+EOF
+)"
+```
+
+The guardrail workflow validates `head=release/* → base=main` automatically. If you target develop by mistake, it fails the PR and tells you the fix command.
+
+### Step 4 — Wait for CI
+
+Watch the PR's checks. The same checks that gate ordinary feature PRs apply:
+
+- `validate` (bats run-all.sh) — must pass
+- `cargo-host` (×2: ubuntu, macos) — fmt + clippy + workspace test + perf-baseline
+- `build-dispatcher` (5 platforms) — full release build per platform
+- `platforms-drift`, `SAST (Semgrep)` — sanity gates
+- `release-branch-guardrail` — confirms target=main
+
+All 10 must be green before merge.
+
+### Step 5 — Merge with `--merge` (NOT `--squash`)
+
+```bash
+gh pr merge <N> --merge --delete-branch
+```
+
+Why `--merge` matters: it preserves the develop commits (e.g. PR #112, PR #113, PR #114) as ancestors of main. After merge, `git merge-base --is-ancestor origin/main origin/develop` returns true, which means:
+
+- Future releases' `sync-develop` job is a clean no-op
+- TD #68's binary auto-resolve doesn't fire on the next release (no spurious conflicts)
+- `git log --first-parent main` shows a clean release-by-release history
+
+Squash merge breaks all three.
+
+### Step 6 — Tag at main's new tip
+
+```bash
+git fetch origin main
+NEW_HEAD=$(git rev-parse origin/main)
+git tag -a v1.0.0-rc.X \
+  -m "$(cat <<'EOF'
+v1.0.0-rc.X — <title>
+
+[1-2 paragraphs from CHANGELOG]
+
+See CHANGELOG.md for full notes.
+EOF
+)" "$NEW_HEAD"
+git push origin v1.0.0-rc.X
+```
+
+Tag at `origin/main` — not at the release branch. The PR's merge commit IS main's new tip; tagging there ensures the bot retag happens on main, not on a now-orphaned commit.
+
+### Step 7 — Watch the release pipeline
+
+```bash
+gh run list --workflow=Release --limit=1
+gh run watch <run-id>
+```
+
+The workflow runs 6 jobs in dependency order:
+
+1. `validate` — runs bats run-all.sh against the tag's tree. Must pass.
+2. `build-binaries` — 5-platform matrix (~10–50 min total wall-clock; darwin-x64 is the slowest).
+3. `commit-binaries` — bot bundles binaries into a chore commit on main, force-moves the tag.
+4. `release` — creates GitHub Release as prerelease.
+5. `bump-marketplace` — opens auto-PR at `drbothen/claude-mp` bumping the version field. Requires `CLAUDE_MP_PAT` secret.
+6. `sync-develop` — back-merges main → develop. Should be a clean no-op since `--merge` preserved ancestry. If it fails, see "Recovery" below.
+
+### Step 8 — Verify the marketplace PR + merge it
+
+```bash
+gh pr list --repo drbothen/claude-mp --state open
+# Look for "chore: bump vsdd-factory to <version>"
+gh pr view <N> --repo drbothen/claude-mp
+# Review the diff (single line in marketplace.json)
+gh pr merge <N> --repo drbothen/claude-mp --squash --delete-branch
+```
+
+After merge, operators on `/plugin update vsdd-factory@claude-mp` resolve to the new version on their next plugin refresh.
+
+### Step 9 — Verify operator install works
+
+```bash
+# In a separate Claude Code session or terminal:
+/plugin update vsdd-factory@claude-mp
+# Verify the cache schema is correct:
+grep -n "^schema_version" \
+  /Users/$USER/.claude/plugins/cache/claude-mp/vsdd-factory/<version>/hooks-registry.toml
+# Expected: schema_version = 2 (or whatever the current canonical schema is)
+```
+
+If the cache shipped with stale schema (the rc.14 failure mode), see "Recovery — operator-side cache fix" below.
+
+## Recovery procedures
+
+### `validate` fails on the release run
+
+`run-all.sh` is failing on `main`'s tree. Either:
+
+1. The release branch wasn't actually a clean superset of develop — find what's missing and add it on a follow-up PR targeting main.
+2. CI runner environment regression — re-run the workflow:
+   ```bash
+   gh run rerun <run-id> --failed
+   ```
+
+### `commit-binaries` fails — binary build issue
+
+Bot couldn't bundle a platform's binary. Check the `build-binaries` matrix output for the failing platform; likely a toolchain or dependency issue. Fix on a follow-up PR, then either:
+
+- Re-run the workflow (`gh run rerun <run-id>`), OR
+- Force-delete the tag, fix, re-tag at the new main tip:
+  ```bash
+  git push origin :refs/tags/v1.0.0-rc.X
+  git tag -d v1.0.0-rc.X
+  # Wait for the fix PR to merge to main
+  git fetch origin main
+  git tag -a v1.0.0-rc.X -m "..." origin/main
+  git push origin v1.0.0-rc.X
+  ```
+
+### `bump-marketplace` skipped — `CLAUDE_MP_PAT` secret missing
+
+Job logs show "CLAUDE_MP_PAT secret is not configured. Skipping marketplace bump." Fix:
+
+1. Generate a fine-grained PAT with `contents: write` + `pull-requests: write` scoped to `drbothen/claude-mp`
+2. Add as `CLAUDE_MP_PAT` in [vsdd-factory secrets](https://github.com/drbothen/vsdd-factory/settings/secrets/actions)
+3. Re-run the workflow
+
+### `sync-develop` fails — binary conflicts
+
+This SHOULD no longer happen if you used `--merge` (TD #68 auto-resolve handles legitimate conflicts). If it does:
+
+```bash
+# Manually run the sync as a follow-up PR:
+git checkout -b chore/sync-main-to-develop-rc.X origin/develop
+git merge origin/main --no-ff -m "chore: sync main → develop (rc.X)"
+# If conflicts on bundle paths only, take main's version:
+git checkout origin/main -- 'plugins/vsdd-factory/hook-plugins/*.wasm' \
+                            'plugins/vsdd-factory/hooks/dispatcher/bin/**'
+git add plugins/vsdd-factory/hook-plugins/ plugins/vsdd-factory/hooks/dispatcher/
+git commit --no-edit
+git push -u origin chore/sync-main-to-develop-rc.X
+gh pr create --base develop --head chore/sync-main-to-develop-rc.X \
+  --title "chore: sync main → develop (rc.X bundle)"
+```
+
+### Operator-side: marketplace cache shipped with stale schema (rc.14-class failure)
+
+The dispatcher binary expects a schema_version that doesn't match the bundled `hooks-registry.toml`. Every tool call fails with `E-REG-001`. Operator workaround until next release:
+
+```bash
+# Find the canonical schema_version expected by your dispatcher:
+grep "expects" /Users/$USER/.claude/plugins/cache/claude-mp/vsdd-factory/<version>/hooks-registry.toml 2>/dev/null
+# (or read the dispatcher's own constant from the rc.X CHANGELOG)
+
+# Force the cache to match:
+sed -i '' 's/^schema_version = 1$/schema_version = 2/' \
+  /Users/$USER/.claude/plugins/cache/claude-mp/vsdd-factory/<version>/hooks-registry.toml
+```
+
+If you're hitting this systematically, the release was poisoned — file an issue, the fix needs to ship as a new release.
+
+## What gets automated, what stays manual
+
+The release workflow (`.github/workflows/release.yml`) automates everything from tag-push onward. Pre-tag is operator-driven on purpose: the human is the one who knows what's ready to ship and who writes the CHANGELOG narrative.
+
+| Step | Who | Why |
+|------|-----|-----|
+| Branch from develop | Operator | Choosing the release point is a human decision |
+| CHANGELOG narrative | Operator (or AI agent) | Writing release notes requires synthesis |
+| PR open + merge | Operator | Code review is human-in-the-loop |
+| Tag push | Operator | Tagging is the "I'm sure" gesture |
+| Validate, build, retag, GitHub Release | Workflow | Mechanical |
+| Marketplace bump PR | Workflow | Mechanical (but the merge of THAT PR is operator) |
+| Sync develop | Workflow | Mechanical |
+
+## How agents should consume this document
+
+If you are an AI agent (orchestrator, devops-engineer, release skill, etc.) executing a release:
+
+1. **Read this entire file before any action.** It's the source of truth.
+2. **Honor the mandatory invariants table.** They are the wire format of the procedure; deviating breaks the marketplace.
+3. **Use the step-by-step section literally.** The shell snippets are tested; substitute `1.0.0-rc.X` and the title.
+4. **If you encounter a failure mode not in the recovery section, STOP and surface it to the human.** Do not improvise on the release pipeline.
+5. **If you are about to update RELEASING.md itself, dispatch a separate explicit request for human review.** This file is a fast lane to making future releases worse if changed without thought.
+
+## See also
+
+- `.github/workflows/release.yml` — the automated half (run on tag push)
+- `.github/workflows/release-branch-guardrail.yml` — enforces release/* → main
+- `.factory/release-config.yaml` — pre-release commands, version source paths
+- `scripts/bump-version.sh` — CHANGELOG stub generator
+- `plugins/vsdd-factory/skills/release/SKILL.md` — the invokable skill (defers here)
+- `CHANGELOG.md` — release history and per-release operational notes
+- TD #69 — guardrail tracking ticket

--- a/plugins/vsdd-factory/skills/release/SKILL.md
+++ b/plugins/vsdd-factory/skills/release/SKILL.md
@@ -15,9 +15,60 @@ When the user wants to cut a release, bootstrap release config for a new repo,
 or preview what a release would do. Works with any project type — Claude Code
 plugins, Rust crates, Node.js packages, Python packages, Go modules.
 
+## Defer to RELEASING.md when present (project canonical procedure)
+
+If a `RELEASING.md` exists at the project root, **read it first** and use it
+as the authoritative procedure for this project. This skill provides the
+generic invokable shell; `RELEASING.md` provides the project-specific details
+(branch conventions, merge strategy, marketplace publish, recovery procedures).
+
+Procedure:
+
+1. Check for `RELEASING.md` at the project root.
+2. **If it exists**:
+   - Announce: `**Release Pipeline** — RELEASING.md found at project root. Deferring to its canonical procedure.`
+   - Read RELEASING.md in full before any action.
+   - Honor every "Mandatory invariants" entry. Violating them is what
+     historically broke vsdd-factory's marketplace publish.
+   - Follow the "Step-by-step: cutting a release" section literally; the
+     shell snippets are tested.
+   - Return RELEASING.md's recovery procedures verbatim if you encounter
+     a known failure mode. STOP and surface to the human if you encounter
+     anything not in RELEASING.md's recovery section.
+   - Skip the rest of this SKILL.md unless RELEASING.md explicitly defers
+     a step back to the generic skill.
+
+3. **If `RELEASING.md` does NOT exist**:
+   - Announce: `**Release Pipeline** — no RELEASING.md found at project root. The canonical release procedure should be documented before cutting a release.`
+   - Prompt the human:
+
+     > This project doesn't have a `RELEASING.md` at the root, which is
+     > the documented source of truth for how releases are cut. Without
+     > one, this skill will fall back to a generic config-driven release
+     > flow which may not match your project's actual release conventions
+     > (branch naming, merge strategy, marketplace publish, etc.).
+     >
+     > **Recommended:** create RELEASING.md before cutting this release.
+     > Use the example at
+     > [vsdd-factory/RELEASING.md](https://github.com/drbothen/vsdd-factory/blob/main/RELEASING.md)
+     > as a starting template and adapt to your project's conventions.
+     >
+     > **Choose:**
+     > 1. Pause and create RELEASING.md now (recommended for first-time releases or any project with a non-trivial release flow).
+     > 2. Proceed with the generic config-driven flow (use only if you've already validated the generic flow works for this project).
+
+   - If the human chooses (1), help them draft RELEASING.md by reading
+     `.github/workflows/release.yml`, `.factory/release-config.yaml`,
+     and `CHANGELOG.md` to extract the project's actual release behavior,
+     then write a draft for human review.
+   - If the human chooses (2), proceed with the generic flow below and
+     consider it operating without a safety net — prepare to halt if
+     anything looks wrong.
+
 ## Announce at Start
 
-Before any other action, say verbatim:
+After the RELEASING.md check above, if you're proceeding with the generic flow,
+say verbatim:
 
 > **Release Pipeline** — reading release config from `.factory/release-config.yaml`.
 


### PR DESCRIPTION
## Summary

First release cut by following [RELEASING.md](https://github.com/drbothen/vsdd-factory/blob/main/RELEASING.md) step-by-step. This is the **live exercise** of the new procedure, dogfooding the very documentation it ships to main.

rc.16 ships:

- \`RELEASING.md\` — canonical release procedure (single source of truth)
- \`.github/workflows/release-branch-guardrail.yml\` — CI guardrail enforcing release/* → main
- \`CLAUDE.md\` — project conventions auto-loaded by Claude Code
- Updated \`release\` skill that defers to RELEASING.md (and prompts to create when missing)
- YAML parse fix + shell-injection hardening for the guardrail itself (PR #117)

Combined with rc.15's source-sync fix, rc.16 closes both halves of the rc.14 marketplace root cause:
- rc.15 fixed the **content drift** (main lagged develop by 92 files)
- rc.16 fixes the **procedural drift** that allowed the content drift to accumulate

## Procedural validation

This very PR demonstrates the procedure works:

| RELEASING.md Step | Action | Status |
|-------------------|--------|--------|
| Step 0 — Preflight | develop CI green, develop ⊇ main confirmed | ✅ |
| Step 1 — Create release branch | \`git checkout -B release/v1.0.0-rc.16 origin/develop\` | ✅ |
| Step 2 — bump-version + CHANGELOG | \`scripts/bump-version.sh 1.0.0-rc.16 "..."\` + manual narrative | ✅ |
| Step 3 — Push + open PR target=main | This PR | ✅ |
| Step 4 — Wait for CI | (in progress) | 🔄 |
| Step 5 — Merge with \`--merge\` | (post-CI) | ⏳ |
| Step 6 — Tag at main's new tip | (post-merge) | ⏳ |
| Step 7 — Watch release pipeline | (post-tag) | ⏳ |
| Step 8 — Merge claude-mp PR | (post-pipeline) | ⏳ |
| Step 9 — Verify operator install | (post-marketplace merge) | ⏳ |

The guardrail workflow fires on this PR's open event. With \`head=release/v1.0.0-rc.16\` and \`base=main\`, the **`Reject release/* PRs not targeting main`** check should evaluate the if-conditions and report SUCCESS (correctly recognizing the canonical pattern). If we'd accidentally targeted develop, the same check would fail with a multi-line annotation pointing to the fix command.

## Architecture Changes

\`\`\`mermaid
graph TD
    PR111["PR #111 (rc.13)<br/>❌ targeted develop"] -.broke chain.-> RC14_BUG["rc.14 marketplace<br/>E-REG-001"]
    RC14_BUG --> PR115["PR #115 (rc.15)<br/>content backfill"]
    RC14_BUG --> PR116["PR #116<br/>RELEASING.md + guardrail"]
    PR116 --> PR117["PR #117<br/>YAML + security fix"]
    PR115 --> RC15["rc.15 marketplace<br/>(content fixed)"]
    PR117 --> THIS["this PR (rc.16)<br/>procedural infrastructure"]
    THIS --> RC16["rc.16 marketplace<br/>(infrastructure baked in)"]
    RC16 -.prevents recurrence.-> RC17["rc.17+<br/>cannot drift"]
\`\`\`

## Story Dependencies

- Branched from develop (which contains all PR #112, #113, #114, #115, #116, #117 content)
- Targets main (enforced by guardrail)
- Will merge with \`--merge\` (preserves ancestry)
- Tag at main's new tip post-merge

## Spec Traceability

- TD #69 (closure half 2 of 2 — first half was the guardrail itself in PR #116; second half is shipping it to main via this release)

## Tests

- [x] CHANGELOG entry under \`## 1.0.0-rc.16\` heading
- [x] Branched from develop
- [x] Targets main
- [ ] All CI checks pass (in progress)
- [ ] release-branch-guardrail check explicitly passes (proof the guardrail accepts canonical pattern)
- [ ] Squash merge is FORBIDDEN — use \`--merge\`

## Security Review

This release ships:
- One workflow file (`release-branch-guardrail.yml`) with `contents: read` permission only
- One markdown doc (`RELEASING.md`) with no executable content
- One config doc (`CLAUDE.md`) with no secrets
- A skill SKILL.md change that's pure documentation

No new attack surface introduced. The PR #117 shell-injection hardening reduces existing surface (env: indirection for github context).

## Risk Assessment

- **Blast radius:** procedural infrastructure ships to main. Marketplace tarball will include RELEASING.md + guardrail + skill update.
- **Affected operators:** future release authors get clear procedure + mechanical safety net.
- **Performance impact:** None.
- **Regression risk:** Low. Every commit on this branch already validated by its own PR's CI.

## Affected behavior

- Future operators cutting releases follow RELEASING.md
- Mechanical CI enforcement of release branch convention
- Release skill self-documents (defers to RELEASING.md)
- Project conventions auto-loaded via CLAUDE.md

## Demo Evidence

This PR is the demo. Step 4 (CI) and the release-branch-guardrail check passing on this PR will validate the entire procedure end-to-end.

## AI Pipeline Metadata

- Pipeline mode: release (rc.16 — procedural infrastructure)
- Autonomy level: 4 (auto-merge with **--merge** strategy if CI passes)
- No AI attribution per project policy.

## Refs

- TD #69 (closure)
- PR #115 — rc.15 content backfill (companion, prerequisite)
- PR #116 — RELEASING.md + guardrail (squash-merged to develop)
- PR #117 — YAML + security fix (squash-merged to develop)
- v1.0.0-rc.14 marketplace failure — historical root cause

## Pre-Merge Checklist

- [x] PR created with structured description
- [x] Branched from develop
- [x] Targets main (canonical pattern)
- [x] CHANGELOG entry on this branch
- [ ] CI passes
- [ ] **Squash merge is FORBIDDEN — use \`--merge\`** for ancestry preservation
- [ ] Post-merge: tag v1.0.0-rc.16 at main's new tip → release.yml chain → claude-mp PR opens
- [ ] After ship: TD #69 closed (both halves), task #71 marked completed