### PR TITLE
fix(tests): bump Context Injection Contract sanity ceiling 400 → 600

### DIFF
--- a/plugins/vsdd-factory/tests/resolver-host-abi-context-injection.bats
+++ b/plugins/vsdd-factory/tests/resolver-host-abi-context-injection.bats
@@ -404,15 +404,21 @@ section_text() {
 }
 
 # =============================================================================
-# Section sanity: length is reasonable (100–400 lines).
+# Section sanity: length is reasonable (100–600 lines).
 # Catches absurd over/under (empty placeholder vs. runaway prose).
+#
+# Upper bound raised from 400 → 600 when the S-12.x ABI documentation
+# (resolver lifecycle, host fns, registry schema, error envelope, examples)
+# settled at ~475 lines on first ship to main (v1.0.0-rc.17). The original
+# 400-line ceiling was an early estimate, not a spec invariant — the
+# section's job is to fully document the contract, which it does.
 # =============================================================================
 
-@test "sanity: Context Injection Contract section is between 100 and 400 lines" {
+@test "sanity: Context Injection Contract section is between 100 and 600 lines" {
     local line_count
     line_count=$(section_text | wc -l | tr -d ' ')
     [ "$line_count" -ge 100 ]
-    [ "$line_count" -le 400 ]
+    [ "$line_count" -le 600 ]
 }
 
 # =============================================================================


### PR DESCRIPTION
## Summary

One-line fix to `resolver-host-abi-context-injection.bats` line 415: bump the upper bound of the section-length sanity test from 400 → 600 lines.

## Why

While cutting **v1.0.0-rc.17** the `Pre-release Validation` job failed on this single test:

```
not ok 46 sanity: Context Injection Contract section is between 100 and 400 lines
  `[ "$line_count" -le 400 ]' failed
```

HOST_ABI.md's `## Context Injection Contract` section is **475 lines** — legitimate content (resolver lifecycle, host fns, registry schema, error envelope, examples). The 400-line ceiling was an early sanity estimate from S-12.06, not a spec invariant. The section's job is to fully document the contract; it does.

## CI gap noted (not fixed here)

This test belongs to the bats `run-all.sh` suite that **only runs in `release.yml`'s `Pre-release Validation`**, not in `ci.yml`'s `validate` job (which runs only `hooks.bats` / `block-helper.bats` / `bin.bats`). That's why develop CI was green when this test was failing. Closing the gap (mirroring `run-all.sh` into ci.yml) would be a separate follow-up.

## Test plan

- [x] Local: `bats plugins/vsdd-factory/tests/resolver-host-abi-context-injection.bats` → 48/48 pass
- [ ] CI: `validate` job passes on this PR
- [ ] Release: enables re-cutting the rc release (v1.0.0-rc.18) which carries the research-agent MCP fix + S-12.x convergence migration that rc.17 attempted to ship

## Carries forward to release

After this lands on develop, a new `release/v1.0.0-rc.18` branch can be cut from updated develop to retry the release that rc.17 attempted.