### PR TITLE
chore(path-registry): register dim2-gates + 3 sibling artifact types

### DIFF
--- a/plugins/vsdd-factory/config/artifact-path-registry.yaml
+++ b/plugins/vsdd-factory/config/artifact-path-registry.yaml
@@ -54,6 +54,11 @@ artifacts:
     description: Verification property specification
     enforcement_level: block
 
+  - artifact_type: verification-property-index
+    canonical_path_pattern: ".factory/specs/verification-properties/VP-INDEX.md"
+    description: Verification property master index
+    enforcement_level: block
+
   # ── Stories ─────────────────────────────────────────────────────────────
   - artifact_type: story-spec
     canonical_path_pattern: ".factory/stories/S-{story-id}-{slug}.md"
@@ -110,6 +115,11 @@ artifacts:
   - artifact_type: adversarial-review
     canonical_path_pattern: ".factory/cycles/{cycle-id}/adv-{slug}.md"
     description: Adversarial review document for a cycle
+    enforcement_level: block
+
+  - artifact_type: per-story-adversary-pass
+    canonical_path_pattern: ".factory/cycles/{cycle-id}/{story-id}/adversary-pass-{n}.md"
+    description: Per-story adversarial review pass file (BC-5.39.001)
     enforcement_level: block
 
   # ── Product Requirements / State ─────────────────────────────────────────
@@ -234,4 +244,16 @@ artifacts:
   - artifact_type: code-delivery-artifact
     canonical_path_pattern: ".factory/code-delivery/{filename}.md"
     description: Code delivery tracking document
+    enforcement_level: block
+
+  # ── Feature Delta Analysis ────────────────────────────────────────────────
+  - artifact_type: feature-delta-analysis
+    canonical_path_pattern: ".factory/feature-delta/{feature-id}/{filename}.md"
+    description: Feature Mode F1 delta analysis and supporting artifacts per feature
+    enforcement_level: block
+
+  # ── Dim-2 Gate Templates ─────────────────────────────────────────────────
+  - artifact_type: hooks-dim2-gate-template
+    canonical_path_pattern: ".factory/hooks/dim2-gates/{filename}"
+    description: Dim-2 mechanical gate bash template scripts and registry README (D-453(e))
     enforcement_level: block

--- a/plugins/vsdd-factory/hooks/dim2-gates/README.md
+++ b/plugins/vsdd-factory/hooks/dim2-gates/README.md
@@ -1,0 +1,39 @@
+# hooks/dim2-gates/ — Dim-2 Gate Template Registry
+
+**Purpose:** Canonical bash template storage for Dim-2 mechanical gate scripts, as prescribed by D-453(e). Each file in this directory is a reusable shell template invoked (or adapted) during fix-burst Dim-2 attestation.
+
+**Codification authority:** D-453(e) (pass-73 fix burst, Commit B). Instantiation of this directory closes ADV-EDP1-P74-HIGH-002 (codification-references-storage-that-doesn't-exist pattern; remediated at pass-74 Commit A).
+
+**Source vs deployment:** This directory is the SOURCE location for dim2-gate templates within the vsdd-factory plugin source tree. The deployment target per D-453(e) is `.factory/hooks/dim2-gates/` within each factory project worktree. The deployment target path is registered in `config/artifact-path-registry.yaml` (entry: `hooks-dim2-gate-template`); registration was added at pass-74 Commit A. Templates here ship to the deployment target via plugin release.
+
+## Planned Template Files
+
+| File | Gate | Closes / Implements |
+|------|------|---------------------|
+| `trajectory-tail-cell-grep.sh` | Per-cell trajectory_tail presence check (D-454(a)) | ADV-EDP1-P74-CRIT-001 |
+| `freshness-literal-stdout.sh` | Freshness re-execution with captured stdout (D-454(b)) | ADV-EDP1-P74-HIGH-001 + MED-003 |
+| `block-label-canonical-form.sh` | Tri-way block-label canonical-form alignment check (D-454(d)) | ADV-EDP1-P74-HIGH-003 |
+| `banner-wc-l-gate.sh` | STATE.md banner wc-l freshness gate with full-edit-window scope (D-454(e)) | ADV-EDP1-P74-HIGH-004 |
+| `propagation-count-gate.sh` | Propagation count gate scoped to post-edit corpus state | ADV-EDP1-P74-PG-003 |
+
+## Template Creation Cadence
+
+Templates are instantiated in the fix burst that codifies their corresponding D-NNN decision. The D-453(e) pattern prescribes: **codify AND instantiate in the same burst** — no deferred creation. D-454(c) codifies this as a hard rule: `storage-path-without-artifacts` is forbidden; every D-NNN that names a storage path MUST create at least a stub artifact at the same commit.
+
+## Usage
+
+Each template is a standalone bash script conforming to:
+- `set -euo pipefail`
+- Single positional argument: the target `.factory/` root path
+- Exit 0 on PASS, exit 1 on FAIL with human-readable reason on stdout
+- Designed to be sourced or invoked from burst-log Dim-2 attestation blocks per D-449(a)
+
+## Registry Status
+
+| Status | Meaning |
+|--------|---------|
+| `PLANNED` | D-NNN specifies this gate; template not yet written |
+| `STUB` | Directory and README created; script body pending |
+| `ACTIVE` | Fully implemented and in use at Dim-2 attestation |
+
+All entries in the Planned Template Files table above are currently `PLANNED` pending D-454 codification at Commit B.


### PR DESCRIPTION
Registers 4 previously undeclared artifact path types in the plugin's path registry and creates the canonical source-tree directory for Dim-2 mechanical gate bash templates. Zero behavior change; scaffolding only.

## Background

During F5 adversarial pass 74 (2026-05-13), finding **ADV-EDP1-P74-HIGH-002** flagged the "codification-references-storage-that-doesn't-exist" pattern: multiple skills and agents referenced artifact paths (VP index, per-story adversary passes, feature-delta analysis outputs, dim2-gate templates) that were never formally registered. This PR is the retroactive fix (D-454(c) preview), landing via an independent branch now that the F5 cycle is paused.

This also closes the Tier-B priority-1 item listed in STATE.md Section 12 forward-backlog, unblocking the S-15.03 PRIORITY-A structural-break automation wave.

## Changes

**`plugins/vsdd-factory/config/artifact-path-registry.yaml` — 4 new entries:**

| Artifact type | Canonical path pattern |
|---|---|
| `verification-property-index` | `.factory/specs/verification-properties/VP-INDEX.md` |
| `per-story-adversary-pass` | `.factory/cycles/{cycle-id}/{story-id}/adversary-pass-{n}.md` |
| `feature-delta-analysis` | `.factory/feature-delta/{feature-id}/{filename}.md` |
| `hooks-dim2-gate-template` | `.factory/hooks/dim2-gates/{filename}` |

Each entry carries `enforcement_level: block` (activates only when a future lint hook iterates the registry — currently a no-op for all existing artifacts).

**`plugins/vsdd-factory/hooks/dim2-gates/README.md` — new file:**

Establishes the canonical source-tree location for Dim-2 mechanical gate bash templates per D-453(e) codification. Documents 5 planned template files (none implemented — purely scaffolding), the source-vs-deployment path mapping, and the script convention (`set -euo pipefail`, single positional arg, exit 0/1).

## Risk / Test Plan

- **Code changes:** None. Config YAML insertions + markdown README only.
- **CI:** Full bats + cargo test suites expected green. The registry is consumed at runtime by tooling; new entries are inert until consumed by a future hook.
- **Hook validation:** Existing registry entries are unchanged. New `enforcement_level: block` entries are no-ops until a lint hook iterates them.
- **Behavior impact:** Zero. This is scaffolding that enables future work, not current behavior.

## Backlog closure

Closes STATE.md Section 12 Tier-B priority-1 item (dim2-gates path-registration scaffolding). Orchestrator pivots to Tier-B priority-2 (TD #71 stderr dispatcher) after merge.