### PR TITLE
S-15.16-Part-B: lessons.md size gate — D-442(e) structural closure

### DIFF
--- a/plugins/vsdd-factory/hooks/validate-state-size.sh
+++ b/plugins/vsdd-factory/hooks/validate-state-size.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
-# validate-state-size.sh — PostToolUse hook for STATE.md size enforcement
+# validate-state-size.sh — PostToolUse hook for STATE.md and lessons.md size enforcement
 #
 # Checks line count of STATE.md after every Write/Edit.
-# WARN at 200 lines, BLOCK at 500 lines (unless the write reduced size).
+# STATE.md: WARN at >200 lines, BLOCK at >500 lines (unless the write reduced size).
+# lessons.md: WARN at >3500 lines, BLOCK at >4000 lines (unless the write reduced size).
 #
-# Trigger: PostToolUse on Write/Edit to STATE.md.
-# Exit 0 on pass (or if file is not STATE.md, or if write reduced size).
-# Exit 2 on bloat detected (>500 lines AND file grew) with diagnostic on stderr.
+# Trigger: PostToolUse on Write/Edit to STATE.md or .factory/cycles/*/lessons.md.
+# Exit 0 on pass (or if file is not a target, or if write reduced size).
+# Exit 2 on bloat detected with diagnostic on stderr.
 #
 # Deterministic, <100ms, no LLM.
 
@@ -30,47 +31,104 @@ if [[ -z "$FILE_PATH" ]]; then
   exit 0
 fi
 
-# Only trigger for STATE.md files in .factory/
+# Determine target arm
 case "$FILE_PATH" in
-  */.factory/STATE.md|*.factory/STATE.md) ;;
-  *) exit 0 ;;
+  */.factory/STATE.md|*.factory/STATE.md)
+    TARGET="state"
+    ;;
+  */.factory/cycles/*/lessons.md|*.factory/cycles/*/lessons.md)
+    TARGET="lessons"
+    ;;
+  *)
+    exit 0
+    ;;
 esac
 
-if [[ ! -f "$FILE_PATH" ]]; then
+# ─── STATE.md arm ────────────────────────────────────────────────────────────
+if [[ "$TARGET" == "state" ]]; then
+  if [[ ! -f "$FILE_PATH" ]]; then
+    exit 0
+  fi
+
+  LINE_COUNT=$(wc -l < "$FILE_PATH" | tr -d ' \t\n')
+
+  # Check if this write reduced the file size (compaction).
+  # Use git to compare against the committed version.
+  PARENT_DIR=$(dirname "$FILE_PATH")
+  PRIOR_COUNT=0
+  if command -v git &>/dev/null; then
+    _git_out=$(git -C "$PARENT_DIR" show HEAD:STATE.md 2>/dev/null | wc -l | tr -d ' ' 2>/dev/null) || _git_out=0
+    # Ensure PRIOR_COUNT is a clean integer (strip trailing newlines/spaces)
+    PRIOR_COUNT="${_git_out//[[:space:]]/}"
+    PRIOR_COUNT="${PRIOR_COUNT:-0}"
+    # If still not numeric, default to 0
+    [[ "$PRIOR_COUNT" =~ ^[0-9]+$ ]] || PRIOR_COUNT=0
+  fi
+
+  # If the write REDUCED lines, always allow (compaction in progress)
+  if [[ "$LINE_COUNT" -lt "$PRIOR_COUNT" ]]; then
+    exit 0
+  fi
+
+  if [[ "$LINE_COUNT" -gt 500 ]]; then
+    block_pre "validate-state-size" \
+      "STATE.md exceeds 500-line limit ($LINE_COUNT lines). STATE.md should be a quick status check, not a history log" \
+      "Run /vsdd-factory:compact-state to extract historical content to cycle files" \
+      "state_md_bloat"
+  elif [[ "$LINE_COUNT" -gt 200 ]]; then
+    echo "STATE.md SIZE WARNING:" >&2
+    echo "  STATE.md has $LINE_COUNT lines (recommended: <200, limit: 500)." >&2
+    echo "  Consider running /vsdd-factory:compact-state to extract" >&2
+    echo "  historical content to cycle files before it grows further." >&2
+    exit 0
+  fi
   exit 0
 fi
 
-LINE_COUNT=$(wc -l < "$FILE_PATH" | tr -d ' \t\n')
+# ─── lessons.md arm ──────────────────────────────────────────────────────────
+# D-442(e) lessons.md size gate: advisory >3500, block >4000.
+if [[ "$TARGET" == "lessons" ]]; then
+  if [[ ! -f "$FILE_PATH" ]]; then
+    exit 0
+  fi
 
-# Check if this write reduced the file size (compaction).
-# Use git to compare against the committed version.
-PARENT_DIR=$(dirname "$FILE_PATH")
-PRIOR_COUNT=0
-if command -v git &>/dev/null; then
-  _git_out=$(git -C "$PARENT_DIR" show HEAD:STATE.md 2>/dev/null | wc -l | tr -d ' ' 2>/dev/null) || _git_out=0
-  # Ensure PRIOR_COUNT is a clean integer (strip trailing newlines/spaces)
-  PRIOR_COUNT="${_git_out//[[:space:]]/}"
-  PRIOR_COUNT="${PRIOR_COUNT:-0}"
-  # If still not numeric, default to 0
-  [[ "$PRIOR_COUNT" =~ ^[0-9]+$ ]] || PRIOR_COUNT=0
-fi
+  LESSONS_LINE_COUNT=$(wc -l < "$FILE_PATH" | tr -d ' \t\n')
 
-# If the write REDUCED lines, always allow (compaction in progress)
-if [[ "$LINE_COUNT" -lt "$PRIOR_COUNT" ]]; then
+  # Compaction-in-progress: always allow if write REDUCED lines.
+  # Use git to compare against the committed version.
+  # Compute canonical paths to handle macOS /private symlink differences.
+  LESSONS_PARENT_DIR=$(dirname "$FILE_PATH")
+  LESSONS_PRIOR_COUNT=0
+  if command -v git &>/dev/null; then
+    _lessons_git_root=$(git -C "$LESSONS_PARENT_DIR" rev-parse --show-toplevel 2>/dev/null) || _lessons_git_root=""
+    if [[ -n "$_lessons_git_root" ]]; then
+      # Resolve both paths to canonical form (handles macOS /var -> /private/var symlinks)
+      _file_canonical=$(cd "$(dirname "$FILE_PATH")" && pwd -P)/$(basename "$FILE_PATH")
+      _root_canonical=$(cd "$_lessons_git_root" && pwd -P)
+      _lessons_git_rel="${_file_canonical#"${_root_canonical}"/}"
+      _lessons_git_out=$(git -C "$LESSONS_PARENT_DIR" show HEAD:"$_lessons_git_rel" 2>/dev/null | wc -l | tr -d ' ' 2>/dev/null) || _lessons_git_out=0
+    else
+      _lessons_git_out=0
+    fi
+    LESSONS_PRIOR_COUNT="${_lessons_git_out//[[:space:]]/}"
+    LESSONS_PRIOR_COUNT="${LESSONS_PRIOR_COUNT:-0}"
+    [[ "$LESSONS_PRIOR_COUNT" =~ ^[0-9]+$ ]] || LESSONS_PRIOR_COUNT=0
+  fi
+
+  if [[ "$LESSONS_LINE_COUNT" -lt "$LESSONS_PRIOR_COUNT" ]]; then
+    exit 0
+  fi
+
+  if [[ "$LESSONS_LINE_COUNT" -gt 4000 ]]; then
+    block_pre "validate-state-size" \
+      "lessons.md exceeds 4000-line hard limit ($LESSONS_LINE_COUNT lines). WASM fuel exhaustion risk per D-442(e)" \
+      "Run /vsdd-factory:compact-lessons to archive historical content to lessons-archive-*.md" \
+      "lessons_md_fuel_risk"
+  elif [[ "$LESSONS_LINE_COUNT" -gt 3500 ]]; then
+    echo "LESSONS.MD SIZE WARNING:" >&2
+    echo "  lessons.md has $LESSONS_LINE_COUNT lines (recommended: ≤3500, hard limit: 4000)." >&2
+    echo "  Consider running /vsdd-factory:compact-lessons before it grows further (D-442(e))." >&2
+    exit 0
+  fi
   exit 0
 fi
-
-if [[ "$LINE_COUNT" -gt 500 ]]; then
-  block_pre "validate-state-size" \
-    "STATE.md exceeds 500-line limit ($LINE_COUNT lines). STATE.md should be a quick status check, not a history log" \
-    "Run /vsdd-factory:compact-state to extract historical content to cycle files" \
-    "state_md_bloat"
-elif [[ "$LINE_COUNT" -gt 200 ]]; then
-  echo "STATE.md SIZE WARNING:" >&2
-  echo "  STATE.md has $LINE_COUNT lines (recommended: <200, limit: 500)." >&2
-  echo "  Consider running /vsdd-factory:compact-state to extract" >&2
-  echo "  historical content to cycle files before it grows further." >&2
-  exit 0
-fi
-
-exit 0

--- a/plugins/vsdd-factory/tests/run-all.sh
+++ b/plugins/vsdd-factory/tests/run-all.sh
@@ -56,7 +56,7 @@ set +e   # allow individual bats suites to fail without aborting the loop
 fail_count=0
 failed_suites=()
 skipped_suites=()
-for f in tests/*.bats tests/dim2-gates/*.bats tests/validate-index-cite-refresh/*.bats tests/validate-burst-log/*.bats tests/validate-state-structure/*.bats tests/validate-state-size/*.bats tests/validate-dispatch-advance/*.bats; do
+for f in tests/*.bats tests/dim2-gates/*.bats tests/docs-completeness/*.bats tests/validate-index-cite-refresh/*.bats tests/validate-burst-log/*.bats tests/validate-state-structure/*.bats tests/validate-state-size/*.bats tests/validate-dispatch-advance/*.bats; do
   name=$(basename "$f" .bats)
   if is_skipped "$name"; then
     skipped_suites+=("$name")

--- a/plugins/vsdd-factory/tests/run-all.sh
+++ b/plugins/vsdd-factory/tests/run-all.sh
@@ -56,7 +56,7 @@ set +e   # allow individual bats suites to fail without aborting the loop
 fail_count=0
 failed_suites=()
 skipped_suites=()
-for f in tests/*.bats tests/dim2-gates/*.bats tests/validate-index-cite-refresh/*.bats tests/validate-burst-log/*.bats tests/validate-state-structure/*.bats; do
+for f in tests/*.bats tests/dim2-gates/*.bats tests/validate-index-cite-refresh/*.bats tests/validate-burst-log/*.bats tests/validate-state-structure/*.bats tests/validate-state-size/*.bats tests/validate-dispatch-advance/*.bats; do
   name=$(basename "$f" .bats)
   if is_skipped "$name"; then
     skipped_suites+=("$name")

--- a/plugins/vsdd-factory/tests/validate-state-size/fail-lessons-hard-threshold.bats
+++ b/plugins/vsdd-factory/tests/validate-state-size/fail-lessons-hard-threshold.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+# fail-lessons-hard-threshold.bats — AC-3 + AC-7: 4001-line lessons.md → exit 2 + block signal
+#
+# Traces to: BC-7.04.051 extension L4 (Hard block at >4000)
+# Canonical test vector: EC-003 — 4001 lines (1 over hard threshold)
+# D-442(e) hard threshold: >4000 lines → block_pre call + exit 2
+#
+# AC-3: exit 2 (block) when lessons.md has 4001 lines
+# AC-7: block message contains "D-442(e)" citation and "compact-lessons" remediation hint
+#
+# Red gate: all tests skip pending implementation of the lessons.md arm.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../../../.." && pwd)"
+  HOOK="${REPO_ROOT}/plugins/vsdd-factory/hooks/validate-state-size.sh"
+  WORK="$(mktemp -d)"
+  mkdir -p "${WORK}/.factory/cycles/v1.0-test"
+}
+
+teardown() {
+  rm -rf "${WORK}"
+}
+
+_make_lessons_md() {
+  local line_count="$1"
+  local path="$2"
+  seq "${line_count}" > "${path}"
+}
+
+# ---------------------------------------------------------------------------
+# AC-3: 4001-line lessons.md → exit 2
+# Traces to BC-7.04.051 extension L4; D-442(e) hard=4000
+# ---------------------------------------------------------------------------
+
+@test "AC-3 BLOCK: 4001-line lessons.md exits 2 (hard block threshold exceeded)" {
+  skip "pending lessons.md arm implementation (S-15.16-Part-B T-6)"
+
+  local lessons_path="${WORK}/.factory/cycles/v1.0-test/lessons.md"
+  _make_lessons_md 4001 "${lessons_path}"
+
+  local payload
+  payload="$(jq -nc --arg fp "${lessons_path}" '{tool_input: {file_path: $fp}}')"
+
+  run bash -c "printf '%s' '${payload}' | bash '${HOOK}' 2>/tmp/stderr-ac3-$$"
+  local stderr_content
+  stderr_content="$(cat /tmp/stderr-ac3-$$ 2>/dev/null || true)"
+  rm -f /tmp/stderr-ac3-$$
+
+  # Exit 2: hard block
+  [ "${status}" -eq 2 ]
+
+  # Block signal must be present on stderr
+  [[ "${stderr_content}" == *"BLOCKED"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# AC-7: block message contains D-442(e) citation and compact-lessons hint
+# Traces to BC-7.04.051 extension L4 (block_pre message content)
+# ---------------------------------------------------------------------------
+
+@test "AC-7 BLOCK: 4001-line lessons.md block message contains D-442(e) and compact-lessons" {
+  skip "pending lessons.md arm implementation (S-15.16-Part-B T-6)"
+
+  local lessons_path="${WORK}/.factory/cycles/v1.0-test/lessons.md"
+  _make_lessons_md 4001 "${lessons_path}"
+
+  local payload
+  payload="$(jq -nc --arg fp "${lessons_path}" '{tool_input: {file_path: $fp}}')"
+
+  run bash -c "printf '%s' '${payload}' | bash '${HOOK}' 2>/tmp/stderr-ac7-$$"
+  local stderr_content
+  stderr_content="$(cat /tmp/stderr-ac7-$$ 2>/dev/null || true)"
+  rm -f /tmp/stderr-ac7-$$
+
+  # Exit 2: hard block
+  [ "${status}" -eq 2 ]
+
+  # Block message must cite D-442(e) so state-manager knows WHY
+  [[ "${stderr_content}" == *"D-442(e)"* ]]
+
+  # Block message must include compact-lessons remediation hint
+  [[ "${stderr_content}" == *"compact-lessons"* ]]
+}

--- a/plugins/vsdd-factory/tests/validate-state-size/fail-lessons-hard-threshold.bats
+++ b/plugins/vsdd-factory/tests/validate-state-size/fail-lessons-hard-threshold.bats
@@ -33,8 +33,6 @@ _make_lessons_md() {
 # ---------------------------------------------------------------------------
 
 @test "AC-3 BLOCK: 4001-line lessons.md exits 2 (hard block threshold exceeded)" {
-  skip "pending lessons.md arm implementation (S-15.16-Part-B T-6)"
-
   local lessons_path="${WORK}/.factory/cycles/v1.0-test/lessons.md"
   _make_lessons_md 4001 "${lessons_path}"
 
@@ -59,8 +57,6 @@ _make_lessons_md() {
 # ---------------------------------------------------------------------------
 
 @test "AC-7 BLOCK: 4001-line lessons.md block message contains D-442(e) and compact-lessons" {
-  skip "pending lessons.md arm implementation (S-15.16-Part-B T-6)"
-
   local lessons_path="${WORK}/.factory/cycles/v1.0-test/lessons.md"
   _make_lessons_md 4001 "${lessons_path}"
 

--- a/plugins/vsdd-factory/tests/validate-state-size/pass-lessons-compaction-allowed.bats
+++ b/plugins/vsdd-factory/tests/validate-state-size/pass-lessons-compaction-allowed.bats
@@ -41,8 +41,6 @@ teardown() {
 # ---------------------------------------------------------------------------
 
 @test "AC-4 PASS: compaction write (6000→5000 lines) exits 0 unconditionally despite exceeding hard threshold" {
-  skip "pending lessons.md arm implementation (S-15.16-Part-B T-6)"
-
   local lessons_path="${WORK}/.factory/cycles/v1.0-test/lessons.md"
 
   # Write 5000 lines (above 4000 hard threshold, but REDUCING from 6000 committed)

--- a/plugins/vsdd-factory/tests/validate-state-size/pass-lessons-compaction-allowed.bats
+++ b/plugins/vsdd-factory/tests/validate-state-size/pass-lessons-compaction-allowed.bats
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+# pass-lessons-compaction-allowed.bats — AC-4: compaction-in-progress → exit 0 unconditionally
+#
+# Traces to: BC-7.04.051 invariant (compaction-always-allowed); extension L2
+# Canonical test vector: EC-004 — write reduces lessons.md from 6000 to 5000 lines
+#
+# When LINE_COUNT < PRIOR_COUNT (prior = git HEAD line count), the hook must exit 0
+# unconditionally regardless of absolute line count (5000 > 4000 but it's REDUCING).
+#
+# Fixture: temp git repo with lessons.md committed at 6000 lines.
+# Test: modify lessons.md to 5000 lines (still above hard threshold) then invoke hook.
+# Expected: exit 0 (compaction exemption applies).
+#
+# Red gate: all tests skip pending implementation of the lessons.md arm.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../../../.." && pwd)"
+  HOOK="${REPO_ROOT}/plugins/vsdd-factory/hooks/validate-state-size.sh"
+  WORK="$(mktemp -d)"
+  # Build a minimal git repo that simulates .factory/cycles/*/lessons.md
+  mkdir -p "${WORK}/.factory/cycles/v1.0-test"
+
+  # Initialize git repo at WORK so git commands resolve correctly
+  git -C "${WORK}" init -q
+  git -C "${WORK}" config user.email "test@example.com"
+  git -C "${WORK}" config user.name "Test"
+
+  # Commit lessons.md at 6000 lines (the "prior" state)
+  seq 6000 > "${WORK}/.factory/cycles/v1.0-test/lessons.md"
+  git -C "${WORK}" add "${WORK}/.factory/cycles/v1.0-test/lessons.md"
+  git -C "${WORK}" commit -q -m "prior: lessons.md at 6000 lines"
+}
+
+teardown() {
+  rm -rf "${WORK}"
+}
+
+# ---------------------------------------------------------------------------
+# AC-4: lessons.md write REDUCES line count (compaction) → exit 0 always
+# Traces to BC-7.04.051 invariant (compaction-always-allowed); extension L2
+# ---------------------------------------------------------------------------
+
+@test "AC-4 PASS: compaction write (6000→5000 lines) exits 0 unconditionally despite exceeding hard threshold" {
+  skip "pending lessons.md arm implementation (S-15.16-Part-B T-6)"
+
+  local lessons_path="${WORK}/.factory/cycles/v1.0-test/lessons.md"
+
+  # Write 5000 lines (above 4000 hard threshold, but REDUCING from 6000 committed)
+  seq 5000 > "${lessons_path}"
+
+  local payload
+  payload="$(jq -nc --arg fp "${lessons_path}" '{tool_input: {file_path: $fp}}')"
+
+  run bash -c "printf '%s' '${payload}' | bash '${HOOK}' 2>/tmp/stderr-ac4-$$"
+  local stderr_content
+  stderr_content="$(cat /tmp/stderr-ac4-$$ 2>/dev/null || true)"
+  rm -f /tmp/stderr-ac4-$$
+
+  # Exit 0: compaction always allowed
+  [ "${status}" -eq 0 ]
+
+  # Must NOT block (compaction exemption)
+  [[ "${stderr_content}" != *"BLOCKED"* ]]
+}

--- a/plugins/vsdd-factory/tests/validate-state-size/pass-lessons-exact-3500.bats
+++ b/plugins/vsdd-factory/tests/validate-state-size/pass-lessons-exact-3500.bats
@@ -31,8 +31,6 @@ _make_lessons_md() {
 # ---------------------------------------------------------------------------
 
 @test "AC-8 PASS: exactly 3500-line lessons.md exits 0 with no warning (boundary: >3500 not >=3500)" {
-  skip "pending lessons.md arm implementation (S-15.16-Part-B T-6)"
-
   local lessons_path="${WORK}/.factory/cycles/v1.0-test/lessons.md"
   _make_lessons_md 3500 "${lessons_path}"
 

--- a/plugins/vsdd-factory/tests/validate-state-size/pass-lessons-exact-3500.bats
+++ b/plugins/vsdd-factory/tests/validate-state-size/pass-lessons-exact-3500.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+# pass-lessons-exact-3500.bats — AC-8: exactly 3500 lines → exit 0 (strict >3500 boundary)
+#
+# Traces to: BC-7.04.051 extension: strict greater-than for soft threshold
+# Canonical test vector: EC-006 — exactly 3500 lines (boundary)
+# D-442(e) soft threshold is STRICTLY greater-than 3500 (not ≥3500).
+# At exactly 3500 lines, the hook must exit 0 with NO warning.
+#
+# Red gate: all tests skip pending implementation of the lessons.md arm.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../../../.." && pwd)"
+  HOOK="${REPO_ROOT}/plugins/vsdd-factory/hooks/validate-state-size.sh"
+  WORK="$(mktemp -d)"
+  mkdir -p "${WORK}/.factory/cycles/v1.0-test"
+}
+
+teardown() {
+  rm -rf "${WORK}"
+}
+
+_make_lessons_md() {
+  local line_count="$1"
+  local path="$2"
+  seq "${line_count}" > "${path}"
+}
+
+# ---------------------------------------------------------------------------
+# AC-8: exactly 3500 lines → exit 0, no warning (strict > not >=)
+# Traces to BC-7.04.051 extension: strict greater-than for soft threshold
+# ---------------------------------------------------------------------------
+
+@test "AC-8 PASS: exactly 3500-line lessons.md exits 0 with no warning (boundary: >3500 not >=3500)" {
+  skip "pending lessons.md arm implementation (S-15.16-Part-B T-6)"
+
+  local lessons_path="${WORK}/.factory/cycles/v1.0-test/lessons.md"
+  _make_lessons_md 3500 "${lessons_path}"
+
+  local payload
+  payload="$(jq -nc --arg fp "${lessons_path}" '{tool_input: {file_path: $fp}}')"
+
+  run bash -c "printf '%s' '${payload}' | bash '${HOOK}' 2>/tmp/stderr-ac8-$$"
+  local stderr_content
+  stderr_content="$(cat /tmp/stderr-ac8-$$ 2>/dev/null || true)"
+  rm -f /tmp/stderr-ac8-$$
+
+  # Exit 0: exactly 3500 is NOT above the soft threshold (strict >3500)
+  [ "${status}" -eq 0 ]
+
+  # No warning emitted (exactly at boundary, not over it)
+  [[ "${stderr_content}" != *"LESSONS.MD SIZE WARNING"* ]]
+
+  # No block signal
+  [[ "${stderr_content}" != *"BLOCKED"* ]]
+}

--- a/plugins/vsdd-factory/tests/validate-state-size/pass-lessons-within-threshold.bats
+++ b/plugins/vsdd-factory/tests/validate-state-size/pass-lessons-within-threshold.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+# pass-lessons-within-threshold.bats — AC-1: 925-line lessons.md → exit 0 (clean pass)
+#
+# Traces to: BC-7.04.051 extension L5 (Pass within threshold)
+# Canonical test vector: EC-001 — 925 lines, well within ≤3500 range
+#
+# When the lessons.md arm is implemented (T-6 of S-15.16-Part-B), the script will
+# actively match the lessons.md path, check line count (925 ≤ 3500), and exit 0
+# with NO warning on stderr.
+#
+# Red gate: all tests skip pending implementation of the lessons.md arm.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../../../.." && pwd)"
+  HOOK="${REPO_ROOT}/plugins/vsdd-factory/hooks/validate-state-size.sh"
+  WORK="$(mktemp -d)"
+  mkdir -p "${WORK}/.factory/cycles/v1.0-test"
+}
+
+teardown() {
+  rm -rf "${WORK}"
+}
+
+_make_lessons_md() {
+  local line_count="$1"
+  local path="$2"
+  seq "${line_count}" > "${path}"
+}
+
+# ---------------------------------------------------------------------------
+# AC-1: 925-line lessons.md → exit 0 (no warning, no block)
+# Traces to BC-7.04.051 extension L5
+# ---------------------------------------------------------------------------
+
+@test "AC-1 PASS: 925-line lessons.md exits 0 with no stderr output (within threshold)" {
+  skip "pending lessons.md arm implementation (S-15.16-Part-B T-6)"
+
+  local lessons_path="${WORK}/.factory/cycles/v1.0-test/lessons.md"
+  _make_lessons_md 925 "${lessons_path}"
+
+  local payload
+  payload="$(jq -nc --arg fp "${lessons_path}" '{tool_input: {file_path: $fp}}')"
+
+  run bash -c "printf '%s' '${payload}' | bash '${HOOK}' 2>/tmp/stderr-ac1-$$"
+  local stderr_content
+  stderr_content="$(cat /tmp/stderr-ac1-$$ 2>/dev/null || true)"
+  rm -f /tmp/stderr-ac1-$$
+
+  # Exit 0: clean pass, no block
+  [ "${status}" -eq 0 ]
+
+  # No warning on stderr: script actively processed the file and found it within threshold
+  [[ "${stderr_content}" != *"LESSONS.MD SIZE WARNING"* ]]
+  [[ "${stderr_content}" != *"BLOCKED"* ]]
+}

--- a/plugins/vsdd-factory/tests/validate-state-size/pass-lessons-within-threshold.bats
+++ b/plugins/vsdd-factory/tests/validate-state-size/pass-lessons-within-threshold.bats
@@ -33,8 +33,6 @@ _make_lessons_md() {
 # ---------------------------------------------------------------------------
 
 @test "AC-1 PASS: 925-line lessons.md exits 0 with no stderr output (within threshold)" {
-  skip "pending lessons.md arm implementation (S-15.16-Part-B T-6)"
-
   local lessons_path="${WORK}/.factory/cycles/v1.0-test/lessons.md"
   _make_lessons_md 925 "${lessons_path}"
 

--- a/plugins/vsdd-factory/tests/validate-state-size/pass-non-lessons-no-trigger.bats
+++ b/plugins/vsdd-factory/tests/validate-state-size/pass-non-lessons-no-trigger.bats
@@ -26,8 +26,6 @@ teardown() {
 # ---------------------------------------------------------------------------
 
 @test "AC-5 PASS: lessons-backup.md path does not trigger lessons.md arm (exit 0, no output)" {
-  skip "pending lessons.md arm implementation (S-15.16-Part-B T-6)"
-
   # lessons-backup.md with >4000 lines — would block if lessons.md arm incorrectly matched it
   local backup_path="${WORK}/.factory/cycles/v1.0-test/lessons-backup.md"
   seq 4001 > "${backup_path}"

--- a/plugins/vsdd-factory/tests/validate-state-size/pass-non-lessons-no-trigger.bats
+++ b/plugins/vsdd-factory/tests/validate-state-size/pass-non-lessons-no-trigger.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+# pass-non-lessons-no-trigger.bats — AC-5: non-lessons.md path → exit 0 (no arm fires)
+#
+# Traces to: BC-7.04.051 extension L6 (Non-target file)
+# Canonical test vector: EC-005 — file path is lessons-backup.md (not lessons.md)
+#
+# The lessons.md arm must only fire when FILE_PATH matches */.factory/cycles/*/lessons.md.
+# A file named lessons-backup.md in the same directory must NOT trigger the arm.
+#
+# Red gate: all tests skip pending implementation of the lessons.md arm.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../../../.." && pwd)"
+  HOOK="${REPO_ROOT}/plugins/vsdd-factory/hooks/validate-state-size.sh"
+  WORK="$(mktemp -d)"
+  mkdir -p "${WORK}/.factory/cycles/v1.0-test"
+}
+
+teardown() {
+  rm -rf "${WORK}"
+}
+
+# ---------------------------------------------------------------------------
+# AC-5: lessons-backup.md path → exit 0 (path check rejects non-lessons.md)
+# Traces to BC-7.04.051 extension L6
+# ---------------------------------------------------------------------------
+
+@test "AC-5 PASS: lessons-backup.md path does not trigger lessons.md arm (exit 0, no output)" {
+  skip "pending lessons.md arm implementation (S-15.16-Part-B T-6)"
+
+  # lessons-backup.md with >4000 lines — would block if lessons.md arm incorrectly matched it
+  local backup_path="${WORK}/.factory/cycles/v1.0-test/lessons-backup.md"
+  seq 4001 > "${backup_path}"
+
+  local payload
+  payload="$(jq -nc --arg fp "${backup_path}" '{tool_input: {file_path: $fp}}')"
+
+  run bash -c "printf '%s' '${payload}' | bash '${HOOK}' 2>/tmp/stderr-ac5-$$"
+  local stderr_content
+  stderr_content="$(cat /tmp/stderr-ac5-$$ 2>/dev/null || true)"
+  rm -f /tmp/stderr-ac5-$$
+
+  # Exit 0: non-target path → immediate exit 0 (no arm fires)
+  [ "${status}" -eq 0 ]
+
+  # No block signal and no warning (arm did not fire at all)
+  [[ "${stderr_content}" != *"BLOCKED"* ]]
+  [[ "${stderr_content}" != *"LESSONS.MD SIZE WARNING"* ]]
+}

--- a/plugins/vsdd-factory/tests/validate-state-size/pass-state-md-non-regression.bats
+++ b/plugins/vsdd-factory/tests/validate-state-size/pass-state-md-non-regression.bats
@@ -1,0 +1,97 @@
+#!/usr/bin/env bats
+# pass-state-md-non-regression.bats — AC-6: STATE.md arm unchanged after lessons.md extension
+#
+# Traces to: BC-7.04.051 non-regression invariants
+# Canonical test vector: EC-011 — STATE.md write with 400 lines (within threshold)
+#
+# After the T-6 refactor (routing via $TARGET variable), the STATE.md arm behavior
+# must remain byte-for-byte identical to the original script. This test exercises
+# the STATE.md path with a 400-line file (within STATE.md's 500-line limit) to confirm
+# the existing arm still exits 0 cleanly after the refactor.
+#
+# AC-6 tests the EXISTING behavior (STATE.md arm) — it invokes the CURRENT script
+# and verifies the non-regression baseline before and after the lessons.md arm is added.
+#
+# Note: this is the only test in this suite NOT marked skip. It tests existing behavior
+# that the current (unmodified) script already handles correctly. It serves as the
+# non-regression anchor: if this test breaks after T-6 refactor, the implementer
+# has broken the STATE.md arm.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../../../.." && pwd)"
+  HOOK="${REPO_ROOT}/plugins/vsdd-factory/hooks/validate-state-size.sh"
+  WORK="$(mktemp -d)"
+  # Build a minimal git repo so git show HEAD doesn't produce errors
+  git -C "${WORK}" init -q
+  git -C "${WORK}" config user.email "test@example.com"
+  git -C "${WORK}" config user.name "Test"
+  mkdir -p "${WORK}/.factory"
+}
+
+teardown() {
+  rm -rf "${WORK}"
+}
+
+# ---------------------------------------------------------------------------
+# AC-6a: 400-line STATE.md → exit 0 (within 500-line limit, no warning at 400)
+# Traces to BC-7.04.051 existing STATE.md arm (non-regression)
+# ---------------------------------------------------------------------------
+
+@test "AC-6a NON-REGRESSION: 400-line STATE.md exits 0 after lessons.md arm refactor (STATE.md arm unchanged)" {
+  local state_path="${WORK}/.factory/STATE.md"
+
+  # 400 lines: above the 200-line advisory but below the 500-line block limit
+  # The current script emits a STATE.md SIZE WARNING at >200 lines.
+  seq 400 > "${state_path}"
+
+  # Commit so git show HEAD doesn't return an error (PRIOR_COUNT defaults to 0 if no commit)
+  git -C "${WORK}" add "${WORK}/.factory/STATE.md"
+  git -C "${WORK}" commit -q -m "state: 400 lines"
+
+  local payload
+  payload="$(jq -nc --arg fp "${state_path}" '{tool_input: {file_path: $fp}}')"
+
+  run bash -c "printf '%s' '${payload}' | bash '${HOOK}' 2>/tmp/stderr-ac6a-$$"
+  local stderr_content
+  stderr_content="$(cat /tmp/stderr-ac6a-$$ 2>/dev/null || true)"
+  rm -f /tmp/stderr-ac6a-$$
+
+  # Exit 0: advisory warning, not a block
+  [ "${status}" -eq 0 ]
+
+  # STATE.md arm emits a warning at >200 lines
+  [[ "${stderr_content}" == *"STATE.md SIZE WARNING"* ]]
+
+  # Must NOT emit LESSONS.MD warning (wrong arm)
+  [[ "${stderr_content}" != *"LESSONS.MD SIZE WARNING"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# AC-6b: 600-line STATE.md → exit 2 (exceeds 500-line block limit)
+# Traces to BC-7.04.051 existing STATE.md arm (non-regression — block path)
+# ---------------------------------------------------------------------------
+
+@test "AC-6b NON-REGRESSION: 600-line STATE.md exits 2 (BLOCKED) after lessons.md arm refactor" {
+  local state_path="${WORK}/.factory/STATE.md"
+
+  # 600 lines: above the 500-line block threshold
+  seq 600 > "${state_path}"
+
+  # Do NOT commit: PRIOR_COUNT defaults to 0; LINE_COUNT (600) > PRIOR_COUNT (0) → check thresholds
+  local payload
+  payload="$(jq -nc --arg fp "${state_path}" '{tool_input: {file_path: $fp}}')"
+
+  run bash -c "printf '%s' '${payload}' | bash '${HOOK}' 2>/tmp/stderr-ac6b-$$"
+  local stderr_content
+  stderr_content="$(cat /tmp/stderr-ac6b-$$ 2>/dev/null || true)"
+  rm -f /tmp/stderr-ac6b-$$
+
+  # Exit 2: hard block (STATE.md exceeds 500-line limit)
+  [ "${status}" -eq 2 ]
+
+  # Block message present
+  [[ "${stderr_content}" == *"BLOCKED"* ]]
+
+  # Block message references STATE.md (not lessons.md)
+  [[ "${stderr_content}" == *"STATE.md"* ]]
+}

--- a/plugins/vsdd-factory/tests/validate-state-size/warn-lessons-exact-4000.bats
+++ b/plugins/vsdd-factory/tests/validate-state-size/warn-lessons-exact-4000.bats
@@ -31,8 +31,6 @@ _make_lessons_md() {
 # ---------------------------------------------------------------------------
 
 @test "AC-9 WARN: exactly 4000-line lessons.md exits 0 with advisory warning (boundary: >4000 not >=4000 for block)" {
-  skip "pending lessons.md arm implementation (S-15.16-Part-B T-6)"
-
   local lessons_path="${WORK}/.factory/cycles/v1.0-test/lessons.md"
   _make_lessons_md 4000 "${lessons_path}"
 

--- a/plugins/vsdd-factory/tests/validate-state-size/warn-lessons-exact-4000.bats
+++ b/plugins/vsdd-factory/tests/validate-state-size/warn-lessons-exact-4000.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+# warn-lessons-exact-4000.bats — AC-9: exactly 4000 lines → exit 0 + warning (strict >4000 for block)
+#
+# Traces to: BC-7.04.051 extension: strict greater-than for hard threshold
+# Canonical test vector: EC-007 — exactly 4000 lines (block boundary)
+# D-442(e) hard threshold is STRICTLY greater-than 4000 (not ≥4000).
+# At exactly 4000 lines: advisory warning only (>3500), NOT a block (not >4000).
+#
+# Red gate: all tests skip pending implementation of the lessons.md arm.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../../../.." && pwd)"
+  HOOK="${REPO_ROOT}/plugins/vsdd-factory/hooks/validate-state-size.sh"
+  WORK="$(mktemp -d)"
+  mkdir -p "${WORK}/.factory/cycles/v1.0-test"
+}
+
+teardown() {
+  rm -rf "${WORK}"
+}
+
+_make_lessons_md() {
+  local line_count="$1"
+  local path="$2"
+  seq "${line_count}" > "${path}"
+}
+
+# ---------------------------------------------------------------------------
+# AC-9: exactly 4000 lines → exit 0 + warning (NOT a block; strict >4000)
+# Traces to BC-7.04.051 extension: strict greater-than for hard threshold
+# ---------------------------------------------------------------------------
+
+@test "AC-9 WARN: exactly 4000-line lessons.md exits 0 with advisory warning (boundary: >4000 not >=4000 for block)" {
+  skip "pending lessons.md arm implementation (S-15.16-Part-B T-6)"
+
+  local lessons_path="${WORK}/.factory/cycles/v1.0-test/lessons.md"
+  _make_lessons_md 4000 "${lessons_path}"
+
+  local payload
+  payload="$(jq -nc --arg fp "${lessons_path}" '{tool_input: {file_path: $fp}}')"
+
+  run bash -c "printf '%s' '${payload}' | bash '${HOOK}' 2>/tmp/stderr-ac9-$$"
+  local stderr_content
+  stderr_content="$(cat /tmp/stderr-ac9-$$ 2>/dev/null || true)"
+  rm -f /tmp/stderr-ac9-$$
+
+  # Exit 0: exactly 4000 is NOT above the hard threshold (strict >4000); advisory only
+  [ "${status}" -eq 0 ]
+
+  # Warning emitted (4000 > 3500 soft threshold, so advisory fires)
+  [[ "${stderr_content}" == *"LESSONS.MD SIZE WARNING"* ]]
+
+  # Must NOT be a block (the block threshold is >4000, not >=4000)
+  [[ "${stderr_content}" != *"BLOCKED"* ]]
+}

--- a/plugins/vsdd-factory/tests/validate-state-size/warn-lessons-soft-threshold.bats
+++ b/plugins/vsdd-factory/tests/validate-state-size/warn-lessons-soft-threshold.bats
@@ -30,8 +30,6 @@ _make_lessons_md() {
 # ---------------------------------------------------------------------------
 
 @test "AC-2 WARN: 3501-line lessons.md exits 0 with LESSONS.MD SIZE WARNING on stderr" {
-  skip "pending lessons.md arm implementation (S-15.16-Part-B T-6)"
-
   local lessons_path="${WORK}/.factory/cycles/v1.0-test/lessons.md"
   _make_lessons_md 3501 "${lessons_path}"
 

--- a/plugins/vsdd-factory/tests/validate-state-size/warn-lessons-soft-threshold.bats
+++ b/plugins/vsdd-factory/tests/validate-state-size/warn-lessons-soft-threshold.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+# warn-lessons-soft-threshold.bats — AC-2: 3501-line lessons.md → exit 0 + stderr warning
+#
+# Traces to: BC-7.04.051 extension L3 (Soft advisory at >3500)
+# Canonical test vector: EC-002 — 3501 lines (1 over soft threshold)
+# D-442(e) soft threshold: >3500 lines → stderr warning + exit 0 (NOT a block)
+#
+# Red gate: all tests skip pending implementation of the lessons.md arm.
+
+setup() {
+  REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../../../.." && pwd)"
+  HOOK="${REPO_ROOT}/plugins/vsdd-factory/hooks/validate-state-size.sh"
+  WORK="$(mktemp -d)"
+  mkdir -p "${WORK}/.factory/cycles/v1.0-test"
+}
+
+teardown() {
+  rm -rf "${WORK}"
+}
+
+_make_lessons_md() {
+  local line_count="$1"
+  local path="$2"
+  seq "${line_count}" > "${path}"
+}
+
+# ---------------------------------------------------------------------------
+# AC-2: 3501-line lessons.md → exit 0 + "LESSONS.MD SIZE WARNING" on stderr
+# Traces to BC-7.04.051 extension L3; D-442(e) soft=3500
+# ---------------------------------------------------------------------------
+
+@test "AC-2 WARN: 3501-line lessons.md exits 0 with LESSONS.MD SIZE WARNING on stderr" {
+  skip "pending lessons.md arm implementation (S-15.16-Part-B T-6)"
+
+  local lessons_path="${WORK}/.factory/cycles/v1.0-test/lessons.md"
+  _make_lessons_md 3501 "${lessons_path}"
+
+  local payload
+  payload="$(jq -nc --arg fp "${lessons_path}" '{tool_input: {file_path: $fp}}')"
+
+  run bash -c "printf '%s' '${payload}' | bash '${HOOK}' 2>/tmp/stderr-ac2-$$"
+  local stderr_content
+  stderr_content="$(cat /tmp/stderr-ac2-$$ 2>/dev/null || true)"
+  rm -f /tmp/stderr-ac2-$$
+
+  # Exit 0: advisory only, not a block
+  [ "${status}" -eq 0 ]
+
+  # stderr must contain the advisory marker
+  [[ "${stderr_content}" == *"LESSONS.MD SIZE WARNING"* ]]
+
+  # Must NOT be a block signal
+  [[ "${stderr_content}" != *"BLOCKED"* ]]
+}


### PR DESCRIPTION
## Summary

- Extends `validate-state-size.sh` with a lessons.md arm using `$TARGET` routing variable
- **Soft advisory** at >3500 lines (stderr warning, exit 0)
- **Hard block** at >4000 lines (`block_pre`, exit 2) — prevents WASM fuel exhaustion per D-442(e)
- **Compaction exemption** preserved: writes that reduce line count always pass
- STATE.md arm behavior **unchanged** (structural refactor only)
- Adds `docs-completeness` and `validate-dispatch-advance` test directories to `run-all.sh` glob (pre-existing gap)

## Test Evidence

10 bats tests (8 new + 2 non-regression), all passing:
- AC-1: 925 lines → clean pass
- AC-2: 3501 lines → advisory warning
- AC-3/AC-7: 4001 lines → hard block with D-442(e) citation
- AC-4: compaction (6000→5000) → always allowed
- AC-5: non-target path (`lessons-backup.md`) → ignored
- AC-6a/AC-6b: STATE.md non-regression (400-line pass, 600-line block)
- AC-8: exactly 3500 → clean pass (strict >3500)
- AC-9: exactly 4000 → advisory only (strict >4000 for block)

## Adversary Convergence

LOCAL cascade: 5 passes, trajectory 1C→1M→0→0→0. CONVERGED 3/3 per BC-5.39.001.
- Pass-1: `run-all.sh` missing glob (CRITICAL) → fixed
- Pass-2: `docs-completeness` missing from glob (MEDIUM) → fixed
- Passes 3-5: CLEAN

## Closes

- D-442(e) structural risk (WASM fuel exhaustion on large lessons.md)
- BC-7.04.051 behavioral extension (L1-L6 postconditions)
- S-15.03 PRIORITY-A M3 wave (S-15.16-Part-B)