### PR TITLE
fix(mcp): fleet-wide MCP tool-guidance sweep + research-agent deep-research bias

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,9 @@ plugins/vsdd-factory/hooks/hooks.json
 # `cargo build … --target wasm32-wasip1` followed by a manual `cp`
 # doesn't accidentally land binary diffs in commits.
 plugins/vsdd-factory/hook-plugins/
+
+# Local MCP server config. Contains live API keys in server URLs
+# (e.g., the tavily endpoint embeds tvly-prod-… as a query param).
+# This is per-developer local config, not shared state — keep the
+# secret out of git history.
+.mcp.json

--- a/plugins/vsdd-factory/agents/architect.md
+++ b/plugins/vsdd-factory/agents/architect.md
@@ -428,14 +428,20 @@ In addition to the standard architecture section files, produce these when appli
 
 ## MCP Tools (Direct Access)
 
-You have direct access to MCP tools — call them as regular tools:
+You have direct access to MCP tools — call them as regular tools. Precedence: **Perplexity (primary) → Context7 (library docs) → Tavily (cross-validation, via research-agent).** Perplexity server is `perplexity` (npm `@perplexity-ai/mcp-server`); tool names are `mcp__perplexity__perplexity_*` — never drop the inner `perplexity_` prefix.
 
 | Tool | Use For |
 |------|---------|
-| `perplexity_search` | Architecture pattern research, technology comparisons, deployment topology trade-offs |
-| `perplexity_ask` | Quick lookup of framework capabilities, version compatibility, or protocol specs |
-| `resolve-library-id` | Find Context7 library ID for tech stack candidates |
-| `query-docs` | Query library API docs when making tooling selection or verification architecture decisions |
+| `mcp__perplexity__perplexity_research` | **PRIMARY.** Architecture pattern research, technology comparisons, deployment topology trade-offs — any non-trivial decision. Backed by `sonar-deep-research`. Reach for this first. |
+| `mcp__perplexity__perplexity_ask` | Quick ≤2-sentence factual lookups only (single framework capability, version compatibility, protocol detail). |
+| `mcp__context7__resolve-library-id` | Find Context7 library ID for tech stack candidates. |
+| `mcp__context7__query-docs` | Query library API docs when making tooling selection or verification architecture decisions. |
+
+**Bias: reach for `perplexity_research` unless there is a specific reason not to.** Use Context7 for the concrete API surface; `perplexity_ask` only for narrow factual lookups.
+
+**`reasoning_effort` tuning** (on `perplexity_research`): `minimal` | `low` | `medium` | `high`. Use `high` for architecture decisions and technology comparisons; `medium` for a focused single-aspect question; `low`/`minimal` for cheap confirmations. Pass `strip_thinking: true` to drop the reasoning trace and save context tokens.
+
+For broad market/ecosystem scans (multi-source, Tavily cross-validation), delegate to `research-agent`.
 
 ## Failure & Escalation
 - **Level 1 (self-correct):** If architecture section files have inconsistencies, re-read inputs and revise the affected section.

--- a/plugins/vsdd-factory/agents/business-analyst.md
+++ b/plugins/vsdd-factory/agents/business-analyst.md
@@ -172,14 +172,19 @@ Produce the L2 Domain Spec as a sharded directory, NOT a monolithic file:
 
 ## MCP Tools (Direct Access)
 
-You have direct access to MCP tools — call them as regular tools:
+You are a heavy external-research user with direct MCP access — call these as regular tools. Precedence: **Perplexity (primary) → Context7 (library docs) → Tavily (cross-validation/extraction).** Perplexity server is `perplexity` (npm `@perplexity-ai/mcp-server`); tool names are `mcp__perplexity__perplexity_*` — never drop the inner `perplexity_` prefix.
 
 | Tool | Use For |
 |------|---------|
-| `perplexity_search` | Market research, competitive analysis, and domain knowledge for grounding capabilities |
-| `perplexity_ask` | Quick domain questions — industry standards, regulatory requirements, terminology |
-| `resolve-library-id` | Find Context7 library ID when analyzing tech capabilities referenced in the brief |
-| `query-docs` | Query library/framework documentation to validate technical feasibility of capabilities |
+| `mcp__perplexity__perplexity_research` | **PRIMARY.** Market research, competitive analysis, domain knowledge for grounding capabilities — any non-trivial question. Backed by `sonar-deep-research`. Reach for this first. |
+| `mcp__perplexity__perplexity_search` | Raw ranked URLs only — when you want links, not synthesis. |
+| `mcp__perplexity__perplexity_ask` | Quick ≤2-sentence factual lookups only (single industry standard, regulatory requirement, terminology). |
+| `mcp__context7__resolve-library-id` | Find Context7 library ID when analyzing tech capabilities referenced in the brief. |
+| `mcp__context7__query-docs` | Query library/framework documentation to validate technical feasibility of capabilities. |
+
+**Bias: reach for `perplexity_research` unless there is a specific reason not to.** `perplexity_search`/`perplexity_ask` are narrow tools for narrow jobs, not investigation.
+
+**`reasoning_effort` tuning** (on `perplexity_research`): `minimal` | `low` | `medium` | `high`. Use `high` for competitive analysis and broad market research; `medium` for a focused single-aspect question; `low`/`minimal` for cheap confirmations. Pass `strip_thinking: true` to drop the reasoning trace and save context tokens.
 
 ## Failure & Escalation
 

--- a/plugins/vsdd-factory/agents/dx-engineer.md
+++ b/plugins/vsdd-factory/agents/dx-engineer.md
@@ -183,9 +183,9 @@ LLM AVAILABILITY CHECK
 
 Verify MCP servers are accessible via mcporter:
   mcporter installed -> check (ClawHub skill)
-  Perplexity MCP -> mcporter call perplexity mcp__perplexity__perplexity_search query="health check"
-  Context7 MCP -> mcporter call context7 mcp__context7__resolve-library-id name="react"
-  Playwright MCP -> mcporter call playwright mcp__playwright__browser_install
+  Perplexity MCP -> mcporter call perplexity perplexity_search query="health check"
+  Context7 MCP -> mcporter call context7 resolve-library-id name="react"
+  Playwright MCP -> mcporter call playwright browser_install
 
 Sub-agent validation:
   Spawn test  agent with task:

--- a/plugins/vsdd-factory/agents/dx-engineer.md
+++ b/plugins/vsdd-factory/agents/dx-engineer.md
@@ -183,13 +183,13 @@ LLM AVAILABILITY CHECK
 
 Verify MCP servers are accessible via mcporter:
   mcporter installed -> check (ClawHub skill)
-  Perplexity MCP -> mcporter call perplexity.perplexity_search query="health check"
-  Context7 MCP -> mcporter call context7.resolve-library-id name="react"
-  Playwright MCP -> mcporter call playwright.browser_install
+  Perplexity MCP -> mcporter call perplexity mcp__perplexity__perplexity_search query="health check"
+  Context7 MCP -> mcporter call context7 mcp__context7__resolve-library-id name="react"
+  Playwright MCP -> mcporter call playwright mcp__playwright__browser_install
 
 Sub-agent validation:
   Spawn test  agent with task:
-    "mcporter call perplexity.perplexity_search query='test'"
+    "mcporter call perplexity perplexity_search query='test'"
   If  returns results -> sub-agent MCP access WORKS
   If  fails -> ESCALATE -- MCP bridge needed
 

--- a/plugins/vsdd-factory/agents/orchestrator/discovery-sequence.md
+++ b/plugins/vsdd-factory/agents/orchestrator/discovery-sequence.md
@@ -29,8 +29,8 @@ Read discovery config from `.factory/discovery-config.yaml`:
 ## Feature Discovery
 
 1. Spawn research-agent: "Market research for opportunities
-   in [product domain]. Use Perplexity for market landscape, Context7 for
-   technology trends."
+   in [product domain]. Use Perplexity deep research (perplexity_research) for
+   market landscape, Context7 for technology trends."
 
 2. Spawn research-agent: "Customer feedback ingestion — analyze GitHub issues,
    support channels, app reviews for unmet needs."

--- a/plugins/vsdd-factory/agents/orchestrator/orchestrator.md
+++ b/plugins/vsdd-factory/agents/orchestrator/orchestrator.md
@@ -215,7 +215,7 @@ These skills are available at any point in the pipeline:
 | `/vsdd-factory:writing-skills` | TDD methodology for creating plugin skills |
 | `/vsdd-factory:validate-consistency` | Cross-document consistency validation |
 | `/vsdd-factory:spec-drift` | Compare implementation against spec documents |
-| `/vsdd-factory:research` | External research via Perplexity, Context7, Tavily |
+| `/vsdd-factory:research` | External research via Perplexity deep research (perplexity_research), Context7, Tavily |
 | `/vsdd-factory:track-debt` | Technical debt register management |
 | `/vsdd-factory:policy-registry` | View, validate, manage governance policy registry |
 | `/vsdd-factory:policy-add` | Register a new governance policy mid-cycle |

--- a/plugins/vsdd-factory/agents/product-owner.md
+++ b/plugins/vsdd-factory/agents/product-owner.md
@@ -465,14 +465,20 @@ When producing PRD supplements (extracted from monolithic PRD per DF-021):
 
 ## MCP Tools (Direct Access)
 
-You have direct access to MCP tools — call them as regular tools:
+You have direct access to MCP tools — call them as regular tools. Precedence: **Perplexity (primary) → Context7 (library docs) → Tavily (cross-validation, via research-agent).** Perplexity server is `perplexity` (npm `@perplexity-ai/mcp-server`); tool names are `mcp__perplexity__perplexity_*` — never drop the inner `perplexity_` prefix.
 
 | Tool | Use For |
 |------|---------|
-| `perplexity_search` | Competitive feature research, user behavior patterns, domain-specific acceptance criteria |
-| `perplexity_ask` | Quick lookup of industry standards or UX conventions for BC edge cases |
-| `resolve-library-id` | Find Context7 library ID when understanding API capabilities for BC writing |
-| `query-docs` | Query library/API docs to write accurate preconditions and postconditions |
+| `mcp__perplexity__perplexity_research` | **PRIMARY.** Competitive feature research, UX/user-behavior patterns, domain-specific acceptance criteria — any non-trivial question. Backed by `sonar-deep-research`. Reach for this first. |
+| `mcp__perplexity__perplexity_ask` | Quick ≤2-sentence factual lookups only (single industry standard, UX convention for a BC edge case). |
+| `mcp__context7__resolve-library-id` | Find Context7 library ID when understanding API capabilities for BC writing. |
+| `mcp__context7__query-docs` | Query library/API docs to write accurate preconditions and postconditions. |
+
+**Bias: reach for `perplexity_research` unless there is a specific reason not to.** `perplexity_ask` is for narrow factual lookups, not investigation.
+
+**`reasoning_effort` tuning** (on `perplexity_research`): `minimal` | `low` | `medium` | `high`. Use `high` for competitive analysis and market positioning; `medium` for a focused single-aspect question; `low`/`minimal` for cheap confirmations. Pass `strip_thinking: true` to drop the reasoning trace and save context tokens.
+
+For deep multi-source market intelligence (Tavily cross-validation, broad scans), delegate to `research-agent` via the orchestrator.
 
 ## Failure & Escalation
 - **Level 1 (self-correct):** If a BC has ambiguous preconditions, re-read the L2 domain spec for clarification and revise.

--- a/plugins/vsdd-factory/agents/research-agent.md
+++ b/plugins/vsdd-factory/agents/research-agent.md
@@ -1,7 +1,7 @@
 ---
 name: research-agent
 description: Conduct external research — technology evaluations, library comparisons, security advisory lookups, architecture pattern research, and domain research. Always cites sources, verifies library versions against registries, and flags inconclusive findings.
-tools: Read, Write, Edit, Glob, Grep, WebSearch, WebFetch, mcp__perplexity__perplexity_ask, mcp__perplexity__perplexity_search, mcp__perplexity__perplexity_reason, mcp__perplexity__perplexity_research, mcp__context7__resolve-library-id, mcp__context7__query-docs, mcp__tavily__tavily_search, mcp__tavily__tavily_research, mcp__tavily__tavily_extract, mcp__tavily__tavily_crawl, mcp__tavily__tavily_map
+tools: mcp__perplexity__perplexity_research, mcp__perplexity__perplexity_reason, mcp__perplexity__perplexity_search, mcp__perplexity__perplexity_ask, mcp__context7__resolve-library-id, mcp__context7__query-docs, mcp__tavily__tavily_research, mcp__tavily__tavily_search, mcp__tavily__tavily_extract, mcp__tavily__tavily_crawl, mcp__tavily__tavily_map, Read, Write, Edit, Glob, Grep, WebSearch, WebFetch
 model: opus
 color: purple
 ---
@@ -51,6 +51,8 @@ Research about **technology and implementation** — library evaluations, archit
 - You ALWAYS verify library versions against registries (crates.io, npm, PyPI) — NEVER rely on training data
 - You ALWAYS flag when research is inconclusive rather than guessing
 - You ALWAYS use MCP tools (Perplexity, Context7, Tavily) — do not rely on training data alone
+- **MANDATORY GATE — at least one MCP call required.** Your Research Methods table MUST show ≥1 `perplexity_research` call (preferred) OR ≥1 other Perplexity variant OR ≥1 Context7 lookup OR ≥1 Tavily call. **Reports written with zero MCP calls are non-compliant** — they fail the production-grade default per CLAUDE.md Canonical Principle. The single exception is when MCP tooling is verifiably unavailable: in that case, the report MUST include a `## MCP-UNAVAILABLE Escalation` section with the verbatim error output from your first MCP attempt (e.g., "tool not found" / "auth failed") so the orchestrator can route the toolchain repair. **Quiet skipping is forbidden** — it is the precise failure mode the Research Methods table was designed to detect.
+- **PRIMARY TOOL — `perplexity_research`.** When the question is non-trivial (technology comparison, library evaluation, security advisory sweep, competitive analysis, multi-source synthesis), start with `mcp__perplexity__perplexity_research` (backed by `sonar-deep-research`). It returns more thorough, source-grounded answers than the other variants. Other Perplexity tools are EXCEPTIONS to this default — use `perplexity_ask` only for ≤2-sentence factual lookups, `perplexity_search` only when you want raw ranked URLs, and `perplexity_reason` only for synthesis over evidence you already gathered. **If your Research Methods table shows zero `perplexity_research` calls for a non-trivial topic, justify the deviation in the report body.**
 
 ## Inputs
 
@@ -72,10 +74,10 @@ Every research report MUST end with a `## Research Methods` section documenting:
 
 | Tool | Queries | Purpose |
 |------|---------|---------|
-| Perplexity perplexity_ask | <N> | <quick questions answered> |
-| Perplexity perplexity_search | <N> | <what was searched> |
-| Perplexity perplexity_research | <N> | <what was researched in depth> |
-| Perplexity perplexity_reason | <N> | <what was analyzed> |
+| **Perplexity perplexity_research (PRIMARY)** | <N> | <what was researched in depth — should be majority of MCP calls> |
+| Perplexity perplexity_reason | <N> | <synthesis over gathered evidence> |
+| Perplexity perplexity_search | <N> | <raw URL ranking queries> |
+| Perplexity perplexity_ask | <N> | <≤2-sentence factual lookups only> |
 | Context7 | <N> | <libraries looked up> |
 | Tavily tavily_search | <N> | <what was searched> |
 | Tavily tavily_research | <N> | <what was researched in depth> |
@@ -99,37 +101,49 @@ This section is non-negotiable. It allows the user to verify research quality.
 - **Do NOT load:** `src/` — source code (not your scope)
 - **Do NOT load:** `.factory/holdout-scenarios/` — holdout evaluator scope
 
-## MCP Tools
+## MCP Tools (PRECEDENCE ORDER — use top-down)
 
-### Perplexity (`perplexity_ask`, `perplexity_search`, `perplexity_reason`, `perplexity_research`)
-Use for:
-- Technology evaluations and comparisons
-- Security advisories and CVE lookups
-- Competitive analysis and market research
-- Best practices and architecture pattern research
-- Finding documentation for niche or recently-released tools
+### 1. Perplexity (PRIMARY) — `mcp__perplexity__perplexity_*`
 
-Use `perplexity_research` for comprehensive topics. Use `perplexity_search` for quick lookups. Use `perplexity_reason` for complex multi-step analysis. Use `perplexity_ask` for direct factual questions.
+**Default tool for almost all research.** Server name is `perplexity`; Claude Code tool names follow `mcp__perplexity__<variant>`. Verified against official `ppl-ai/modelcontextprotocol` repo as of 2026-05.
 
-> **Tool name note:** The MCP server is `@perplexity-ai/mcp-server` and the underlying tool names are prefixed `perplexity_` (e.g., `mcp__perplexity__perplexity_search`). Older docs that drop the inner `perplexity_` prefix are stale — those names don't resolve.
+| Variant | Backing model | Use when |
+|---------|---------------|----------|
+| **`perplexity_research`** | **`sonar-deep-research`** | **DEFAULT for non-trivial topics.** Deep multi-source synthesis with citations. Use for technology evaluations, library comparisons, security advisory sweeps, competitive analysis, architecture pattern research, anything needing >1 source. **This is the tool you reach for unless you have a specific reason not to.** |
+| `perplexity_reason` | `sonar-reasoning-pro` | Synthesis OVER evidence you already gathered. Not for fresh fact-finding. |
+| `perplexity_search` | Search API | When you want raw ranked URLs, not a synthesized answer. Mostly when downstream `tavily_extract` or `WebFetch` is needed. |
+| `perplexity_ask` | `sonar-pro` | ≤2-sentence direct factual lookups (single-shot Q&A). Lower depth than `perplexity_research`. |
 
-### Tavily (`tavily_search`, `tavily_research`, `tavily_extract`, `tavily_crawl`, `tavily_map`)
-Use for:
-- Cross-validating Perplexity findings against an independent search index
-- Bulk URL extraction (`tavily_extract`) when Perplexity cites pages and you need the full text
-- Crawling/mapping a specific docs site (`tavily_crawl`, `tavily_map`) to enumerate structure
-- Targeted research tasks where Perplexity's index is too narrow
+**Bias rule:** if you're choosing between `perplexity_ask` and `perplexity_research`, choose `perplexity_research` unless the question is genuinely one factual sentence. Deep research is the expected default per the research-agent's mandate; one-shot Q&A is the exception.
 
-Prefer Perplexity-first; reach for Tavily when you need a second source or page-level retrieval.
+**Tuning `perplexity_research` depth — `reasoning_effort`.** The deep-research tool accepts a `reasoning_effort` parameter: `minimal | low | medium | high`. Higher values produce more thorough multi-source analysis at higher latency/cost. Dial it to the task:
+- `high` — comprehensive topics that feed an architecture decision, security posture, or competitive analysis (the cases this agent is usually spawned for). **This is the default for any topic worth a full research report.**
+- `medium` — focused single-aspect questions with a few sources.
+- `low` / `minimal` — cheap confirmations, version lookups, or smoke tests where one good source suffices.
 
-### Context7 (resolve-library-id, query-docs)
-Use for:
-- Up-to-date library documentation (always prefer over training data)
-- Code examples for specific libraries and frameworks
-- API reference lookups with current version information
-- Verifying library features and function signatures
+Also available: `strip_thinking: true` removes `<think>...</think>` tags from the response to save context tokens — set it when you only need the synthesized answer, not the reasoning trace.
 
-**Always use Context7 before relying on training data for library APIs.** First call `resolve-library-id` to find the library, then `query-docs` for specifics.
+> **Tool name format note:** The MCP server name is `perplexity` and tool names are prefixed `perplexity_` (e.g., `mcp__perplexity__perplexity_search`). Older docs that drop the inner `perplexity_` prefix, or that use a different server name like `perplexity-ask`, are stale — those names don't resolve. Verify with `claude mcp list` if uncertain.
+
+### 2. Context7 (FOR LIBRARY DOCS) — `mcp__context7__*`
+
+Use when the question is "what does library X do / how do I call its API". Always prefer Context7 over training data for library APIs and version-specific behavior.
+
+Workflow:
+1. `mcp__context7__resolve-library-id` — find the library
+2. `mcp__context7__query-docs` — fetch specifics
+
+Reach for Context7 BEFORE Perplexity when the question is narrowly about a specific library's documentation. For broader technology evaluations (X vs Y vs Z), use `perplexity_research` first and Context7 second to verify library-specific claims.
+
+### 3. Tavily (CROSS-VALIDATION + EXTRACTION) — `mcp__tavily__*`
+
+Use when:
+- You need a second independent source to cross-validate a Perplexity finding
+- Perplexity cites a URL and you need the full page text — use `tavily_extract`
+- You need to crawl/map a specific docs site — use `tavily_crawl` / `tavily_map`
+- Perplexity returned no useful results — use `tavily_research` as fallback
+
+Tavily is rarely the first call. It's the verification layer.
 
 ## Query Construction
 

--- a/plugins/vsdd-factory/agents/security-reviewer.md
+++ b/plugins/vsdd-factory/agents/security-reviewer.md
@@ -184,9 +184,9 @@ When dx-engineer requests a security audit before installing a tool:
 
 1. **CVE/NVD/OSV lookup:** Check the tool name + version against NVD,
    OSV (osv.dev), and GitHub Advisory Database
-2. **Recent compromise events:** Search Perplexity directly:
+2. **Recent compromise events:** Research with Perplexity directly:
    ```
-   perplexity_search({ query: "[TOOL] [VERSION] security vulnerability compromise 2025 2026" })
+   mcp__perplexity__perplexity_research({ query: "[TOOL] [VERSION] security vulnerability compromise 2025 2026", reasoning_effort: "high", strip_thinking: true })
    ```
 3. **Package integrity:** Verify SHA/checksum where available
    (cargo: Cargo.lock checksum, npm: package-lock.json integrity, brew: SHA256)
@@ -247,14 +247,20 @@ or "fix this" without showing the secure alternative.
 
 ## MCP Tools (Direct Access)
 
-You have direct access to MCP tools — call them as regular tools:
+You have direct access to MCP tools — call them as regular tools. Precedence: **Perplexity (primary) → Context7 (library docs) → Tavily (cross-validation, via research-agent).** Perplexity server is `perplexity` (npm `@perplexity-ai/mcp-server`); tool names are `mcp__perplexity__perplexity_*` — never drop the inner `perplexity_` prefix, never a `perplexity-ask` server name.
 
 | Tool | Use For |
 |------|---------|
-| `perplexity_search` | CVE/NVD/OSV lookup, supply chain compromise events, recent vulnerability disclosures |
-| `perplexity_ask` | Quick CWE classification details, OWASP category definitions, exploit technique references |
-| `perplexity_reason` | Complex threat modeling requiring multi-step analysis of attack chains |
-| `perplexity_research` | Deep investigation of dependency security history or emerging attack patterns |
+| `mcp__perplexity__perplexity_research` | **PRIMARY.** CVE/dependency-history sweeps, supply-chain compromise investigation, emerging attack-pattern research — any non-trivial security question. Backed by `sonar-deep-research`. Reach for this first. |
+| `mcp__perplexity__perplexity_reason` | Threat modeling: multi-step synthesis OVER evidence you already gathered (attack-chain analysis). |
+| `mcp__perplexity__perplexity_search` | Raw ranked URLs only — when you want links (e.g. advisory pages), not synthesis. |
+| `mcp__perplexity__perplexity_ask` | Quick ≤2-sentence factual lookups only (single CWE detail, OWASP category definition). |
+
+**Bias: reach for `perplexity_research` unless there is a specific reason not to.** `perplexity_ask`/`perplexity_search` are narrow tools for narrow jobs, not investigation.
+
+**`reasoning_effort` tuning** (on `perplexity_research`): `minimal` | `low` | `medium` | `high`. Use `high` for security-posture sweeps and CVE-history analysis; `medium` for a focused single-dependency question; `low`/`minimal` for cheap confirmations. Pass `strip_thinking: true` to drop the reasoning trace and save context tokens.
+
+For broad multi-source cross-validation (corroborating a CVE finding via Tavily), delegate to `research-agent` via the orchestrator.
 
 ## Failure & Escalation
 - **Level 1 (self-correct):** Re-assess a finding's severity if initial classification is uncertain after deeper analysis.

--- a/plugins/vsdd-factory/agents/session-reviewer.md
+++ b/plugins/vsdd-factory/agents/session-reviewer.md
@@ -166,7 +166,7 @@ You produce TWO documents (returned to orchestrator, written by state-manager):
 
 ### Planning + Discovery Paths (5-7, 8)
 For entry paths and discovery, analyze the planning/discovery run itself:
-- Research quality (were Perplexity results useful?)
+- Research quality (were Perplexity deep-research (`perplexity_research`) results useful?)
 - Market intel accuracy (did GO/CAUTION/STOP align with human judgment?)
 - Brainstorming effectiveness (did the human find the session useful?)
 - Scoring calibration (did Delphi scores predict human approval?)

--- a/plugins/vsdd-factory/skills/competitive-monitoring/SKILL.md
+++ b/plugins/vsdd-factory/skills/competitive-monitoring/SKILL.md
@@ -32,8 +32,7 @@ competitive update report.
 
 - `discovery-config.yaml` exists with `products[*].competitors` configured
 - `.factory/discovery/competitive-baseline.md` exists (or will be created on first run)
-- `research-agent` is available (DF-002) with Perplexity MCP access
-- `` available for delegated research calls
+- `research-agent` is the canonical MCP caller (DF-002); this skill spawns it for delegated research calls. Its primary tool is `perplexity_research` (deep research, backed by `sonar-deep-research`), with `perplexity_search`/`perplexity_ask` for quick lookups
 
 ## Monitoring Targets
 
@@ -41,12 +40,12 @@ For each competitor in `discovery-config.yaml`:
 
 | Signal | How Detected | Urgency |
 |--------|-------------|---------|
-| New feature/release | Perplexity: "[competitor] release notes [month year]" | HIGH if overlaps with our roadmap |
-| Pricing change | Perplexity: "[competitor] pricing" vs baseline | MEDIUM |
-| Funding round | Perplexity: "[competitor] funding" | LOW (info only) |
-| Acquisition | Perplexity: "[competitor] acquired" | HIGH (market shift) |
-| Shutdown/pivot | Perplexity: "[competitor] shutdown OR pivot" | HIGH (opportunity) |
-| New competitor | Perplexity: "[domain] new startup 2026" | MEDIUM |
+| New feature/release | perplexity_research: "[competitor] release notes [month year]" | HIGH if overlaps with our roadmap |
+| Pricing change | perplexity_search: "[competitor] pricing" vs baseline | MEDIUM |
+| Funding round | perplexity_search: "[competitor] funding" | LOW (info only) |
+| Acquisition | perplexity_search: "[competitor] acquired" | HIGH (market shift) |
+| Shutdown/pivot | perplexity_search: "[competitor] shutdown OR pivot" | HIGH (opportunity) |
+| New competitor | perplexity_research: "[domain] new startup 2026" | MEDIUM |
 
 ## Monitoring Workflow
 
@@ -79,7 +78,7 @@ establishes the baseline.
 
 ### Step 3: Research Each Competitor
 
-For each competitor, spawn research-agent to run Perplexity queries:
+For each competitor, spawn research-agent to run these queries (deep `perplexity_research` for release/feature scans; `perplexity_search` for the single-fact baseline checks):
 
 1. **Release check:** "[competitor] release notes [current month] [current year]"
    - Compare against baseline's `Latest Known Release`
@@ -101,9 +100,9 @@ For each competitor, spawn research-agent to run Perplexity queries:
 
 ### Step 4: Scan for New Entrants
 
-Research the product's domain for new competitors:
-- Perplexity: "[product domain] new startup [current year]"
-- Perplexity: "[product domain] new tool launch [current year]"
+Research the product's domain for new competitors (deep research — this is an open-ended landscape scan, not a single-fact lookup):
+- perplexity_research: "[product domain] new startup [current year]"
+- perplexity_research: "[product domain] new tool launch [current year]"
 - Compare against known competitor list
 
 ### Step 5: Classify Urgency
@@ -159,7 +158,7 @@ of each competitor entry.
 
 ## Failure Modes
 
-- If a data source is unavailable (Perplexity timeout, API error): flag the source as UNAVAILABLE, continue with remaining sources, note gap in report
+- If a data source is unavailable (Perplexity timeout, API error): do not silently skip — per the research-agent's mandatory-MCP gate, flag the source as UNAVAILABLE with the verbatim error, continue with remaining sources, and note the gap in the report
 - If no changes detected for any competitor: produce a "no change" report (not a silent no-op)
 - If a new entrant cannot be verified: mark as UNVERIFIED and include in report with caveat
 

--- a/plugins/vsdd-factory/skills/customer-feedback-ingestion/SKILL.md
+++ b/plugins/vsdd-factory/skills/customer-feedback-ingestion/SKILL.md
@@ -31,8 +31,8 @@ process -- the factory does not interact with customers directly.
 
 - `discovery-config.yaml` exists with `products[*].user_channels` configured
 - `.factory/discovery/feedback-state.yaml` exists (or will be created on first run)
-- `research-agent` is available (DF-002) for Perplexity-based review searches
-- `` available for GitHub API, Slack API access
+- `research-agent` is the canonical MCP caller (DF-002); this skill spawns it for review searches (`perplexity_search` for public app/review-site lookups)
+- GitHub API and Slack API access available for channel ingestion
 
 ## Supported Channels
 
@@ -41,8 +41,8 @@ process -- the factory does not interact with customers directly.
 | GitHub Issues | `gh` CLI / GitHub API | Feature requests, bug reports, discussions |
 | GitHub Discussions | `gh` CLI / GitHub API | Community questions, feature ideas |
 | Slack/Discord | Webhook archive or API | Customer messages in feedback channels |
-| App Store Reviews | Perplexity search (public) | iOS/Android app reviews |
-| G2/Capterra Reviews | Perplexity search (public) | Enterprise software reviews |
+| App Store Reviews | perplexity_search (public) | iOS/Android app reviews |
+| G2/Capterra Reviews | perplexity_search (public) | Enterprise software reviews |
 | Support Tickets | API integration (configurable) | Customer support issues |
 | NPS/Survey Results | File import (.factory/surveys/*.csv) | Structured survey responses |
 
@@ -130,15 +130,15 @@ gh api graphql -f query='{ repository(owner:"org", name:"product") {
 ```
 
 **Slack/Discord:**
-- Via : fetch messages from configured channel since last ingestion
+- Via the Slack/Discord API: fetch messages from configured channel since last ingestion
 - Parse for feature requests, complaints, praise
 
 **App Store Reviews:**
-- Via research-agent -> Perplexity: "[product name] app reviews [platform] [month year]"
+- Via research-agent -> perplexity_search: "[product name] app reviews [platform] [month year]"
 - Extract individual reviews with ratings and text
 
 **Review Sites (G2/Capterra):**
-- Via research-agent -> Perplexity: "[product name] reviews [site] [month year]"
+- Via research-agent -> perplexity_search: "[product name] reviews [site] [month year]"
 - Extract review summaries with ratings
 
 **Survey Import:**

--- a/plugins/vsdd-factory/skills/discovery-engine/SKILL.md
+++ b/plugins/vsdd-factory/skills/discovery-engine/SKILL.md
@@ -24,8 +24,8 @@ Discovery runs can be triggered:
 
 - `.factory/discovery-config.yaml` exists (or use defaults)
 - `.factory/product-registry.yaml` exists for feature discovery (list of products the factory has built)
-- `research-agent` is available (DF-002) with MCP tools:
-  - **Perplexity** — web search, deep research, reasoning (already configured in DF-002)
+- `research-agent` is the canonical MCP caller (DF-002); this skill spawns it. Its MCP tools:
+  - **Perplexity** — deep research (`perplexity_research`, the primary tool, backed by `sonar-deep-research`, tunable via `reasoning_effort: high|medium|low|minimal`), plus quick lookups (`perplexity_search`, `perplexity_ask`) and synthesis (`perplexity_reason`) (already configured in DF-002)
   - **Context7** — library documentation and code examples (already configured in DF-002)
   - **Tavily** — web search, intelligent extraction, website mapping (already configured)
   - **Exa** — company research, code search, academic paper search (free, no API key needed)
@@ -65,37 +65,37 @@ use the appropriate MCP tools:
 
 **Competitive intelligence:**
 - What have direct competitors shipped in the last 30 days?
-  Tools: Perplexity search, Product Hunt MCP, GitHub release Atom feeds via RSS Aggregator
+  Tools: deep research (perplexity_research), Product Hunt MCP, GitHub release Atom feeds via RSS Aggregator
 - What are competitors' public roadmaps or announced features?
-  Tools: Perplexity deep research, competitor changelog monitoring via RSS/changedetection
+  Tools: deep research (perplexity_research), competitor changelog monitoring via RSS/changedetection
 - What are users requesting in competitor communities (GitHub issues, forums, social media)?
-  Tools: Perplexity search, Hacker News MCP, Exa (social/community search)
+  Tools: deep research (perplexity_research), Hacker News MCP, Exa (social/community search)
 - What technology stacks are competitors adopting or abandoning?
-  Tools: BuiltWith MCP (if configured), Perplexity search
+  Tools: BuiltWith MCP (if configured), perplexity_search
 
 **Technology opportunities:**
 - Have any key dependencies released new versions with capabilities the product could use?
   Tools: GitHub release Atom feeds via RSS Aggregator, Context7 (library docs)
 - Are there new libraries or tools that could simplify or enhance existing functionality?
-  Tools: Context7, Exa (code search), Perplexity search
+  Tools: Context7, Exa (code search), perplexity_search
 - Have any AI model capabilities improved in ways that benefit the product's domain?
-  Tools: Perplexity deep research
+  Tools: deep research (perplexity_research)
 
 **User signal:**
 - What are the most common issues or feature requests in the product's issue tracker?
   Tools: GitHub API (issue search), Exa (community search)
 - What pain points do users report in the product's domain (not just this product)?
-  Tools: Perplexity search, Hacker News MCP, Reddit MCP (if configured)
+  Tools: deep research (perplexity_research), Hacker News MCP, Reddit MCP (if configured)
 - What workflows are users building around the product that could be first-class features?
-  Tools: GitHub API (search for repos that depend on the product), Perplexity search
+  Tools: GitHub API (search for repos that depend on the product), perplexity_search
 
 **Industry trends:**
 - What best practices have evolved in the product's domain?
-  Tools: Perplexity deep research, Exa (academic paper search)
+  Tools: deep research (perplexity_research), Exa (academic paper search)
 - Are there new standards, protocols, or regulations that affect the product?
-  Tools: Perplexity search, Tavily (extract from standards body websites)
+  Tools: deep research (perplexity_research), Tavily extract (from standards body websites)
 - What patterns are emerging across similar products?
-  Tools: Perplexity research, Product Hunt MCP
+  Tools: deep research (perplexity_research), Product Hunt MCP
 
 **Research quality controls:**
 - Every finding must cite a specific source with URL and date
@@ -247,7 +247,7 @@ Novelty 0.10 (was 0.10), Time-Criticality 0.10 (was 0.10), Effort 0.10 (was 0.15
 | Score | Criteria |
 |-------|---------|
 | 0.0 - 0.2 | Speculation -- no external validation |
-| 0.3 - 0.5 | Market research only -- Perplexity findings |
+| 0.3 - 0.5 | Market research only -- deep research (perplexity_research) findings |
 | 0.5 - 0.6 | Market + one customer signal (feedback OR analytics) |
 | 0.6 - 0.8 | Market + multiple customer signals |
 | 0.8 - 0.9 | Market + customer feedback + usage analytics |
@@ -296,7 +296,7 @@ intelligence data) default to evidence_strength = 0.3 (market scan level).
 
 ## Failure Modes
 
-- If MCP tools are unavailable (Perplexity, Context7, etc.): use training data with explicit "UNVERIFIED -- no live research" disclaimer on all findings
+- If MCP tools are unavailable (Perplexity, Context7, etc.): do NOT silently skip. Per the research-agent's mandatory-MCP gate, escalate the toolchain failure (capture the verbatim MCP error) and only then fall back to training data with an explicit "UNVERIFIED -- no live research" disclaimer on all findings
 - If product registry is empty: run Product Discovery mode only, skip Feature Discovery
 - If all ideas score below threshold: produce the report anyway, noting "no actionable ideas this cycle"
 

--- a/plugins/vsdd-factory/skills/dtu-creation/SKILL.md
+++ b/plugins/vsdd-factory/skills/dtu-creation/SKILL.md
@@ -38,7 +38,7 @@ description: >
 ### Step 1: Clone Specification
 
 For each DTU candidate, spawn `research-agent` to:
-1. Fetch the service's API documentation via Perplexity/Context7
+1. Fetch the service's API documentation via Context7 (library docs) or Perplexity deep research (`perplexity_research`)
 2. If an OpenAPI/Swagger spec exists, download it
 3. Analyze the SUT's code to identify which endpoints are actually used
 4. Write a clone specification using `templates/dtu-clone-spec-template.md`

--- a/plugins/vsdd-factory/skills/guided-brief-creation/SKILL.md
+++ b/plugins/vsdd-factory/skills/guided-brief-creation/SKILL.md
@@ -81,7 +81,7 @@ If the human provided existing documents:
 - Spawn research-agent to analyze provided documents
 - Extract relevant insights for the brief
 - If web research would help (competitive landscape, technical feasibility),
-  spawn research-agent with Perplexity
+  spawn research-agent for deep research (perplexity_research)
 
 If the human provided brainstorming output:
 - Read `.factory/planning/brainstorming-report.md`

--- a/plugins/vsdd-factory/skills/guided-brief-creation/steps/step-02-contextual-discovery.md
+++ b/plugins/vsdd-factory/skills/guided-brief-creation/steps/step-02-contextual-discovery.md
@@ -23,7 +23,7 @@
    - Ask it to extract: stated problem, audience hints, scope hints, success metrics, constraints.
    - Capture findings in `elicitation-notes.md` under "Document analysis: <doc name>".
 
-3. **Decide whether web research is needed.** Spawn `research-agent` with Perplexity if any of these are true:
+3. **Decide whether web research is needed.** Spawn `research-agent` for deep research (`perplexity_research`) if any of these are true:
    - The domain is specialized (medical, legal, scientific, regulated)
    - The competitive landscape is unknown to you
    - Technical feasibility is unclear (would this even work?)

--- a/plugins/vsdd-factory/skills/intelligence-synthesis/SKILL.md
+++ b/plugins/vsdd-factory/skills/intelligence-synthesis/SKILL.md
@@ -114,7 +114,7 @@ Score each theme's evidence strength based on source diversity and quality:
 
 | Evidence Level | Sources | Score Range |
 |---------------|---------|-------------|
-| Market scan only | Perplexity research | 0.3 - 0.5 |
+| Market scan only | deep research (perplexity_research) | 0.3 - 0.5 |
 | Market + one customer signal | Research + feedback OR analytics | 0.5 - 0.6 |
 | Market + multiple customer signals | Research + feedback + analytics | 0.6 - 0.8 |
 | Market + customer + competitive | Research + feedback + competitive | 0.7 - 0.8 |

--- a/plugins/vsdd-factory/skills/market-intelligence-assessment/SKILL.md
+++ b/plugins/vsdd-factory/skills/market-intelligence-assessment/SKILL.md
@@ -58,9 +58,9 @@ reasonable assumptions and flag them as assumptions in the output.
 
 ## Step 2: Market Landscape Research
 
-**Agent:** `research-agent` via Perplexity MCP
+**Agent:** `research-agent` (canonical MCP caller; this skill spawns it)
 
-The research-agent executes five parallel research tracks using Perplexity:
+The research-agent executes five parallel research tracks, leading with deep research (`perplexity_research`, backed by `sonar-deep-research`, `reasoning_effort: high` for this landscape-level work):
 
 ### 2a. Competitive Landscape
 
@@ -245,5 +245,5 @@ research on projects that already have market validation:
 ## Failure Modes
 
 - If research sources are sparse (few results, low confidence): produce CAUTION recommendation with explicit gaps listed
-- If Perplexity MCP is unavailable: use training data with "UNVERIFIED -- no live research" disclaimer, default to CAUTION
+- If Perplexity MCP is unavailable: do not silently skip — per the research-agent's mandatory-MCP gate, escalate the toolchain failure with the verbatim error, then fall back to training data with an "UNVERIFIED -- no live research" disclaimer and default to CAUTION
 - If the input is too vague for meaningful research (L0 with one sentence): ask up to 3 clarifying questions, then proceed with assumptions flagged

--- a/plugins/vsdd-factory/skills/planning-research/SKILL.md
+++ b/plugins/vsdd-factory/skills/planning-research/SKILL.md
@@ -3,7 +3,8 @@ name: planning-research
 description: >
   Conducts market, domain, and technical research to validate assumptions
   and fill knowledge gaps before brief or PRD creation. Uses Perplexity
-  for web research and Context7 for library/framework documentation.
+  deep research (perplexity_research) for web research, Context7 for
+  library/framework documentation, and Tavily for cross-validation.
   Can run domain, market, or technical research independently or combined.
 ---
 
@@ -39,7 +40,7 @@ description: >
 ## Research Process
 
 1. **Receive research brief** -- what questions need answering
-2. **Spawn research-agent** with Perplexity + Context7 MCP tools
+2. **Spawn research-agent** with Perplexity (deep research via `perplexity_research`) + Context7 + Tavily MCP tools
 3. **Follow AGENTS.md query construction rules** (explicit search directives,
    parent org context, alternative terms, source suggestions)
 4. **Cross-reference findings** across at least 2 independent sources
@@ -56,7 +57,7 @@ description: >
 
 ## Failure Modes
 
-- If MCP tools (Perplexity, Context7) are unavailable: use training data with explicit "UNVERIFIED -- based on training data, not live research" disclaimer
+- If MCP tools (Perplexity, Context7, Tavily) are unavailable: use training data with explicit "UNVERIFIED -- based on training data, not live research" disclaimer
 - If research yields no relevant results for a research type: document the gap and recommend alternative research approaches
 - If sources contradict each other: present both sides with evidence strength assessment
 

--- a/plugins/vsdd-factory/skills/post-feature-validation/SKILL.md
+++ b/plugins/vsdd-factory/skills/post-feature-validation/SKILL.md
@@ -82,7 +82,7 @@ Categorize as positive, negative, or neutral.
 Search for discussions mentioning the feature since ship date.
 
 **App Reviews / Review Sites:**
-Via research-agent -> Perplexity: "[product] [feature name] review"
+Via research-agent -> perplexity_search: "[product] [feature name] review"
 Look for mentions of the specific feature in recent reviews.
 
 **Slack/Discord:**

--- a/plugins/vsdd-factory/skills/repo-initialization/SKILL.md
+++ b/plugins/vsdd-factory/skills/repo-initialization/SKILL.md
@@ -330,11 +330,11 @@ After repo is created, orchestrator spawns dx-engineer for environment setup:
 7. **Configure MCP servers via mcporter:**
    ```bash
    mcporter config add perplexity --transport stdio \
-     --command "npx" --args "-y @anthropic/perplexity-mcp"
+     --command "npx" --args "-y @perplexity-ai/mcp-server"
    mcporter config add context7 --transport stdio \
-     --command "npx" --args "-y @anthropic/context7-mcp"
+     --command "npx" --args "-y @upstash/context7-mcp"
    mcporter config add playwright --transport stdio \
-     --command "npx" --args "-y @anthropic/playwright-mcp"
+     --command "npx" --args "-y @playwright/mcp@latest"
    ```
 
 8. **LLM health check:**

--- a/plugins/vsdd-factory/skills/research-cache-ops/SKILL.md
+++ b/plugins/vsdd-factory/skills/research-cache-ops/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: research-cache-ops
-description: Operate the research-cache for Perplexity/Context7 query results. Check, inspect, and clear cached research to avoid re-running expensive queries.
+description: Operate the research-cache for Perplexity/Context7 query results (especially expensive perplexity_research deep-research calls). Check, inspect, and clear cached research to avoid re-running expensive queries.
 ---
 
 # Research Cache Operations
 
-Wraps `${CLAUDE_PLUGIN_ROOT}/bin/research-cache` for common cache operations. Research is expensive (Perplexity deep-research is 30s+ and costs money); cached results should be reused across sessions unless explicitly invalidated.
+Wraps `${CLAUDE_PLUGIN_ROOT}/bin/research-cache` for common cache operations. Research is expensive (`perplexity_research` deep-research — the primary research call — is 30s+ and costs money); cached results should be reused across sessions unless explicitly invalidated.
 
 ## Operations
 
@@ -25,7 +25,7 @@ Wraps `${CLAUDE_PLUGIN_ROOT}/bin/research-cache` for common cache operations. Re
 
 ## Integration
 
-The `research-agent` subagent should call this via Bash before making Perplexity/Context7 calls. Pseudocode:
+The `research-agent` subagent should call this via Bash before making Perplexity (`perplexity_research`) / Context7 calls. Pseudocode:
 
 ```bash
 key=$(${CLAUDE_PLUGIN_ROOT}/bin/research-cache key "$query")

--- a/plugins/vsdd-factory/skills/research/SKILL.md
+++ b/plugins/vsdd-factory/skills/research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research
-description: Conduct external research — domain analysis or technology evaluation. Spawns the research-agent with MCP tool access (Perplexity, Context7, Tavily). Usage - /research domain <topic> or /research <topic> for general.
+description: Conduct external research — domain analysis or technology evaluation. Spawns the research-agent with MCP tool access (Perplexity deep research via perplexity_research, Context7, Tavily). Usage - /research domain <topic> or /research <topic> for general.
 argument-hint: "[domain|general] <topic>"
 
 context: fork


### PR DESCRIPTION
## Summary

This PR contains two related changes to `plugins/vsdd-factory/` (plugin-source markdown only — no Rust code, no hooks-registry, no CI workflow changes):

### 1. research-agent deep-research bias fix (commit `69f066eb`)

The `research-agent` was not reliably using Perplexity even when the MCP server was available. Five root causes identified and fixed:

| Root cause | Fix |
|---|---|
| Tool manifest listed `WebSearch`/`WebFetch` **before** MCP tools → position bias toward non-MCP tools | Reordered manifest so `mcp__perplexity__*` leads, `perplexity_research` first |
| No enforcement that MCP tools were actually called | Added **MANDATORY gate**: Research Methods table must show ≥1 MCP call OR an explicit `MCP-UNAVAILABLE` escalation section with verbatim error. Quiet skipping is now non-compliant. |
| MCP Tools section was a flat menu, no precedence | Restructured into ranked sections: **Perplexity (PRIMARY) > Context7 (library docs) > Tavily (cross-validation)** with a variant table |
| No deep-research bias | `perplexity_research` (`sonar-deep-research`) is now the documented default for non-trivial topics; other variants are explicit exceptions |
| `reasoning_effort` knob undocumented | Documented `reasoning_effort: minimal\|low\|medium\|high` + `strip_thinking`, confirmed against the live MCP schema |

**Also:** `.mcp.json` gitignored — it embeds live API keys in server URLs (tavily endpoint carries `tvly-prod-*` as a query param). Was untracked; this rule keeps it that way.

---

### 2. Fleet-wide MCP tool-guidance sweep (commit `eee825be`)

Across 22 files touching 9 agents and 13 skills, three categories of fixes:

**Real bugs fixed:**
- Wrong npm package names in `repo-initialization` SKILL.md: `@anthropic/perplexity-mcp` → `@perplexity-ai/mcp-server`, `@anthropic/context7-mcp` → `@upstash/context7-mcp`, `@anthropic/playwright-mcp` → `@playwright/mcp@latest` (all three were wrong — agents installing these would silently get 404s from npm)
- `dx-engineer` `mcporter call` examples corrected to `mcporter call <server> <tool>` space-separated syntax with proper tool names (old examples used dot-notation which doesn't match the actual CLI)
- A duplicate-line regression repaired; pre-existing empty-backtick placeholder lines repaired in 2 skills

**Direct-caller agents updated** (security-reviewer, architect, product-owner, business-analyst — agents with their own `mcp__` tool tables in their prompts):
- `perplexity_research` biased as PRIMARY with `reasoning_effort` guidance
- Fully-qualified `mcp__perplexity__perplexity_*` names throughout (old forms dropped the inner `perplexity_` prefix)
- Explicit Perplexity → Context7 → Tavily precedence documented

**Prose skills updated** (~15 skills):
- Deep-research bias language aligned to `perplexity_research` (not generic "Perplexity")
- `research-agent` delegation calls reference `perplexity_research` explicitly
- MCP-unavailable failure modes updated: "silently fall back" replaced with "escalate the toolchain failure with verbatim error, then fall back"

`mcporter` retained as the canonical provisioning tool (13 files depend on it); only wrong names/forms corrected.

---

## Files changed

23 files — all under `plugins/vsdd-factory/` (agents + skills markdown) plus `.gitignore`.

## Post-merge caveat

**This is plugin-source only.** Merging to `develop` does NOT change operator-level behavior. The operator-level marketplace cache (`~/.claude/plugins/cache/claude-mp/vsdd-factory/<version>/`) only picks up source edits after a new rc release. These fixes take effect for consumers on the next rc tag, not at develop merge time.

## Pre-merge checklist

- [x] All changes are markdown/documentation — no Rust code modified
- [x] No secrets introduced (`.mcp.json` gitignored, not added)
- [x] No hooks-registry changes
- [x] No CI workflow changes
- [x] npm package names verified against registries (`@perplexity-ai/mcp-server`, `@upstash/context7-mcp`, `@playwright/mcp`)
- [x] `mcporter call <server> <tool>` syntax verified against actual CLI behavior
- [x] `mcp__` alias names correct for direct in-Claude tool calls (4 direct-caller agent tables)
