### PR TITLE
ci(e10-p16): derive WASM-plugin-count assertion from registry (F-PASS16-002)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
         run: cargo publish --dry-run --workspace -p vsdd-hook-sdk-macros -p vsdd-hook-sdk
 
       - name: cargo build (all native WASM plugins, wasm32-wasip1)
-        # Build all 16 native WASM plugins to catch compilation regressions
+        # Build all hook-plugin crates to catch compilation regressions
         # across the full plugin set (CRIT-W15-001 / W-15-gate fix).
         run: |
           cargo build -p legacy-bash-adapter --bin legacy-bash-adapter --target wasm32-wasip1
@@ -186,16 +186,20 @@ jobs:
         # any plugin author sees it.
         run: cargo build -p vsdd-hook-sdk --example hello-hook --target wasm32-wasip1
 
-      - name: Verify all 16 native WASM plugins built
+      - name: Verify all native WASM plugins built
         shell: bash
         run: |
-          count=$(ls target/wasm32-wasip1/debug/*.wasm 2>/dev/null | wc -l)
-          if [ "$count" -lt 16 ]; then
-            echo "::error::Only $count wasm files built; expected >= 16."
+          # F-PASS16-002 / E-10 pass-16: derive floor from crates/hook-plugins/ count so
+          # the assertion stays correct automatically when plugins are added or removed,
+          # and a silent plugin drop FAILS this check without a manual floor update.
+          expected=$(ls -d crates/hook-plugins/*/ | wc -l | tr -d ' ')
+          count=$(ls target/wasm32-wasip1/debug/*.wasm 2>/dev/null | wc -l | tr -d ' ')
+          if [ "$count" -lt "$expected" ]; then
+            echo "::error::Only $count wasm files built; expected >= $expected (derived from crates/hook-plugins/ crate count)."
             ls target/wasm32-wasip1/debug/*.wasm 2>/dev/null || true
             exit 1
           fi
-          echo "Built $count wasm files."
+          echo "Built $count wasm files (floor: $expected crate dirs in crates/hook-plugins/)."
 
       - name: Mount factory artifacts (for perf-baseline bats)
         # perf-baseline.bats needs .factory/ (script + fixture + baseline doc).
@@ -223,13 +227,17 @@ jobs:
         run: |
           mkdir -p plugins/vsdd-factory/hook-plugins
           cp target/wasm32-wasip1/debug/*.wasm plugins/vsdd-factory/hook-plugins/ 2>/dev/null || true
-          count=$(ls plugins/vsdd-factory/hook-plugins/*.wasm 2>/dev/null | wc -l)
-          if [ "$count" -lt 16 ]; then
-            echo "::error::Only $count WASM plugins staged; expected >= 16. Build output:"
+          # F-PASS16-002 / E-10 pass-16: derive floor from crates/hook-plugins/ count so
+          # the assertion stays correct automatically when plugins are added or removed,
+          # and a silent plugin drop FAILS this check without a manual floor update.
+          expected=$(ls -d crates/hook-plugins/*/ | wc -l | tr -d ' ')
+          count=$(ls plugins/vsdd-factory/hook-plugins/*.wasm 2>/dev/null | wc -l | tr -d ' ')
+          if [ "$count" -lt "$expected" ]; then
+            echo "::error::Only $count WASM plugins staged; expected >= $expected (derived from crates/hook-plugins/ crate count). Build output:"
             ls target/wasm32-wasip1/debug/*.wasm 2>/dev/null || echo "  (no wasm files in debug target)"
             exit 1
           fi
-          echo "Staged $count WASM plugins to hook-plugins/."
+          echo "Staged $count WASM plugins to hook-plugins/ (floor: $expected crate dirs in crates/hook-plugins/)."
           ls plugins/vsdd-factory/hook-plugins/
 
       - name: Run S-9.00 perf-baseline tests
@@ -406,7 +414,7 @@ jobs:
         run: cargo test --release --target ${{ matrix.target }} --workspace
 
       - name: Build all native WASM plugins (release)
-        # Build all 16 native WASM plugins on every matrix entry —
+        # Build all hook-plugin crates on every matrix entry —
         # proves all plugins compile against the same toolchain as the
         # native dispatcher. Catches feature-flag drift and compilation
         # regressions across the full plugin set (CRIT-W15-001 / W-15-gate fix).
@@ -426,16 +434,20 @@ jobs:
       - name: Build wasm hello-hook example
         run: cargo build -p vsdd-hook-sdk --example hello-hook --target wasm32-wasip1 --release
 
-      - name: Verify all 16 native WASM plugins built (release)
+      - name: Verify all native WASM plugins built (release)
         shell: bash
         run: |
-          count=$(ls target/wasm32-wasip1/release/*.wasm 2>/dev/null | wc -l)
-          if [ "$count" -lt 16 ]; then
-            echo "::error::Only $count wasm files built (release); expected >= 16."
+          # F-PASS16-002 / E-10 pass-16: derive floor from crates/hook-plugins/ count so
+          # the assertion stays correct automatically when plugins are added or removed,
+          # and a silent plugin drop FAILS this check without a manual floor update.
+          expected=$(ls -d crates/hook-plugins/*/ | wc -l | tr -d ' ')
+          count=$(ls target/wasm32-wasip1/release/*.wasm 2>/dev/null | wc -l | tr -d ' ')
+          if [ "$count" -lt "$expected" ]; then
+            echo "::error::Only $count wasm files built (release); expected >= $expected (derived from crates/hook-plugins/ crate count)."
             ls target/wasm32-wasip1/release/*.wasm 2>/dev/null || true
             exit 1
           fi
-          echo "Built $count wasm files (release)."
+          echo "Built $count wasm files (release) (floor: $expected crate dirs in crates/hook-plugins/)."
 
       - name: Stage artifacts
         # Collect the dispatcher binary + every .wasm file into a single


### PR DESCRIPTION
## What was the defect

`.github/workflows/ci.yml` had three WASM-plugin-count assertions hardcoded to `>= 16`. The actual hook-plugin crate count is now 28 (and the registry ships 61 unique plugin names / 53 in the marketplace). The floor was ~57% below reality, meaning a regression that silently dropped 12 plugins would still pass `>= 16`. The regression detector had stopped detecting regressions.

This is F-PASS16-002 (LOW, [process-gap]) from the E-10 pass-16 adversarial review — the same finding as pass-15's F-PASS15-007, which was ACCEPTED-AT-FLOOR. The adversary re-escalated it to FIX-NOW because the gap widened and the fix is cheap.

## The fix

All three sites now derive the floor at runtime from `ls -d crates/hook-plugins/*/ | wc -l` — the authoritative count of hook-plugin crate directories. Currently 28.

**Why this is self-maintaining:** when a crate is added or removed, the assertion automatically adjusts on the next CI run with no manual edit required. A silent plugin drop (fewer `.wasm` files than crate directories) FAILS the check regardless of what the old floor was.

**Why `>= crate_count` is correct:** each hook-plugin crate has a `[[bin]]` target which produces one `.wasm` file in `target/wasm32-wasip1/{debug,release}/`. The actual `.wasm` count is always `>= crate_count` (cdylib plugins produce an extra lib `.wasm` under a normalized name). So the floor can never produce a false-positive under normal build conditions.

## Sites changed

- **Site 1** (`name: Verify all native WASM plugins built`, debug build): was `count -lt 16`, now `count -lt expected` where `expected=$(ls -d crates/hook-plugins/*/ | wc -l | tr -d ' ')`
- **Site 2** (`name: Stage WASM plugins to hook-plugins directory`): same derivation for the staged-plugins count check
- **Site 3** (`name: Verify all native WASM plugins built (release)`, release matrix build): same derivation for the release `.wasm` count

Also updated the step name comments that previously said "all 16 native WASM plugins" to remove the now-meaningless literal.

## Verified locally

```
$ ls -d crates/hook-plugins/*/ | wc -l | tr -d ' '
28
```

That is the floor CI will enforce on this PR. The actual built `.wasm` count is expected to be >= 28 (higher, due to cdylib lib targets on 8 plugins plus `vsdd-context-resolvers` and `wasm_resolver_export`).

## Traceability

- Finding: F-PASS16-002, E-10 pass-16 adversarial review
- Prior deferral: F-PASS15-007 ACCEPTED-AT-FLOOR (now closed by this fix)
- Process gap: stale magic literal, floor ~57% below reality

## Self-test

CI runs the modified assertions on this very PR. If the derived count logic is wrong (actual wasm count inconsistent with crate count), CI will surface it as a failure — per guardrails, this will be reported as a new finding rather than papered over.