### PR TITLE
fix(pr-manager): verify remote branch deletion after merge (#128)

### DIFF
--- a/plugins/vsdd-factory/agents/pr-manager.md
+++ b/plugins/vsdd-factory/agents/pr-manager.md
@@ -258,12 +258,14 @@ Agent(subagent_type="vsdd-factory:github-ops", prompt="cd <project-path> && gh p
 
 - If `state == MERGED` — proceed to Step 8b.
 - If `state == CLOSED` — the PR was closed without merging; abort Step 8 and surface a
-  clear BLOCKED note. Do NOT attempt branch deletion.
+  clear BLOCKED note. Do NOT attempt branch deletion. **If Step 8 aborts for any reason
+  (CLOSED state or merge-queue timeout exceeded), the agent MUST HALT and do NOT proceed
+  to Step 9.** Step 9 is only for successfully merged PRs.
 - If `state != MERGED` and `state != CLOSED` (queued, open, or pending) — do NOT attempt
   force-delete. A merge queue is still in-flight; deleting the branch now would break the
   queue run. Poll every ~30 seconds, up to 10 attempts (total ~5 minutes). If state is
   still not MERGED after 10 attempts, abort Step 8 and emit a clear BLOCKED note — never
-  hot-loop or wait indefinitely.
+  hot-loop or wait indefinitely. **Abort must not proceed to Step 9.**
 
 **Step 8b — Fork / cross-repo guard.**
 Dispatch github-ops to determine whether the PR head branch is on a fork:
@@ -286,8 +288,11 @@ Agent(subagent_type="vsdd-factory:github-ops", prompt="cd <project-path> && git 
 ```
 
 Use `--exit-code` so that exit code 2 means the ref is absent (deleted) and exit code 0
-means it is present. Do NOT rely on "any non-empty output" — `git ls-remote` performs
-prefix matching and could match `refs/heads/<branch-name>-suffix`.
+means it is present. Additionally, parse stdout to confirm an exact-line match: the output
+must contain a line ending exactly in `<TAB>refs/heads/<branch-name>` (not a suffix variant
+like `refs/heads/<branch-name>-v2`). Do NOT rely solely on exit code or any non-empty
+output — `git ls-remote` performs prefix matching and could match
+`refs/heads/<branch-name>-suffix`.
 
 Interpret the result:
 - **Exit code 2 (ref absent)** — branch deleted; proceed to Step 9.
@@ -308,14 +313,31 @@ Dispatch github-ops to force-delete:
 Agent(subagent_type="vsdd-factory:github-ops", prompt="cd <project-path> && git push origin --delete <branch-name>")
 ```
 
-After force-delete, re-run the `git ls-remote --exit-code origin refs/heads/<branch-name>`
-check. Exit code 2 confirms deletion. Treat a non-zero exit from the force-delete command
-that indicates "remote ref does not exist" as SUCCESS (idempotent — a 404/already-gone is
-also success; branch was deleted concurrently between the ls-remote check and the push).
+Classify the `git push origin --delete` exit code before running any post-delete check:
 
-If deletion is rejected due to branch-protection rules or insufficient permissions,
-LOG A WARNING and PROCEED — do not dead-end the delivery. The branch-leak is surfaced
-in the STEP_COMPLETE note, but branch-protection rejection is not fatal to the workflow.
+- **Exit 0 (push succeeded)** — proceed to post-delete ls-remote verification below.
+  If a subsequent lagging ls-remote still shows the branch transiently present, accept the
+  push exit 0 as deletion confirmation (replication lag); the post-delete retry absorbs the
+  lag but push success is authoritative if all retry attempts see the branch still present.
+- **"remote ref does not exist" / already-gone (any non-zero that indicates the ref is
+  absent)** — treat as SUCCESS (idempotent); branch was deleted concurrently between the
+  ls-remote check and the push. Proceed to post-delete confirmation.
+- **Transient/network error** (e.g. connection timeout, temporary auth failure, exit 128) —
+  retry the push briefly (up to 2 additional attempts with a short wait); if the transient
+  error persists after retries, surface a clear failure note and abort the deletion step.
+- **Branch-protection or permission rejection** — LOG A WARNING and PROCEED — do not
+  dead-end the delivery. The branch-leak is surfaced in the STEP_COMPLETE note, but
+  branch-protection rejection is not fatal to the workflow.
+- **Persistent unexpected non-zero exit** (not covered above) — surface a clear failure
+  note; do NOT treat as deleted.
+
+After a successful push (exit 0 or already-gone), re-run `git ls-remote --exit-code origin
+refs/heads/<branch-name>` to confirm deletion. To absorb GitHub replication lag, use a
+post-force-delete bounded retry: up to 3 re-checks, each separated by a 5–10 second wait.
+Exit code 2 on any attempt confirms deletion. If replication lag means ls-remote still
+returns exit 0 after all 3 post-force-delete retry attempts, but the push itself returned
+exit 0 (success), accept the push exit 0 as confirmation — the replication-lag deadlock
+must not wedge the completion gate.
 
 Emit `STEP_COMPLETE: step=8` when ANY of the following conditions is true:
 (a) the ls-remote exact-ref check returns exit code 2 (branch confirmed deleted),
@@ -334,7 +356,9 @@ Choose the note that reflects the actual <deletion-outcome>: deleted / skipped-f
 protection-rejected-warning. Do NOT hardcode the "confirmed deleted" wording when the
 actual outcome was different.
 
-**Proceed immediately to step 9.**
+**On the success/warn-and-proceed path only: proceed immediately to step 9.** If Step 8
+aborted (CLOSED state, merge-queue timeout, or persistent deletion failure), the agent
+MUST HALT — do NOT proceed to Step 9.
 
 ### Step 9: Post-merge
 

--- a/plugins/vsdd-factory/agents/pr-manager.md
+++ b/plugins/vsdd-factory/agents/pr-manager.md
@@ -247,29 +247,70 @@ Do NOT treat the sub-agent's response as terminal.
 **Verify remote branch deletion** — `gh pr merge --delete-branch` only *requests*
 deletion; it is asynchronous and not guaranteed (especially under merge queues,
 see cli/cli#9073). You MUST verify the branch is actually gone before emitting
-STEP_COMPLETE for step 8. Dispatch github-ops to check:
+STEP_COMPLETE for step 8. Follow this sequence:
+
+**Step 8a — Confirm PR is MERGED (not just queued).**
+Dispatch github-ops to confirm the PR state before any branch-deletion work:
 
 ```
-Agent(subagent_type="vsdd-factory:github-ops", prompt="cd <project-path> && git ls-remote origin refs/heads/<branch-name>")
+Agent(subagent_type="vsdd-factory:github-ops", prompt="cd <project-path> && gh pr view <PR_NUMBER> --json state,mergeStateStatus")
 ```
+
+- If `state == MERGED` — proceed to Step 8b.
+- If `state != MERGED` (queued, open, or pending) — do NOT attempt force-delete.
+  A merge queue is still in-flight; deleting the branch now would break the queue run.
+  Wait for the state to reach MERGED before continuing.
+
+**Step 8b — Fork / cross-repo guard.**
+Dispatch github-ops to determine whether the PR head branch is on a fork:
+
+```
+Agent(subagent_type="vsdd-factory:github-ops", prompt="cd <project-path> && gh pr view <PR_NUMBER> --json isCrossRepository,headRepositoryOwner,headRefName")
+```
+
+- If `isCrossRepository == true` — the branch lives on the contributor's fork remote,
+  not on `origin`. SKIP the `git ls-remote origin` verification and force-delete steps
+  entirely. Note in STEP_COMPLETE that branch lives on fork (cross-repository PR) and
+  deletion verification is not applicable for `origin`. Proceed to Step 9.
+- If `isCrossRepository == false` — continue to Step 8c.
+
+**Step 8c — ls-remote exact-ref verification.**
+Dispatch github-ops to check with an exact-ref match:
+
+```
+Agent(subagent_type="vsdd-factory:github-ops", prompt="cd <project-path> && git ls-remote --exit-code origin refs/heads/<branch-name>")
+```
+
+Use `--exit-code` so that exit code 2 means the ref is absent (deleted) and exit code 0
+means it is present. Do NOT rely on "any non-empty output" — `git ls-remote` performs
+prefix matching and could match `refs/heads/<branch-name>-suffix`.
 
 Interpret the result:
-- **Empty output** — branch deleted; proceed.
-- **Non-empty output** — branch still exists; re-check up to 3 times (bounded retry)
-  to absorb GitHub's own queued/async deletion before taking action. If still
-  non-empty after 3 re-checks, dispatch github-ops to force-delete and re-verify:
+- **Exit code 2 (ref absent)** — branch deleted; proceed to Step 9.
+- **Exit code 0 (ref present)** — branch still exists; wait 5–10 seconds between
+  re-checks and re-check up to 3 times (bounded retry) to absorb GitHub's own
+  queued/async deletion before taking action. If still present after 3 re-checks
+  (each separated by a 5–10 second wait), proceed to force-delete.
 
-  ```
-  Agent(subagent_type="vsdd-factory:github-ops", prompt="cd <project-path> && git push origin --delete <branch-name>")
-  ```
+**Step 8d — Force-delete (only if ls-remote still shows branch after bounded retry).**
+Dispatch github-ops to force-delete:
 
-  After the force-delete, re-run the `git ls-remote origin refs/heads/<branch-name>`
-  check. Empty output confirms deletion (idempotent — a 404/already-gone is also
-  success). If deletion is blocked by branch protection rules, emit a BLOCKED note
-  with the reason rather than looping further.
+```
+Agent(subagent_type="vsdd-factory:github-ops", prompt="cd <project-path> && git push origin --delete <branch-name>")
+```
 
-Do NOT emit `STEP_COMPLETE: step=8` until `git ls-remote origin refs/heads/<branch-name>`
-returns empty (branch confirmed deleted).
+After force-delete, re-run the `git ls-remote --exit-code origin refs/heads/<branch-name>`
+check. Exit code 2 confirms deletion. Treat a non-zero exit from the force-delete command
+that indicates "remote ref does not exist" as SUCCESS (idempotent — a 404/already-gone is
+also success; branch was deleted concurrently between the ls-remote check and the push).
+
+If deletion is rejected due to branch-protection rules or insufficient permissions,
+LOG A WARNING and PROCEED — do not dead-end the delivery. The branch-leak is surfaced
+in the STEP_COMPLETE note, but branch protection rejection is not fatal to the workflow.
+
+Do NOT emit `STEP_COMPLETE: step=8` until the ls-remote exact-ref check returns exit code 2
+(branch confirmed deleted), or the fork guard determined deletion verification is not
+applicable for this cross-repository PR.
 
 After completing this step, emit:
 `STEP_COMPLETE: step=8 name=execute-merge status=ok note=PR #<N> merged; remote branch confirmed deleted via ls-remote`

--- a/plugins/vsdd-factory/agents/pr-manager.md
+++ b/plugins/vsdd-factory/agents/pr-manager.md
@@ -257,9 +257,13 @@ Agent(subagent_type="vsdd-factory:github-ops", prompt="cd <project-path> && gh p
 ```
 
 - If `state == MERGED` — proceed to Step 8b.
-- If `state != MERGED` (queued, open, or pending) — do NOT attempt force-delete.
-  A merge queue is still in-flight; deleting the branch now would break the queue run.
-  Wait for the state to reach MERGED before continuing.
+- If `state == CLOSED` — the PR was closed without merging; abort Step 8 and surface a
+  clear BLOCKED note. Do NOT attempt branch deletion.
+- If `state != MERGED` and `state != CLOSED` (queued, open, or pending) — do NOT attempt
+  force-delete. A merge queue is still in-flight; deleting the branch now would break the
+  queue run. Poll every ~30 seconds, up to 10 attempts (total ~5 minutes). If state is
+  still not MERGED after 10 attempts, abort Step 8 and emit a clear BLOCKED note — never
+  hot-loop or wait indefinitely.
 
 **Step 8b — Fork / cross-repo guard.**
 Dispatch github-ops to determine whether the PR head branch is on a fork:
@@ -291,6 +295,11 @@ Interpret the result:
   re-checks and re-check up to 3 times (bounded retry) to absorb GitHub's own
   queued/async deletion before taking action. If still present after 3 re-checks
   (each separated by a 5–10 second wait), proceed to force-delete.
+- **Any other non-zero exit code (e.g. exit 128 — network failure, auth error, or
+  bad repository)** — treat as an error, NOT as "deleted". Retry the ls-remote check
+  up to 2 times with a brief wait between attempts; if the unexpected non-zero exit
+  persists, surface a clear failure note and abort the deletion verification. Do NOT
+  proceed as if the branch is gone.
 
 **Step 8d — Force-delete (only if ls-remote still shows branch after bounded retry).**
 Dispatch github-ops to force-delete:
@@ -306,14 +315,25 @@ also success; branch was deleted concurrently between the ls-remote check and th
 
 If deletion is rejected due to branch-protection rules or insufficient permissions,
 LOG A WARNING and PROCEED — do not dead-end the delivery. The branch-leak is surfaced
-in the STEP_COMPLETE note, but branch protection rejection is not fatal to the workflow.
+in the STEP_COMPLETE note, but branch-protection rejection is not fatal to the workflow.
 
-Do NOT emit `STEP_COMPLETE: step=8` until the ls-remote exact-ref check returns exit code 2
-(branch confirmed deleted), or the fork guard determined deletion verification is not
-applicable for this cross-repository PR.
+Emit `STEP_COMPLETE: step=8` when ANY of the following conditions is true:
+(a) the ls-remote exact-ref check returns exit code 2 (branch confirmed deleted),
+(b) deletion was rejected by branch-protection rules or insufficient permissions
+    (warn-and-proceed — the warning has been logged and delivery continues), or
+(c) the fork guard determined origin verification is not applicable (cross-repo PR).
 
-After completing this step, emit:
-`STEP_COMPLETE: step=8 name=execute-merge status=ok note=PR #<N> merged; remote branch confirmed deleted via ls-remote`
+Set the STEP_COMPLETE note dynamically to reflect the actual deletion outcome:
+
+After completing this step, emit one of:
+- `STEP_COMPLETE: step=8 name=execute-merge status=ok note=PR #<N> merged; remote branch confirmed deleted via ls-remote`
+- `STEP_COMPLETE: step=8 name=execute-merge status=ok note=PR #<N> merged; branch-deletion skipped — cross-repository (fork) PR, origin verification not applicable`
+- `STEP_COMPLETE: step=8 name=execute-merge status=ok note=PR #<N> merged; branch-deletion-warning — protection-rejected-warning, branch may still exist on remote`
+
+Choose the note that reflects the actual <deletion-outcome>: deleted / skipped-fork /
+protection-rejected-warning. Do NOT hardcode the "confirmed deleted" wording when the
+actual outcome was different.
+
 **Proceed immediately to step 9.**
 
 ### Step 9: Post-merge

--- a/plugins/vsdd-factory/agents/pr-manager.md
+++ b/plugins/vsdd-factory/agents/pr-manager.md
@@ -242,15 +242,44 @@ Read `.factory/merge-config.yaml` for autonomy level:
 - **Level 4:** Auto-merge if CI passes
 
 After github-ops returns, YOU must verify the merge succeeded.
-Do NOT treat the sub-agent's response as terminal. Continue immediately to step 9.
+Do NOT treat the sub-agent's response as terminal.
+
+**Verify remote branch deletion** — `gh pr merge --delete-branch` only *requests*
+deletion; it is asynchronous and not guaranteed (especially under merge queues,
+see cli/cli#9073). You MUST verify the branch is actually gone before emitting
+STEP_COMPLETE for step 8. Dispatch github-ops to check:
+
+```
+Agent(subagent_type="vsdd-factory:github-ops", prompt="cd <project-path> && git ls-remote origin refs/heads/<branch-name>")
+```
+
+Interpret the result:
+- **Empty output** — branch deleted; proceed.
+- **Non-empty output** — branch still exists; re-check up to 3 times (bounded retry)
+  to absorb GitHub's own queued/async deletion before taking action. If still
+  non-empty after 3 re-checks, dispatch github-ops to force-delete and re-verify:
+
+  ```
+  Agent(subagent_type="vsdd-factory:github-ops", prompt="cd <project-path> && git push origin --delete <branch-name>")
+  ```
+
+  After the force-delete, re-run the `git ls-remote origin refs/heads/<branch-name>`
+  check. Empty output confirms deletion (idempotent — a 404/already-gone is also
+  success). If deletion is blocked by branch protection rules, emit a BLOCKED note
+  with the reason rather than looping further.
+
+Do NOT emit `STEP_COMPLETE: step=8` until `git ls-remote origin refs/heads/<branch-name>`
+returns empty (branch confirmed deleted).
 
 After completing this step, emit:
-`STEP_COMPLETE: step=8 name=execute-merge status=ok note=PR #<N> merged`
+`STEP_COMPLETE: step=8 name=execute-merge status=ok note=PR #<N> merged; remote branch confirmed deleted via ls-remote`
 **Proceed immediately to step 9.**
 
 ### Step 9: Post-merge
 
-Trigger worktree cleanup and state updates. Compile the final deliverables report.
+Trigger worktree cleanup and state updates. The remote feature branch has been
+verified deleted (confirmed by ls-remote returning empty in step 8). Compile
+the final deliverables report.
 
 After completing this step, emit:
 `STEP_COMPLETE: step=9 name=post-merge status=ok note=cleanup complete`

--- a/plugins/vsdd-factory/skills/code-delivery/SKILL.md
+++ b/plugins/vsdd-factory/skills/code-delivery/SKILL.md
@@ -188,10 +188,17 @@ Agent(subagent_type="vsdd-factory:github-ops", prompt="cd <project-path> && gh p
 After successful merge (delegated to devops-engineer):
 
 1. Remote branch deletion verified: `--delete-branch` only *requests* deletion
-   (async; not guaranteed under merge queues — cli/cli#9073). Confirm via
-   `git ls-remote origin refs/heads/<branch>` returning empty. If non-empty,
-   dispatch github-ops to `git push origin --delete <branch>` and re-verify
-   (idempotent — already-gone/404 is success).
+   (async; not guaranteed under merge queues — cli/cli#9073). Full hardened
+   sequence (see pr-manager.md Step 8 for authoritative detail):
+   (a) Confirm PR state is MERGED (not queued) before deletion work.
+   (b) Check `isCrossRepository`; if fork PR, skip origin deletion — branch
+       lives on the contributor's fork, not origin.
+   (c) Verify with exact-ref: `git ls-remote --exit-code origin refs/heads/<branch>`
+       (exit code 2 = not found = deleted; avoids prefix-match false positives).
+   (d) If still present, wait 5–10 seconds between re-checks (bounded retry, up
+       to 3 re-checks), then force-delete: `git push origin --delete <branch>`
+       and re-verify (idempotent — already-gone/404 is success).
+   (e) If branch-protection blocks deletion, log a warning and proceed — not fatal.
 2. Remove local worktree: `git worktree remove .worktrees/STORY-NNN`
 3. Update `.factory/STATE.md` with merge status, PR number, and timestamp
 4. Write delivery report to `.factory/code-delivery/STORY-NNN/delivery.md`

--- a/plugins/vsdd-factory/skills/code-delivery/SKILL.md
+++ b/plugins/vsdd-factory/skills/code-delivery/SKILL.md
@@ -187,7 +187,11 @@ Agent(subagent_type="vsdd-factory:github-ops", prompt="cd <project-path> && gh p
 
 After successful merge (delegated to devops-engineer):
 
-1. Remote branch deleted (`--delete-branch` handles this)
+1. Remote branch deletion verified: `--delete-branch` only *requests* deletion
+   (async; not guaranteed under merge queues — cli/cli#9073). Confirm via
+   `git ls-remote origin refs/heads/<branch>` returning empty. If non-empty,
+   dispatch github-ops to `git push origin --delete <branch>` and re-verify
+   (idempotent — already-gone/404 is success).
 2. Remove local worktree: `git worktree remove .worktrees/STORY-NNN`
 3. Update `.factory/STATE.md` with merge status, PR number, and timestamp
 4. Write delivery report to `.factory/code-delivery/STORY-NNN/delivery.md`

--- a/plugins/vsdd-factory/skills/fix-pr-delivery/SKILL.md
+++ b/plugins/vsdd-factory/skills/fix-pr-delivery/SKILL.md
@@ -127,9 +127,15 @@ Max 10 review cycles:
 
 ### Step 10: Merge and Cleanup
 
-pr-manager spawns github-ops to merge, then orchestrator spawns devops-engineer and state-manager for cleanup:
+pr-manager spawns github-ops to merge, then verifies remote branch deletion,
+then orchestrator spawns devops-engineer and state-manager for cleanup:
 ```
 github-ops: "cd <project-path> && gh pr merge --squash --delete-branch"
+# Post-merge: verify branch is actually deleted — --delete-branch is async
+# (not guaranteed under merge queues; see cli/cli#9073).
+github-ops: "cd <project-path> && git ls-remote origin refs/heads/<branch>"
+# Empty output → deleted. Non-empty → bounded retry (up to 3 re-checks),
+# then force-delete: git push origin --delete <branch> and re-verify.
 devops-engineer: "cd <project-path> && git worktree remove .worktrees/FIX-P[phase]-NNN"
 state-manager: "Update STATE.md with FIX-P[phase]-NNN completion — merge status, PR number, timestamp"
 ```

--- a/plugins/vsdd-factory/skills/fix-pr-delivery/SKILL.md
+++ b/plugins/vsdd-factory/skills/fix-pr-delivery/SKILL.md
@@ -133,9 +133,16 @@ then orchestrator spawns devops-engineer and state-manager for cleanup:
 github-ops: "cd <project-path> && gh pr merge --squash --delete-branch"
 # Post-merge: verify branch is actually deleted — --delete-branch is async
 # (not guaranteed under merge queues; see cli/cli#9073).
-github-ops: "cd <project-path> && git ls-remote origin refs/heads/<branch>"
-# Empty output → deleted. Non-empty → bounded retry (up to 3 re-checks),
-# then force-delete: git push origin --delete <branch> and re-verify.
+# Full hardened sequence (pr-manager.md Step 8 is authoritative):
+# 1. Confirm PR state is MERGED (not queued): gh pr view --json state,mergeStateStatus
+# 2. Check isCrossRepository: gh pr view --json isCrossRepository,headRepositoryOwner,headRefName
+#    If fork PR → skip origin deletion (branch lives on contributor's fork).
+# 3. Exact-ref check: git ls-remote --exit-code origin refs/heads/<branch>
+#    (exit code 2 = not found = deleted; avoids prefix-match false positives)
+# 4. If still present: wait 5–10 seconds between re-checks, bounded retry (up to 3),
+#    then force-delete: git push origin --delete <branch> and re-verify
+#    (idempotent — already-gone/404 is success).
+# 5. If branch-protection blocks deletion: log warning and proceed (not fatal).
 devops-engineer: "cd <project-path> && git worktree remove .worktrees/FIX-P[phase]-NNN"
 state-manager: "Update STATE.md with FIX-P[phase]-NNN completion — merge status, PR number, timestamp"
 ```

--- a/plugins/vsdd-factory/tests/pr-lifecycle-hooks.bats
+++ b/plugins/vsdd-factory/tests/pr-lifecycle-hooks.bats
@@ -484,3 +484,72 @@ EOF
   run grep -iE 'exit.?(code.)?(128|unexpected|other)|unexpected.*(exit|non.zero)|non.zero.*unexpected|network.*fail|auth.*fail|ls.remote.*error|error.*ls.remote' "$file"
   [ "$status" -eq 0 ]
 }
+
+# ========================================================================
+# pr-manager Step 8 fourth-pass hardening (issue #128 round 4)
+# ========================================================================
+# RED GATE: these tests MUST fail against the unmodified pr-manager.md
+# before the Step (Green) fixes are applied.
+
+@test "pr-manager step-8d: post-force-delete ls-remote verification uses bounded retry" {
+  # Fix 1 (HIGH): After a successful git push origin --delete, an immediate
+  # ls-remote re-verify can still show the branch present (GitHub replication
+  # lag). The current single re-check after force-delete is not enough — the
+  # playbook must instruct a bounded retry (with explicit wait between attempts)
+  # on the post-force-delete ls-remote check, not just one immediate re-check.
+  local file="$PLUGIN_ROOT/agents/pr-manager.md"
+  # The post-force-delete ls-remote check must mention a bounded retry or
+  # multiple attempts to absorb replication lag.
+  run grep -iE 'post.force.delete.*retr|retr.*post.force.delete|after.*force.delete.*up.to|after.*push.*delete.*retr|retr.*after.*push.*delete|post.delete.*retr|retr.*post.delete|force.delete.*up.to.*retr|up.to.*retr.*force.delete' "$file"
+  [ "$status" -eq 0 ]
+}
+
+@test "pr-manager step-8d: push exit-0 accepted as deletion confirmation even if ls-remote lags" {
+  # Fix 1 (HIGH): If git push origin --delete itself returned exit 0 (or
+  # "remote ref does not exist"), the completion gate must treat the deletion
+  # as successful even if a subsequent lagging ls-remote still transiently
+  # shows the branch present. This prevents the rigid completion gate from
+  # wedging on replication-lag.
+  local file="$PLUGIN_ROOT/agents/pr-manager.md"
+  # The playbook must instruct: push exit 0 (success) is accepted as
+  # confirmation even if the post-delete ls-remote is still non-empty.
+  run grep -iE 'push.*exit.0.*success|push.*exit.0.*confirm|push.*success.*lag|replication.lag|lag.*replication|push.*succe.*even if|push.*succe.*still|accept.*push.*success|push.*delete.*success.*lag|push.*0.*still.*show|push.*0.*transient' "$file"
+  [ "$status" -eq 0 ]
+}
+
+@test "pr-manager step-8: abort path explicitly HALTS and must not proceed to step 9" {
+  # Fix 2 (LOW): Step 8a can abort (PR state CLOSED, or merge-queue wait
+  # bound exceeded) emitting a BLOCKED note, but the section currently ends
+  # with "Proceed immediately to step 9." — an agent could then run step 9
+  # worktree cleanup on an UNMERGED PR. The playbook must explicitly state
+  # that if Step 8 aborts, the agent HALTS and must NOT proceed to Step 9.
+  local file="$PLUGIN_ROOT/agents/pr-manager.md"
+  # Must instruct that abort path does NOT proceed to step 9.
+  run grep -iE 'abort.*do not proceed|abort.*must not proceed|abort.*halt|halt.*abort|blocked.*do not proceed|do not proceed.*step.?9|must not.*step.?9.*abort|abort.*step.?9.*halt|step.8.*abort.*halt' "$file"
+  [ "$status" -eq 0 ]
+}
+
+@test "pr-manager step-8c: instructs stdout exact-line parse for refs/heads branch" {
+  # Fix 3 (HIGH, cheap): Rather than relying solely on --exit-code (which
+  # could match refs/heads/<branch>-suffix via prefix matching), the playbook
+  # must also instruct parsing stdout to confirm a line ending exactly in
+  # <TAB>refs/heads/<branch-name>, removing ambiguity.
+  local file="$PLUGIN_ROOT/agents/pr-manager.md"
+  # Must mention parsing stdout / confirming an exact line match against
+  # the returned ref string.
+  run grep -iE 'parse.*stdout|stdout.*parse|confirm.*line.*refs.heads|exact.*line.*refs.heads|line.*ending.*refs.heads|tab.*refs.heads|grep.*refs.heads.*exact|exact.*grep.*refs.heads' "$file"
+  [ "$status" -eq 0 ]
+}
+
+@test "pr-manager step-8d: force-delete error taxonomy classifies transient errors" {
+  # Fix 4 (MEDIUM): Step 8d must explicitly classify non-zero git push origin
+  # --delete exits into distinct branches: transient/network errors (retry
+  # briefly), branch-protection/permission rejection (warn-and-proceed, per
+  # existing behavior), already-gone (success/idempotent), and persistent
+  # unexpected errors (surface clear failure). The transient/network retry
+  # branch must be explicitly named.
+  local file="$PLUGIN_ROOT/agents/pr-manager.md"
+  # Must mention transient/network errors → retry for force-delete.
+  run grep -iE 'transient.*retr|retr.*transient|network.*retr.*push.*(delete|origin)|push.*(delete|origin).*network.*retr|transient.*push.*delete|push.*delete.*transient|network.*error.*retr.*delete|delete.*network.*error.*retr' "$file"
+  [ "$status" -eq 0 ]
+}

--- a/plugins/vsdd-factory/tests/pr-lifecycle-hooks.bats
+++ b/plugins/vsdd-factory/tests/pr-lifecycle-hooks.bats
@@ -412,3 +412,75 @@ EOF
   [ "$status" -eq 0 ]
 }
 
+# ========================================================================
+# pr-manager Step 8 third-pass hardening (issue #128 round 3)
+# ========================================================================
+# RED GATE: these tests MUST fail against the unmodified pr-manager.md
+# before the Step (Green) fixes are applied.
+
+@test "pr-manager step-8: completion gate admits branch-protection-rejected case" {
+  # Fix 1 (HIGH): The STEP_COMPLETE gate must allow emission when deletion was
+  # rejected by branch-protection or permissions (warn-and-proceed case).
+  # The gate line must include all three conditions: (a) ls-remote exit 2
+  # (deleted), (b) branch-protection/permission rejection (warn-and-proceed),
+  # (c) fork guard skipped (cross-repo). A gate that only lists (a) and (c)
+  # creates a deadlock: the branch still exists → ls-remote returns 0 → gate
+  # never fires → STEP_COMPLETE is never emitted.
+  local file="$PLUGIN_ROOT/agents/pr-manager.md"
+  # The completion-gate sentence must reference branch-protection or permission
+  # rejection as an allowed emission condition alongside ls-remote exit 2.
+  run grep -iE 'protection.*rejected|rejected.*protection|permission.*rejected|rejected.*permission|branch.protection.*proceed|warn.and.proceed' "$file"
+  [ "$status" -eq 0 ]
+  # Crucially the three-way OR must be in the gate itself — verify the gate
+  # sentence references all three completion paths.
+  run grep -iE 'STEP_COMPLETE.*step=8.*(fork|cross|protection|permission|warn)|fork.*STEP_COMPLETE.*step=8|protection.*STEP_COMPLETE.*step=8' "$file"
+  [ "$status" -eq 0 ]
+}
+
+@test "pr-manager step-8: merge-queue wait is bounded with explicit poll interval" {
+  # Fix 2 (MEDIUM): Step 8a must specify a poll interval (e.g. ~30 seconds)
+  # and a maximum attempt count (e.g. up to 10 attempts) when waiting for
+  # state == MERGED. An unbounded "wait" hot-loops or hangs forever; the
+  # agent needs explicit numbers to know when to give up.
+  local file="$PLUGIN_ROOT/agents/pr-manager.md"
+  # Must include a numeric poll-interval instruction near the wait-for-MERGED prose.
+  run grep -iE '(poll|check|wait).*every.*(second|minute|[0-9]+s)|every.*(second|minute|[0-9]+s).*(poll|check|wait)|30.second|30s' "$file"
+  [ "$status" -eq 0 ]
+  # Must include a maximum attempt count or timeout.
+  run grep -iE 'up to.*(attempt|poll|check|time)|max.*(attempt|poll|check)|(attempt|poll|check).*max|[0-9]+.attempt' "$file"
+  [ "$status" -eq 0 ]
+}
+
+@test "pr-manager step-8: merge-queue wait FAILS on CLOSED state" {
+  # Fix 2 (MEDIUM): If the PR reaches CLOSED (rather than MERGED) the agent
+  # must abort — not continue polling. The playbook must explicitly name
+  # CLOSED as a terminal failure condition in Step 8a.
+  local file="$PLUGIN_ROOT/agents/pr-manager.md"
+  run grep -iE 'CLOSED.*(fail|abort|stop|halt|error)|state.*CLOSED.*(fail|abort)|CLOSED.*terminal' "$file"
+  [ "$status" -eq 0 ]
+}
+
+@test "pr-manager step-8: STEP_COMPLETE note is dynamic not hardcoded" {
+  # Fix 3 (LOW): The STEP_COMPLETE note must reflect the actual outcome:
+  # "deleted" / "skipped-fork" / "protection-rejected-warning". A static
+  # string that always says "confirmed deleted via ls-remote" is incorrect
+  # when deletion was skipped (fork) or rejected (branch protection).
+  local file="$PLUGIN_ROOT/agents/pr-manager.md"
+  # The note template must include a dynamic/variable placeholder or
+  # conditional phrasing rather than a single hardcoded string.
+  # Accept: angle-bracket placeholders, OR explicit conditional note phrasing.
+  run grep -iE 'note=.*<outcome>|note=.*<result>|note=.*<deletion.outcome>|deletion.outcome|actual outcome|reflect.*actual|dynamic.*note' "$file"
+  [ "$status" -eq 0 ]
+}
+
+@test "pr-manager step-8: unexpected ls-remote exit codes treated as errors not success" {
+  # Fix 4 (LOW): Step 8c handles exit 0 and exit 2 only. Exit 128 (network
+  # failure, auth error, or bad repository) must be treated as an error
+  # requiring retry then surface — NOT silently treated as "deleted" (exit 2).
+  # The playbook must explicitly instruct the agent about unexpected non-zero
+  # exit codes from git ls-remote.
+  local file="$PLUGIN_ROOT/agents/pr-manager.md"
+  # Must mention exit 128 or "unexpected" / "non-zero" exit handling near ls-remote.
+  run grep -iE 'exit.?(code.)?(128|unexpected|other)|unexpected.*(exit|non.zero)|non.zero.*unexpected|network.*fail|auth.*fail|ls.remote.*error|error.*ls.remote' "$file"
+  [ "$status" -eq 0 ]
+}

--- a/plugins/vsdd-factory/tests/pr-lifecycle-hooks.bats
+++ b/plugins/vsdd-factory/tests/pr-lifecycle-hooks.bats
@@ -240,3 +240,99 @@ EOF
   [[ "$output" == *"WARNING"* ]]
 }
 
+# ========================================================================
+# pr-manager Step 8 remote-branch-deletion verification (issue #128)
+# ========================================================================
+# These are prompt-contract tests: they assert that the pr-manager.md
+# playbook prose contains the required post-merge ls-remote verification
+# block and that STEP_COMPLETE: step=8 is gated on empty ls-remote output.
+# They MUST fail against the unmodified pr-manager.md (RED gate).
+
+@test "pr-manager step-8: contains git ls-remote branch-deletion verification" {
+  # pr-manager Step 8 must dispatch a git ls-remote check after the merge
+  # to verify the remote branch is actually gone (not just requested).
+  # Root cause: gh pr merge --delete-branch exit 0 is async (cli/cli#9073).
+  local file="$PLUGIN_ROOT/agents/pr-manager.md"
+  run grep -F 'git ls-remote' "$file"
+  [ "$status" -eq 0 ]
+}
+
+@test "pr-manager step-8: ls-remote check targets refs/heads/ namespace" {
+  # The verification must use the full refs/heads/<branch> path so it
+  # targets the remote tracking ref, not tags or other refs.
+  local file="$PLUGIN_ROOT/agents/pr-manager.md"
+  run grep -F 'refs/heads/' "$file"
+  [ "$status" -eq 0 ]
+}
+
+@test "pr-manager step-8: STEP_COMPLETE step=8 gated on ls-remote empty" {
+  # STEP_COMPLETE: step=8 must NOT be emitted until ls-remote returns empty.
+  # Verify that the file documents that the gate condition is ls-remote
+  # returning empty (branch deleted) before the step=8 completion signal.
+  local file="$PLUGIN_ROOT/agents/pr-manager.md"
+  # The playbook must mention that STEP_COMPLETE is gated on the ls-remote
+  # verification confirming the branch is gone.
+  run grep -E 'ls-remote.*empty|empty.*ls-remote|ls-remote.*deleted|deleted.*ls-remote|STEP_COMPLETE.*step=8.*ls-remote|ls-remote.*STEP_COMPLETE' "$file"
+  [ "$status" -eq 0 ]
+}
+
+@test "pr-manager step-8: includes force-delete fallback via github-ops" {
+  # If ls-remote is non-empty after the bounded retry, pr-manager must
+  # dispatch github-ops to force-delete: git push origin --delete <branch>.
+  local file="$PLUGIN_ROOT/agents/pr-manager.md"
+  run grep -F 'push origin --delete' "$file"
+  [ "$status" -eq 0 ]
+}
+
+@test "pr-manager step-8: bounded retry before force-delete" {
+  # The verification must include a bounded retry (not an infinite loop)
+  # to absorb GitHub's own queued/async deletion before force-deleting.
+  # The retry must be in the context of the branch-deletion verification,
+  # so we check for the combination of ls-remote and retry/bounded language.
+  local file="$PLUGIN_ROOT/agents/pr-manager.md"
+  # ls-remote must appear (from earlier test), and there must be a bounded
+  # retry described in the step-8 block (cap/up to 3/bounded/retry N times).
+  run grep -E 'up to.*[0-9].*time|[0-9].*time.*retry|bounded retry|retry.*up to|cap.*retr' "$file"
+  [ "$status" -eq 0 ]
+}
+
+@test "pr-manager step-9: post-merge wording reflects verified deletion" {
+  # Step 9 wording must say the remote branch is *verified* deleted,
+  # not merely assumed deleted by --delete-branch.
+  local file="$PLUGIN_ROOT/agents/pr-manager.md"
+  run grep -E 'verified|confirmed|ls-remote' "$file"
+  [ "$status" -eq 0 ]
+}
+
+@test "code-delivery skill: remote branch deletion uses ls-remote verification" {
+  # skills/code-delivery/SKILL.md Step 10 must not claim --delete-branch
+  # alone handles deletion; it must document the ls-remote verify step.
+  local file="$PLUGIN_ROOT/skills/code-delivery/SKILL.md"
+  run grep -F 'git ls-remote' "$file"
+  [ "$status" -eq 0 ]
+}
+
+@test "fix-pr-delivery skill: merge step includes ls-remote verification" {
+  # skills/fix-pr-delivery/SKILL.md merge step must include the post-merge
+  # ls-remote verification note (sibling-sweep TD-VSDD-060).
+  local file="$PLUGIN_ROOT/skills/fix-pr-delivery/SKILL.md"
+  run grep -F 'git ls-remote' "$file"
+  [ "$status" -eq 0 ]
+}
+
+@test "code-delivery workflow: merge step includes ls-remote verification" {
+  # workflows/code-delivery.lobster merge-pr task must include the
+  # ls-remote verify-and-reconcile clause (sibling-sweep TD-VSDD-060).
+  local file="$PLUGIN_ROOT/workflows/code-delivery.lobster"
+  run grep -F 'ls-remote' "$file"
+  [ "$status" -eq 0 ]
+}
+
+@test "greenfield workflow: merge step includes ls-remote verification" {
+  # workflows/greenfield.lobster merge-pr task must include the
+  # ls-remote verify-and-reconcile clause (sibling-sweep TD-VSDD-060).
+  local file="$PLUGIN_ROOT/workflows/greenfield.lobster"
+  run grep -F 'ls-remote' "$file"
+  [ "$status" -eq 0 ]
+}
+

--- a/plugins/vsdd-factory/tests/pr-lifecycle-hooks.bats
+++ b/plugins/vsdd-factory/tests/pr-lifecycle-hooks.bats
@@ -336,3 +336,79 @@ EOF
   [ "$status" -eq 0 ]
 }
 
+# ========================================================================
+# pr-manager Step 8 adversary hardening: 6 behaviors (issue #128 round 2)
+# ========================================================================
+# RED GATE: these tests MUST fail against the unmodified pr-manager.md
+# before the Step (Green) fixes are applied.
+
+@test "pr-manager step-8: instructs wait/sleep between re-checks" {
+  # Each re-check in the bounded retry loop must include an explicit
+  # wait/sleep instruction (e.g. "wait 5 seconds", "sleep 5–10 seconds")
+  # so the agent absorbs GitHub's async deletion latency instead of
+  # firing three re-checks in milliseconds (adversary finding 1).
+  # The instruction must appear in the branch-deletion context: near a
+  # mention of "second(s)" paired with a delay intent — "wait N s" or
+  # "sleep N s" or "5 seconds between" etc.
+  local file="$PLUGIN_ROOT/agents/pr-manager.md"
+  run grep -iE '(wait|sleep).*([0-9]+.?second|second.*[0-9]+)|([0-9]+.?second|second.*[0-9]+).*(wait|sleep|between|re.?check)' "$file"
+  [ "$status" -eq 0 ]
+}
+
+@test "pr-manager step-8: detects cross-repo fork PRs before verifying deletion" {
+  # For fork PRs the head branch lives on the contributor's fork remote,
+  # not on origin. Checking git ls-remote origin gives a false "deleted".
+  # pr-manager must instruct: determine whether the PR is cross-repo
+  # (e.g. gh pr view --json isCrossRepository) and SKIP origin
+  # branch-deletion verification for fork PRs (adversary finding 2).
+  local file="$PLUGIN_ROOT/agents/pr-manager.md"
+  run grep -iE 'fork|isCrossRepository|cross.?repo|cross-repository' "$file"
+  [ "$status" -eq 0 ]
+}
+
+@test "pr-manager step-8: confirms PR merged state before force-deleting branch" {
+  # If a PR is queued in a GitHub Merge Queue, gh pr merge returns success
+  # while the merge is still in-flight. Force-deleting the branch at that
+  # point breaks the queue run. pr-manager must confirm the PR state is
+  # MERGED (e.g. gh pr view --json state → MERGED) before force-deleting
+  # and skip force-delete if the PR is queued (adversary finding 3).
+  local file="$PLUGIN_ROOT/agents/pr-manager.md"
+  run grep -iE 'merge.?queue|MERGED|--json state|gh pr view.*state|confirm.*merge|merge.*confirm' "$file"
+  [ "$status" -eq 0 ]
+  # Specifically check that force-delete is guarded by a merged-state check
+  run grep -iE '(MERGED|merged state|merge queue).*(force.?delete|push.*delete)|force.?delete.*(MERGED|merged state|merge queue)' "$file"
+  [ "$status" -eq 0 ]
+}
+
+@test "pr-manager step-8: treats already-deleted branch as success (idempotent)" {
+  # git push origin --delete returns non-zero if the branch was already
+  # deleted (race between ls-remote check and the push). The agent must
+  # be instructed to treat "remote ref does not exist" / already-gone as
+  # SUCCESS, not a workflow failure (adversary finding 4).
+  local file="$PLUGIN_ROOT/agents/pr-manager.md"
+  run grep -iE 'already.?gone|already.?deleted|remote ref does not exist|idempotent|non.?zero.*already|already.*success' "$file"
+  [ "$status" -eq 0 ]
+}
+
+@test "pr-manager step-8: uses exact-ref match not prefix match for ls-remote" {
+  # git ls-remote origin refs/heads/<branch> performs prefix matching:
+  # refs/heads/feat matches refs/heads/feat-2. The playbook must instruct
+  # an exact-ref check — either git ls-remote --exit-code origin
+  # refs/heads/<branch> (exit code 2 = not found) or an exact-line match
+  # against the returned ref string (adversary finding 5).
+  local file="$PLUGIN_ROOT/agents/pr-manager.md"
+  run grep -iE '\-\-exit-code|exact.?ref|exact.?match|exact.?line|exact ref' "$file"
+  [ "$status" -eq 0 ]
+}
+
+@test "pr-manager step-8: logs warning and proceeds on branch-protection rejection" {
+  # If branch-protection or permissions prevent deletion, the current prose
+  # emits BLOCKED and stops the whole delivery. Instead the agent must log
+  # a WARNING and PROCEED — the branch-leak is surfaced but not fatal
+  # (adversary finding 6).
+  local file="$PLUGIN_ROOT/agents/pr-manager.md"
+  # Must NOT dead-end with BLOCKED; must emit a warning and continue.
+  run grep -iE 'warn.*proceed|proceed.*warn|log.*warn|warning.*proceed|protection.*warn|warn.*protection' "$file"
+  [ "$status" -eq 0 ]
+}
+

--- a/plugins/vsdd-factory/workflows/code-delivery.lobster
+++ b/plugins/vsdd-factory/workflows/code-delivery.lobster
@@ -410,11 +410,15 @@ workflow:
       depends_on: [dependency-merge-check]
       task: >
         Merge PR via github-ops: gh pr merge --squash --delete-branch.
-        After merge, verify remote branch deletion via github-ops:
-        git ls-remote origin refs/heads/<branch> must return empty before
-        marking merge complete. If non-empty, bounded retry (up to 3 re-checks)
-        to absorb GitHub async deletion, then force-delete via
-        git push origin --delete <branch> and re-verify (idempotent).
+        After merge, run the hardened branch-deletion verification sequence
+        per pr-manager.md Step 8 (authoritative):
+        (1) Confirm PR state is MERGED (not queued) before deletion work;
+        (2) Check isCrossRepository — skip origin deletion for fork PRs;
+        (3) Exact-ref ls-remote: git ls-remote --exit-code origin refs/heads/<branch>
+            (exit code 2 = deleted; avoids prefix-match false positives);
+        (4) If still present: wait 5–10 seconds between re-checks, bounded
+            retry up to 3 times, then force-delete and re-verify (idempotent);
+        (5) If branch-protection blocks deletion: log warning and proceed.
         Read .factory/merge-config.yaml for autonomy level.
         Level 3: label for human review.
         Level 3.5: auto-merge low-risk, label medium/high.

--- a/plugins/vsdd-factory/workflows/code-delivery.lobster
+++ b/plugins/vsdd-factory/workflows/code-delivery.lobster
@@ -410,6 +410,11 @@ workflow:
       depends_on: [dependency-merge-check]
       task: >
         Merge PR via github-ops: gh pr merge --squash --delete-branch.
+        After merge, verify remote branch deletion via github-ops:
+        git ls-remote origin refs/heads/<branch> must return empty before
+        marking merge complete. If non-empty, bounded retry (up to 3 re-checks)
+        to absorb GitHub async deletion, then force-delete via
+        git push origin --delete <branch> and re-verify (idempotent).
         Read .factory/merge-config.yaml for autonomy level.
         Level 3: label for human review.
         Level 3.5: auto-merge low-risk, label medium/high.

--- a/plugins/vsdd-factory/workflows/greenfield.lobster
+++ b/plugins/vsdd-factory/workflows/greenfield.lobster
@@ -782,12 +782,15 @@ workflow:
                 depends_on: [dependency-merge-check]
                 task: >
                   Merge PR via github-ops: gh pr merge --squash --delete-branch.
-                  After merge, verify remote branch deletion via github-ops:
-                  git ls-remote origin refs/heads/<branch> must return empty
-                  before marking merge complete. If non-empty, bounded retry
-                  (up to 3 re-checks) to absorb GitHub async deletion, then
-                  force-delete via git push origin --delete <branch> and
-                  re-verify (idempotent).
+                  After merge, run the hardened branch-deletion verification
+                  sequence per pr-manager.md Step 8 (authoritative):
+                  (1) Confirm PR state is MERGED (not queued) before deletion work;
+                  (2) Check isCrossRepository — skip origin deletion for fork PRs;
+                  (3) Exact-ref ls-remote: git ls-remote --exit-code origin refs/heads/<branch>
+                      (exit code 2 = deleted; avoids prefix-match false positives);
+                  (4) If still present: wait 5–10 seconds between re-checks, bounded
+                      retry up to 3 times, then force-delete and re-verify (idempotent);
+                  (5) If branch-protection blocks deletion: log warning and proceed.
                   Read .factory/merge-config.yaml for autonomy level.
 
               - name: cleanup-worktree

--- a/plugins/vsdd-factory/workflows/greenfield.lobster
+++ b/plugins/vsdd-factory/workflows/greenfield.lobster
@@ -782,6 +782,12 @@ workflow:
                 depends_on: [dependency-merge-check]
                 task: >
                   Merge PR via github-ops: gh pr merge --squash --delete-branch.
+                  After merge, verify remote branch deletion via github-ops:
+                  git ls-remote origin refs/heads/<branch> must return empty
+                  before marking merge complete. If non-empty, bounded retry
+                  (up to 3 re-checks) to absorb GitHub async deletion, then
+                  force-delete via git push origin --delete <branch> and
+                  re-verify (idempotent).
                   Read .factory/merge-config.yaml for autonomy level.
 
               - name: cleanup-worktree


### PR DESCRIPTION
## Summary

Fixes #128 — `pr-manager` treated `gh pr merge --squash --delete-branch` success as proof the remote feature branch was deleted, but that flag only *requests* deletion: it is asynchronous (and deferred under merge queues), so branches frequently survive at their pre-squash SHA (cli/cli#9073, #11187). Stories shipped "successfully" while leaving dangling branches needing manual cleanup.

This adds a real **post-merge branch-deletion verification** to the pr-manager playbook (Step 8) and sweeps the same discipline across every merge callsite, with prompt-contract bats tests. The engine already had the `git ls-remote` verifier primitive elsewhere (`deliver-story`, `factory-worktree-health`) — it just wasn't applied here.

## What changed

`pr-manager.md` Step 8 now verifies deletion robustly (Steps 8a–8d):
- **8a — merge-queue guard:** confirm PR state is `MERGED` before deleting; bounded poll (~30s × up to 10) ; abort (halt, do not proceed to Step 9) on `CLOSED` or timeout.
- **8b — fork guard:** skip origin verification for cross-repo (fork) PRs — the branch isn't on `origin`.
- **8c — exact-ref check:** `git ls-remote --exit-code origin refs/heads/<branch>` **plus** an exact stdout-line parse (no prefix false-positives); unexpected exit (e.g. 128 network/auth) treated as error, not "deleted".
- **8d — reconcile:** bounded post-delete retry to absorb replication lag; force-delete error taxonomy (transient→retry / branch-protection→warn-and-proceed / already-gone→idempotent success / persistent→fail); three-way completion gate (deleted **or** protection-rejected **or** fork-skipped); dynamic `STEP_COMPLETE` note reflecting the actual outcome.

Sibling-swept (short-form, deferring to pr-manager.md as authoritative): `code-delivery/SKILL.md`, `fix-pr-delivery/SKILL.md`, `workflows/code-delivery.lobster`, `workflows/greenfield.lobster`.

## Test evidence

- **45/45** `pr-lifecycle-hooks.bats` (TDD — 21 new prompt-contract assertions, each confirmed red→green).
- No Rust touched; diff = 6 files (`pr-manager.md` +124, bats +313, 4 sibling files).

## Adversarial review

Reviewed by a cross-model-family fresh-context adversary (**Gemini 3.5 Flash High** via antigravity-cli), sliced per-file, run to asymptotic convergence over 3 passes (findings 6→4→4, severity shifting from core-correctness to fine edge-robustness). Each pass caught a real regression the prior fix introduced (branch-protection completion deadlock; post-delete replication-lag wedge) — all fixed in-scope, none deferred. Full trail + raw reviews: `.factory/research/issues/adversary/issue-128-gemini-review-2026-06-09.md` (factory-artifacts branch).

## Notes

- The fork and merge-queue guards are **defensive**: the factory's own PRs are same-repo and don't use merge queues, but `pr-manager` is a general-purpose agent, so the guards are correct.
- Source edits reach the operator cache only on release (per CLAUDE.md); this PR targets `develop`.

Closes #128
