### PR TITLE
chore: gitignore repo-root runtime dispatcher logs + untrack stray

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,12 @@ node_modules/
 
 # VSDD infrastructure — factory worktree lives on factory-artifacts orphan branch
 .factory/
+
+# Repo-root logs/ holds misrouted runtime dispatcher logs. Their canonical home
+# is .factory/logs/ on the factory-artifacts worktree branch. Ignoring here
+# prevents stray JSONL files (e.g. logs/dispatcher-internal-YYYY-MM-DD.jsonl)
+# from leaking onto develop via index conflicts.
+logs/
 # Reference codebases — cloned for brownfield-ingest analysis, never committed to main
 .reference/
 # Subagent isolation worktrees — created by Agent(isolation: "worktree") and


### PR DESCRIPTION
## Summary

- Adds a `logs/` rule to the root `.gitignore` immediately after the `.factory/` ignore block, with a comment explaining that the canonical home for runtime dispatcher JSONL logs is `.factory/logs/` on the `factory-artifacts` worktree branch.
- Prevents future misrouted dispatcher logs from leaking onto `develop` as tracked files or index conflicts (the DU-conflict for `logs/dispatcher-internal-2026-06-19.jsonl` that surfaced on post-PR-#198 reconcile was the trigger).
- No tracked `logs/` content exists in the committed tree at `40cd18ae`, so no `git rm --cached` is needed beyond the index-conflict resolution already performed.

## Root cause

The factory-dispatcher writes daily JSONL logs to a `logs/` directory relative to its working directory. When invoked from the repo root (rather than from inside `.factory/`), that path resolves to `<repo-root>/logs/` instead of `.factory/logs/`. A gitignore entry is the correct recurrence fix.

## Test plan

- [ ] CI passes (fmt + clippy + cargo test + bats) — no code changes, only `.gitignore`
- [ ] `git check-ignore -v logs/dispatcher-internal-2026-06-22.jsonl` returns the new rule after merge
- [ ] Human approves and merges