### PR TITLE
docs: correct stale precompact-flush.sh refs to precompact-flush WASM plugin (D-703 drift-1)

### DIFF
--- a/crates/hook-plugins/validate-burst-log/src/lib.rs
+++ b/crates/hook-plugins/validate-burst-log/src/lib.rs
@@ -411,7 +411,7 @@ fn is_numbered_list_item(s: &str) -> bool {
 // PreCompact flush exemption (BC-5.41.003 + S-18.04b)
 // ---------------------------------------------------------------------------
 
-/// The exact commit subject prefix produced by `precompact-flush.sh`.
+/// The exact commit subject prefix produced by the `precompact-flush` PreCompact WASM plugin (`precompact-flush.wasm`, S-18.04a).
 ///
 /// Matches the value of `COMMIT_PREFIX` in `crates/hook-plugins/precompact-flush/src/lib.rs`.
 /// Case-sensitive; no substring match; no regex. BC-5.41.003 invariant 3.

--- a/crates/hook-plugins/validate-dispatch-advance/src/lib.rs
+++ b/crates/hook-plugins/validate-dispatch-advance/src/lib.rs
@@ -844,7 +844,7 @@ fn safe_truncate(s: &str, max_chars: usize) -> String {
 // PreCompact flush exemption (BC-5.41.003 + S-18.04b)
 // ---------------------------------------------------------------------------
 
-/// The exact commit subject prefix produced by `precompact-flush.sh`.
+/// The exact commit subject prefix produced by the `precompact-flush` PreCompact WASM plugin (`precompact-flush.wasm`, S-18.04a).
 ///
 /// Matches the value of `COMMIT_PREFIX` in `crates/hook-plugins/precompact-flush/src/lib.rs`.
 /// Case-sensitive; no substring match; no regex. BC-5.41.003 invariant 3.

--- a/docs/demo-evidence/S-18.00/README.md
+++ b/docs/demo-evidence/S-18.00/README.md
@@ -81,4 +81,4 @@ correctly suppresses block intent for PostCompact events.
 - `CLAUDE_CODE_VERSION` unset: `harness version undeterminable … set CLAUDE_CODE_VERSION in the harness environment` → exit 1 (advisory)
 - `CLAUDE_CODE_VERSION=2.1.100`: `harness v2.1.100 < v2.1.105 — PreCompact block-intent will not be honoured` → exit 1 (advisory)
 
-The script never exits 2 (block-intent is reserved for precompact-flush.sh per S-18.04a).
+The script never exits 2 (block-intent is reserved for the `precompact-flush` PreCompact WASM plugin per S-18.04a).

--- a/plugins/vsdd-factory/hooks-registry.toml
+++ b/plugins/vsdd-factory/hooks-registry.toml
@@ -1313,7 +1313,7 @@ path_allow = [".factory/STATE.md"]
 # check-harness-version: verify Claude Code harness >= v2.1.105 before compaction.
 # Advisory-only (on_error=continue): dispatcher continues even if the check fails.
 # Registered as PreCompact per BC-1.15.001 INV3 and AC-008.
-# Never sets block_intent — that is reserved for precompact-flush.sh (S-18.04a).
+# Never sets block_intent — that is reserved for the `precompact-flush` PreCompact WASM plugin (S-18.04a).
 # check-harness-version: real implementation in hooks/check-harness-version.sh (S-18.00; PreCompact advisory, on_error=continue).
 
 [[hooks]]

--- a/plugins/vsdd-factory/hooks/check-harness-version.sh
+++ b/plugins/vsdd-factory/hooks/check-harness-version.sh
@@ -11,7 +11,7 @@
 #             The dispatcher continues (on_error=continue); compaction proceeds.
 #
 # Registered as PreCompact, on_error=continue (hooks-registry.toml S-18.00).
-# Never exits 2 — block-intent is reserved for precompact-flush.sh (S-18.04a).
+# Never exits 2 — block-intent is reserved for the `precompact-flush` PreCompact WASM plugin (S-18.04a).
 #
 # Version detection:
 #   CLAUDE_CODE_VERSION env var (primary) or CLAUDE_VERSION env var (alias).

--- a/plugins/vsdd-factory/hooks/precompact-flush-prune.sh
+++ b/plugins/vsdd-factory/hooks/precompact-flush-prune.sh
@@ -33,7 +33,7 @@
 #
 #   Invocation context (AC-012 / VP-090 §3):
 #     This script is invoked ONLY by check-state-health (or equivalent maintenance
-#     entrypoint). It MUST NOT be called from precompact-flush.sh.
+#     entrypoint). It MUST NOT be called from the `precompact-flush` WASM plugin.
 #     It MUST NOT be registered as a hook plugin (no hooks-registry.toml entry).
 #
 #   Dependencies:
@@ -46,7 +46,7 @@
 #   NOT required / FORBIDDEN:
 #     - python, jq, node, or any non-standard tools
 #     - Registration in hooks-registry.toml
-#     - Invocation from precompact-flush.sh
+#     - Invocation from the `precompact-flush` WASM plugin
 #
 set -euo pipefail
 

--- a/plugins/vsdd-factory/tests/check-harness-version.bats
+++ b/plugins/vsdd-factory/tests/check-harness-version.bats
@@ -169,7 +169,7 @@ _require_script() {
     echo "AC-008: exits 1 (advisory) if harness version cannot be determined or is below threshold"
     echo "EC-005: harness version undeterminable → exits 1 advisory"
     echo "NOTE: exit code 2 would be incorrect — check-harness-version.sh never exits 2"
-    echo "(block-intent is reserved for precompact-flush.sh per S-18.04a)"
+    echo "(block-intent is reserved for the precompact-flush PreCompact WASM plugin per S-18.04a)"
     echo "Output: $output"
     return 1
   }


### PR DESCRIPTION
## Summary

Comment/prose-only correction of 8 stale `precompact-flush.sh` references across 7 files. The PreCompact flush is delivered as a native WASM plugin (`precompact-flush.wasm`) per S-18.04a / ADR-028, not as a shell script. This PR corrects documentation, comments, and test prose to match the as-delivered implementation. Zero executable or logic changes.

Closes drift item D-703 drift-1 (stale precompact-flush.sh refs); expanded to a tree-wide TD-VSDD-060 sibling-sweep.

## What changed (comment/prose corrections only)

| File | Old reference | Corrected reference |
|------|--------------|---------------------|
| `crates/hook-plugins/validate-burst-log/src/lib.rs` | `precompact-flush.sh` | `` `precompact-flush` PreCompact WASM plugin (`precompact-flush.wasm`, S-18.04a) `` |
| `crates/hook-plugins/validate-dispatch-advance/src/lib.rs` | `precompact-flush.sh` | `` `precompact-flush` PreCompact WASM plugin (`precompact-flush.wasm`, S-18.04a) `` |
| `docs/demo-evidence/S-18.00/README.md` | `precompact-flush.sh` | `` `precompact-flush` PreCompact WASM plugin `` |
| `plugins/vsdd-factory/hooks-registry.toml` | `precompact-flush.sh (S-18.04a)` | `` `precompact-flush` PreCompact WASM plugin (S-18.04a) `` |
| `plugins/vsdd-factory/hooks/check-harness-version.sh` | `precompact-flush.sh (S-18.04a)` | `` `precompact-flush` PreCompact WASM plugin (S-18.04a) `` |
| `plugins/vsdd-factory/hooks/precompact-flush-prune.sh` (×2) | `precompact-flush.sh` | `` `precompact-flush` WASM plugin `` |
| `plugins/vsdd-factory/tests/check-harness-version.bats` | `precompact-flush.sh` | `precompact-flush PreCompact WASM plugin` |

## As-delivered rationale

S-18.04a (ADR-028) delivered the PreCompact flush as a native WASM plugin compiled from `crates/hook-plugins/precompact-flush/src/lib.rs` and registered in `hooks-registry.toml` as `precompact-flush.wasm`. No `precompact-flush.sh` was ever delivered. Comments written before or during early S-18.04a development that referred to the shell-script form were left as stale residue.

## Verification

- `cargo check --workspace` — clean
- `cargo fmt --check --all` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `bash -n plugins/vsdd-factory/hooks/check-harness-version.sh` — OK
- `bash -n plugins/vsdd-factory/hooks/precompact-flush-prune.sh` — OK

**ZERO executable/logic changes in this PR.** All 8 changed lines are in comments, doc strings, or prose strings printed in test failure messages.

## Traceability

- Story: N/A (maintenance)
- BC traceability: N/A (comment-only)
- Drift item: D-703 drift-1
- Sibling-sweep: TD-VSDD-060
- ADR-028 (native WASM delivery): see `.factory/specs/architecture/`

## Architecture Changes

No architectural changes. This PR corrects documentation to accurately reflect the existing WASM-based architecture delivered by S-18.04a / ADR-028.

## Security Review

N/A — comment/prose corrections only; no executable code modified.

## Risk Assessment

- Blast radius: zero (comment-only changes cannot alter runtime behavior)
- Performance impact: none
- Rollback: trivially reversible

## Pre-Merge Checklist

- [x] No executable/logic changes (verified by diff inspection)
- [x] All corrected references verified against as-delivered WASM plugin (`precompact-flush.wasm`)
- [x] `cargo check` clean
- [x] `cargo fmt --check --all` clean
- [x] `cargo clippy` clean
- [x] `bash -n` on edited .sh files OK
- [x] CI checks passing
- [x] PR reviewed (pr-reviewer confirmed no logic changes, factual accuracy verified)
