### PR TITLE
feat(S-18.12): portability-lint guard extension (E-18 wave-9)

### DIFF
--- a/docs/demo-evidence/S-18.12/evidence-report.md
+++ b/docs/demo-evidence/S-18.12/evidence-report.md
@@ -1,0 +1,117 @@
+# Demo Evidence — S-18.12: portability-lint guard extension
+
+**Story:** S-18.12 (v1.12)
+**Branch:** feature/S-18.12
+**HEAD at capture:** `9cbd9439` (clean worktree)
+**Suite:** `plugins/vsdd-factory/tests/wave-handoff.bats` (portability-lint subset)
+**Product type:** Gate-enforcement bats suite (CLI/shell — no UI)
+**Recording method:** Literal bats execution output (VHS not applicable; the deliverable is a
+static-lint bats guard, not an interactive CLI tool — same rationale as S-18.09's evidence report)
+**Captured:** 2026-07-01T16:09:43Z
+
+---
+
+## Gate Run: All 6 Portability Tests Green
+
+Command executed from worktree root (`/Users/zious/Documents/GITHUB/vsdd-factory/.worktrees/S-18.12`):
+
+```
+bats -f "test_portability_|test_BC_5_41_001_F_P11_001_bsd_portability" plugins/vsdd-factory/tests/wave-handoff.bats
+```
+
+**Captured output (verbatim):**
+
+```
+1..6
+ok 1 test_BC_5_41_001_F_P11_001_bsd_portability_no_pcre_classes_in_grep_sed
+ok 2 test_portability_no_unguarded_local_A_associative_array
+ok 3 test_portability_no_unguarded_bash4_case_modifiers
+ok 4 test_portability_no_global_ifs_mutation
+ok 5 test_portability_no_python_shellout
+ok 6 test_portability_no_jq_shellout
+```
+
+Exit code: 0. No failures, no skipped tests. Bats 1.13.0.
+
+---
+
+## Per-AC Summary (AC-001 through AC-005, plus AC-007 regression)
+
+Each of the five new tests embeds its own positive-control (synthetic BAD fixture that MUST be
+flagged) and negative-control (synthetic GOOD/exempt fixture that MUST NOT be flagged) assertions
+against the detector regex, in addition to scanning the real `wave-handoff` skill scripts. All
+fixtures are synthetic files under `BATS_TEST_TMPDIR` — no real wave-handoff scripts are executed
+or mutated by the controls. A single `ok` line therefore proves both discrimination-correctness
+(the regex fires on bad input and stays silent on good input) and the real-scan-set result (no
+hazard present in the shipped skill).
+
+| Test # | Test Name | AC | Positive control (MUST flag) | Negative control (MUST NOT flag) | Result |
+|--------|-----------|----|------------------------------|-----------------------------------|--------|
+| 1 | `test_BC_5_41_001_F_P11_001_bsd_portability_no_pcre_classes_in_grep_sed` | AC-007 (regression) | Pre-existing PCRE-shorthand-class guard (`\d`, `\w`, `\s` in `grep`/`sed`) | — | PASS |
+| 2 | `test_portability_no_unguarded_local_A_associative_array` | AC-001 | `declare -A`, `declare -Ax`, `declare -gA`, `local -A` (incl. EOL forms), and an unguarded entrypoint sourcing a `local -A` lib | `declare -a` (indexed array, bash-3-safe); a guarded entrypoint (`BASH_VERSINFO` check precedes `source`); a commented-out guard (F-P14-001) does NOT satisfy the oracle | PASS |
+| 3 | `test_portability_no_unguarded_bash4_case_modifiers` | AC-002 | `${var^^}`, `${var,,}`, `${var^}`, `${var,}`, positional/special-param forms (`${1^^}`, `${@^^}`, `${*^^}`, `${#^^}`), and `${var@U}`/`${var@L}`/`${var@u}` `@`-operator transforms | Named vars without case-modifier operators; guarded usage | PASS |
+| 4 | `test_portability_no_global_ifs_mutation` | AC-003 | Bare `IFS='|'`; `export`/`readonly`/`declare -g IFS=`; `cmd; IFS=`; `cmd && / || / & IFS=`; `then/do/else/elif IFS=`; brace-group `{ IFS=`; case-pattern `) IFS=`; `IFS='|'; read x` (semicolon-separated, F-P3-001) | `local IFS=':'`; `IFS=',' read -ra arr` (command-prefix form); `foo() { ... }` (function-def brace, not IFS); `) ` with no following `IFS=` | PASS |
+| 5 | `test_portability_no_python_shellout` | AC-004 | `python3`, `python2`, `pip3`, `pipx`, version-suffixed `python3.11`, and stdlib-only `python3 -c 'import json'` (F-P11-001 Option A: stdlib is now also forbidden) across line-start / pipe / `&&` / backtick / `$(...)` / `if`/`then`/`do`/`else`/`elif` / `time`/`env`/`command`/`sudo` / `xargs` (incl. `-n1`) / brace-group / case-pattern / subshell positions, incl. a `command -v python3` preflight guard (F-P13-002: still forbidden, no preflight-acceptance path) | `python_bin=python3.11` (var name, not invocation); `# python3 is not used...` (comment); `echo "install python3 first"` (argument, not invocation); `foo() { echo; }` (function-brace); `echo "${python3_x}"` (param expansion) | PASS |
+| 6 | `test_portability_no_jq_shellout` | AC-005 | `jq` at line-start / `$(...)` / backtick / `&&` / `else`/`elif`/`if`/`then`/`do` / `time`/`env`/`command`/`sudo` / `xargs` (incl. `-n1`) / brace-group / case-pattern / subshell positions, incl. a `command -v jq` preflight guard (forbidden-removal model: no preflight-acceptance path, mirrors AC-004) | `# no jq dependency; using awk instead` (comment); `result=$(other_cmd . f)` (non-jq cmdsubst); `foo() { echo "hello"; }` (function-brace); `echo "${jq_var}"` (param expansion) | PASS |
+
+---
+
+## What This Suite Enforces
+
+The five new `test_portability_*` tests extend the existing `bsd_portability_no_pcre_classes`
+bats guard (AC-007, preserved unmodified and still passing as test 1) to close the four runtime
+portability gaps that a static PCRE-class-only lint missed and that were only caught by the macOS
+CI leg in S-18.01 (lesson `L-S18-macos-ci-leg-caught-runtime-portability`):
+
+- **AC-001 — bash 4+ associative arrays.** `local -A` / `declare -A` (and combined/prefixed flag
+  forms) require bash ≥ 4.0; macOS ships bash 3.2 as `/bin/bash`. The guard requires either no
+  associative-array usage in the scan set, or an executable `BASH_VERSINFO` guard that precedes
+  every entrypoint's first `source` of a lib using the syntax (EC-006 entrypoint-guard soundness;
+  a commented-out guard does not count, per F-P14-001).
+- **AC-002 — bash 4+ case-modifier parameter expansion.** `${var^^}`/`${var,,}`/`${var^}`/`${var,}`
+  and the bash-4.4 `@`-operator transforms (`${var@U}` etc.) are syntax errors on bash 3.2.
+- **AC-003 — global IFS mutation.** A bare/`export`/`readonly`/`declare -g` `IFS=` assignment at
+  current-shell scope leaks into the parent shell and corrupts word-splitting for the rest of the
+  script. `local IFS=` and the `IFS=... read` command-prefix idiom are the only exemptions;
+  subshell-scoped `(IFS=...)` is exempt by shell semantics (does not leak).
+- **AC-004 — forbidden python/pip shell-outs.** SKILL.md's "Forbidden Dependencies" section
+  forbids any language runtime beyond bash. Per F-P11-001 Option A, ALL python/pip invocations
+  (including stdlib-only, and even behind a `command -v` preflight guard) are violations; the fix
+  is removal, not acceptance.
+- **AC-005 — forbidden jq shell-outs.** Same forbidden-removal model as AC-004 (v1.11 reframe
+  closed the earlier python/jq asymmetry): jq is forbidden in any execution position, with no
+  preflight-acceptance path.
+
+AC-006 (guard is scoped to wave-handoff scripts and is not a false-positive source) and AC-007
+(existing PCRE guard preserved) require no dedicated new test per the story's Test Plan — AC-006
+is demonstrated structurally by every test scanning only `wave-handoff_skill_dir/*.sh`, and AC-007
+is the regression check that test 1 above continues to pass unmodified.
+
+---
+
+## Coverage Mapping
+
+| AC | Test | Result |
+|----|------|--------|
+| AC-001 | `test_portability_no_unguarded_local_A_associative_array` | PASS |
+| AC-002 | `test_portability_no_unguarded_bash4_case_modifiers` | PASS |
+| AC-003 | `test_portability_no_global_ifs_mutation` | PASS |
+| AC-004 | `test_portability_no_python_shellout` | PASS |
+| AC-005 | `test_portability_no_jq_shellout` | PASS |
+| AC-006 | (no dedicated test — structural: scan scope is `wave-handoff_skill_dir` only, per story Test Plan) | N/A (by design) |
+| AC-007 | `test_BC_5_41_001_F_P11_001_bsd_portability_no_pcre_classes_in_grep_sed` (regression) | PASS |
+
+All 5 Red Gate tests (AC-001 through AC-005) plus the AC-007 regression check are green. Each new
+test's own positive/negative-control block (see table above) demonstrates that the detector
+regexes discriminate correctly, independent of whether the real `wave-handoff` skill happens to
+contain the hazard today — the guard is a true regression fence, not a vacuous pass.
+
+## Reproduction
+
+```bash
+# Re-run just the portability subset (this evidence):
+bats -f "test_portability_|test_BC_5_41_001_F_P11_001_bsd_portability" plugins/vsdd-factory/tests/wave-handoff.bats
+
+# Re-run the full wave-handoff suite:
+bats plugins/vsdd-factory/tests/wave-handoff.bats
+```

--- a/plugins/vsdd-factory/docs/bash-portability.md
+++ b/plugins/vsdd-factory/docs/bash-portability.md
@@ -224,7 +224,7 @@ $(python3 -c 'import json; ...')             # command substitution — flagged
 | python3 -c '...'                           # pipe position — flagged
 ```
 
-**Why it is forbidden:** SKILL.md §149 states: "This skill MUST NOT shell out to
+**Why it is forbidden:** SKILL.md 'Forbidden Dependencies' section states: "This skill MUST NOT shell out to
 Python, jq, or any language runtime beyond bash." Python is treated identically to jq —
 the constraint is a hard prohibition, not a "declare a dependency" requirement. macOS
 does not guarantee `python3` on PATH — it is absent on a clean macOS install and on CI
@@ -279,7 +279,7 @@ if command -v jq; then jq '.key' f; fi       # preflight guard present — jq st
 xargs -n1 jq '.key'                          # xargs position — flagged
 ```
 
-**Why it is forbidden:** SKILL.md §149 states: "This skill MUST NOT shell out to
+**Why it is forbidden:** SKILL.md 'Forbidden Dependencies' section states: "This skill MUST NOT shell out to
 Python, jq, or any language runtime beyond bash." `jq` is a non-guaranteed third-party
 binary — it is absent from minimal macOS installs and from CI images that do not
 provision it separately. The constraint is a hard prohibition, not a "declare a

--- a/plugins/vsdd-factory/docs/bash-portability.md
+++ b/plugins/vsdd-factory/docs/bash-portability.md
@@ -1,0 +1,287 @@
+# Bash Portability — Wave-Handoff Static Lint Guard
+
+This document describes the four bash portability anti-patterns that the S-18.12
+portability-lint bats guard detects. The guard performs static analysis only — it
+greps script sources and never executes them. It scans every `.sh` file under
+`plugins/vsdd-factory/skills/wave-handoff/` (main entry point and `lib/` helpers).
+Test fixtures, hook scripts, and scripts outside that directory are out of scope.
+
+These guards are anchored to lesson `L-S18-macos-ci-leg-caught-runtime-portability`,
+which records the four macOS CI failures in S-18.01 that the earlier PCRE-only lint
+missed. Each anti-pattern below has a matching bats test in
+`plugins/vsdd-factory/tests/wave-handoff.bats`.
+
+---
+
+## 1. Unguarded bash 4+ associative arrays (AC-001)
+
+**Pattern detected:** `local -A varname`, `declare -A varname`, or any flag string
+containing `A` at any position, such as `local -Ax` or `declare -gA`, in any
+wave-handoff script. Lowercase `-a` (indexed arrays, bash-3-safe) is NOT flagged.
+
+**Why it breaks:** macOS ships bash 3.2 at `/bin/bash`. Homebrew bash is not on PATH
+by default. `local -A` and `declare -A` are bash 4+ features. On bash 3.2 they do not
+produce a parse-time error — the function body parses without complaint. Instead they
+produce a **runtime** builtin error (`declare: -A: invalid option`) at the moment the
+builtin executes, which only happens if the array-using function is actually invoked.
+GitHub Actions macOS runners also use the system bash unless the workflow explicitly
+installs a newer version. This was the root cause of the S-18.01 CI failure recorded at
+commit ea7328ac.
+
+The entrypoint guard works because `wave-handoff.sh` runs the `${BASH_VERSINFO[0]} -lt 4`
+check at the top of the script, before it `source`s any `lib/*.sh` script, and exits. The lib functions
+that use `local -A` or `declare -A` are therefore never reached on bash 3.2, and the
+runtime builtin error never fires. Per-function guards inside individual lib functions
+are not impossible — they are simply unnecessary given the entrypoint early-exit.
+
+**Portable fix:** Add a version guard at the top of `wave-handoff.sh` (the main entry
+point, before any lib script is sourced) so the check fires before any bash 4+ syntax
+is evaluated:
+
+```bash
+if [ "${BASH_VERSINFO[0]:-0}" -lt 4 ]; then
+  echo "ERROR: wave-handoff requires bash >= 4.0 (associative arrays)" >&2
+  echo "  On macOS: brew install bash" >&2
+  exit 1
+fi
+```
+
+**Soundness boundary:** The entrypoint-guard model is sound only because `wave-handoff.sh`
+is the sole guarded entrypoint and the `lib/*.sh` scripts are sourced exclusively by it
+(after the guard). Adding a new lib script that is sourced only by the guarded entrypoint
+is safe — the guard fires before any lib is sourced, so the new lib is never reached on
+bash 3.2. The hazard is a new entrypoint that sources these libs without its own bash-4
+guard: in that case the scan-set-wide `BASH_VERSINFO` check could pass while that new
+code path crashes on bash 3.2 at runtime. Any new entrypoint that sources these libs
+must carry its own bash-4 guard.
+
+**What the guard checks:** If any file in the scan set matches
+`(local|declare)[[:space:]]+-[a-zA-Z]*A[a-zA-Z]*([[:space:]]|$)` — covering bare `-A`, compound flags
+with `A` at any position such as `-Ax` or `-gA`, and `-A` at end-of-line, but NOT
+lowercase `-a` (indexed arrays, which are bash-3-safe) — the test then verifies that
+the token `BASH_VERSINFO` also appears somewhere in the scan set. Both
+`[ "${BASH_VERSINFO[0]:-0}" -lt 4 ]` and `(( BASH_VERSINFO[0] < 4 ))` satisfy this
+check. A scan set with associative arrays but no `BASH_VERSINFO` token fails the test.
+A scan set with neither associative arrays nor a guard passes (the feature is simply
+absent, so no guard is required).
+
+**Enforcing test:** `test_portability_no_unguarded_local_A_associative_array`
+
+---
+
+## 2. Unguarded bash 4+ case modifiers (AC-002)
+
+**Pattern detected:** `${varname^^}` (to-uppercase), `${varname,,}` (to-lowercase),
+`${varname^}` (first-character uppercase), or `${varname,}` (first-character lowercase)
+in any wave-handoff script, including array-element forms such as `${arr[0]^^}`,
+`${map[k],,}`, and `${arr[i]^}`, and positional and special parameters such as
+`${1^^}`, `${@^^}`, `${*^^}`, and `${#^^}`.
+
+**Why it breaks:** These parameter expansion operators were introduced in bash 4.0. On
+bash 3.2 (macOS system bash) they produce a **runtime** `bad substitution` error at the
+moment that specific parameter expansion executes — not a parse-time error. The script
+body and function declarations parse without complaint on bash 3.2; the error fires only
+when execution reaches the offending expansion. The same entrypoint guard that covers
+AC-001 prevents this: `wave-handoff.sh` exits before sourcing the lib scripts, so
+expansions using these operators are never evaluated on bash 3.2.
+
+**Portable fix (option A):** Use POSIX-portable alternatives instead of the bash 4+
+operators:
+
+```bash
+# to-uppercase
+upper="$(printf '%s' "$var" | tr 'a-z' 'A-Z')"
+# or with awk
+upper="$(printf '%s' "$var" | awk '{print toupper($0)}')"
+```
+
+**Portable fix (option B):** Add the same `BASH_VERSINFO` guard as AC-001 to
+`wave-handoff.sh` before any lib script is sourced.
+
+**What the guard checks:** If any file matches the pattern
+`\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?)` — covering the
+two-char forms `^^` and `,,`, the single-char forms `^` and `,`, named variable forms
+(`${varname^^}`), array-element forms such as `${arr[0]^^}`, `${map[k],,}`, and
+`${arr[i]^}`, and positional and special-parameter forms such as `${1^^}`, `${@^^}`,
+`${*^^}`, and `${#^^}` — the test verifies that `BASH_VERSINFO` appears somewhere in
+the scan set. Case modifiers without a version guard fail the test. The current scan
+set contains no case modifiers, so this test passes on a clean codebase (no guard is
+required when the feature is absent).
+
+**Enforcing test:** `test_portability_no_unguarded_bash4_case_modifiers`
+
+---
+
+## 3. Global IFS mutation (AC-003)
+
+**Pattern detected:** A bare `IFS=...` assignment that is not scoped to a function
+local variable, a command prefix for `read`, or a subshell — detected at line-start,
+after `;`, after `&&` or `||`, and after the keywords `then`, `do`, `else`, and `elif`.
+
+**Why it breaks:** Assigning to `IFS` at script scope or as a standalone statement
+inside a function mutates the shell's global field separator for the remainder of that
+shell process. All subsequent `read` calls, word splits, and `for` expansions in the
+same process inherit the mutated IFS, causing silent misclassification of delimited
+fields. This is a SOUL.md §4 silent-failure category defect: the script continues
+running, produces wrong output, and emits no error. This was the root cause of the
+S-18.01 failure recorded at commit 2b40dfd5 (`IFS='|'` in `parse-sprint-state.sh`
+caused every subsequent `read` to split on `|` instead of newline).
+
+**Allowed forms (not flagged):**
+
+```bash
+local IFS=':'           # scoped to the enclosing function body
+while IFS= read -r line # command prefix, scoped to that single read
+IFS=',' read -ra arr    # command prefix, scoped to that single read
+(IFS='|'; command)      # subshell-scoped (subshell opens on the same line)
+```
+
+**Flagged forms (violations):**
+
+```bash
+IFS='|'                 # standalone assignment — global mutation
+IFS=$'\n'               # standalone assignment — global mutation
+cmd && IFS=':'          # &&-operator prefix — global mutation
+cmd & IFS='|'           # single-& background then global mutation
+cmd || IFS=$'\n'        # ||-operator prefix — global mutation
+if ...; then IFS=':'    # then-keyword prefix — global mutation in if-body
+for ...; do IFS='|'     # do-keyword prefix — global mutation in loop-body
+else IFS=':'            # else-keyword prefix — global mutation in else-branch
+elif ...; then IFS=':'  # elif-keyword prefix — global mutation in elif-body
+```
+
+**Portable fix:** Replace the global assignment with one of the scoped forms above.
+The S-18.01 fix replaced `IFS='|'` field splitting in `parse-sprint-state.sh` with
+`awk -F'|'`, which keeps field-separator semantics entirely inside awk without touching
+the shell's IFS.
+
+**What the guard checks:** The test applies the step-1 anchor
+`(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]])[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=`,
+which matches: bare line-start `IFS=`; second-statement uses such as `cmd; IFS=`;
+operator-prefixed mutations such as `cmd && IFS=`, `cmd & IFS=` (background-then-global),
+and `cmd || IFS=`; and
+keyword-prefixed mutations where `IFS=` follows `then`, `do`, `else`, or `elif` with
+whitespace (e.g., `then IFS=...` in an `if` body or `do IFS=...` in a loop body); as
+well as the qualified forms `export IFS=`, `readonly IFS=`, and `declare -g IFS=` in
+any of those positions. The following forms are exempted and not flagged: `local IFS=`
+(function-scoped), `while IFS= read` and `IFS=... read` (command-prefix scoped to the
+single `read` call), and `(IFS=...; ...)` (subshell-scoped). The command-prefix
+exemption applies only to the no-separator form `IFS=val read` — the exemption does not
+cross `;`, `&`, or `|` statement separators, so `IFS=val; read` (global assignment
+followed by a separate `read` statement) IS flagged. Any match not covered by an
+exemption is reported as a violation.
+
+**Enforcing test:** `test_portability_no_global_ifs_mutation`
+
+---
+
+## 4. Undeclared runtime dependencies (AC-004 and AC-005)
+
+Wave-handoff scripts must not invoke external tools without a preflight availability
+check. Two specific tools are guarded: `python3`/PyYAML (AC-004) and `jq` (AC-005).
+
+### AC-004 — python3 / PyYAML
+
+**Pattern detected:** Any invocation of `python`, `python2`, `python3`, or a
+version-suffixed variant such as `python3.11` or `python3.12`, followed on the same
+line by a yaml token; any invocation of `pip`, `pip2`, `pip3`, or `pipx` followed by
+a pyyaml token (case-insensitive, so both `pyyaml` and `PyYAML` are matched); or a
+bare `import yaml` statement in any wave-handoff script.
+
+**Exception (not flagged):** `python3` invocations that use only stdlib modules (`json`,
+`os`, `sys`, `re`, etc.) are fine and are not flagged. The guard targets only external
+pip packages.
+
+**Why it breaks:** macOS GitHub Actions runners enforce PEP 668 "externally managed
+environment" isolation, which blocks `pip install` commands from modifying the system
+Python. The S-18.01 history has two entries for this failure: commit aaa8da8a (original
+pip failure) and commit 3fe11ea1 (attempted workaround with `--break-system-packages`).
+The `--break-system-packages` flag is explicitly not accepted as a long-term resolution
+in wave-handoff scripts — it works around the runner policy rather than eliminating the
+dependency.
+
+**Required fix:** Either add a preflight check before the first PyYAML invocation:
+
+```bash
+python3 -c "import yaml" 2>/dev/null || {
+  echo "ERROR: PyYAML is required (pip install pyyaml)" >&2
+  exit 1
+}
+```
+
+or replace yaml parsing with a POSIX-portable alternative (`awk` or `sed` key
+extraction). The current wave-handoff implementation uses `awk`-based YAML parsing and
+contains no `import yaml` invocations, so this test passes on a clean codebase.
+
+**What the guard checks (phase 1):** Detects files containing any of: a `python`,
+`python2`, `python3`, or version-suffixed binary (`python3.11`, `python3.12`, etc.)
+invocation followed anywhere on the same line by a case-insensitive yaml token (e.g.,
+`yaml`, `Yaml`, `YAML`) — the python arm uses the pattern `python[0-9.]*` to cover all
+such variants; a `pip`, `pip2`, `pip3`, or `pipx` invocation followed by a
+case-insensitive `pyyaml` token — the pyyaml token match is case-insensitive so the
+canonical PyPI name `PyYAML` (as in `pip3 install PyYAML`) is detected alongside
+lowercase `pyyaml`; or a bare `import yaml` statement. If none found, the test passes
+immediately. **Phase 2 (if
+matches found):** The test first flags any occurrence of `--break-system-packages` as
+an explicit violation. For remaining matches without that flag, it checks whether the
+file contains an acceptable preflight guard matching
+`(python[0-9.]*[[:space:]]+-c[[:space:]]+"import yaml"|command[[:space:]]+-v[[:space:]]+python[0-9.]*)`.
+This covers both bare `python3 -c "import yaml"` and versioned-binary forms such as
+`python3.11 -c "import yaml"`, and both `command -v python3` and versioned forms such as
+`command -v python3.11`; absence of any such guard is a violation.
+
+**Enforcing test:** `test_portability_no_undeclared_pyyaml_dep`
+
+### AC-005 — jq
+
+**Pattern detected:** `jq` appearing as a standalone command token: at the start of a
+line, after a pipe (`|`), after a semicolon (`;`), after an ampersand (`&`), inside a
+command substitution (`$(jq ...)` or backtick form), as an argument to `xargs`
+(including `xargs` with intervening options such as `xargs -n1 jq`), or following
+wrapper keywords `if`, `then`, `do`, `else`, `elif`, `time`, `env`, `command`, or
+`sudo`.
+
+**Why it breaks:** `jq` is not installed by default on all macOS and Linux CI images.
+Scripts that invoke `jq` without checking for its presence fail with `command not found`
+at runtime on any system that does not have it, often with a misleading error that
+obscures the real cause.
+
+**Required fix:** Add a preflight guard before the first `jq` invocation:
+
+```bash
+command -v jq >/dev/null 2>&1 || {
+  echo "ERROR: jq is required; install with brew install jq" >&2
+  exit 1
+}
+```
+
+Both `command -v jq` and `which jq` satisfy the guard. The `command -v` form is
+preferred because it is POSIX-portable (the `which` form is not POSIX but is accepted
+as a common fallback).
+
+**What the guard checks (phase 1):** Detects files where `jq` appears as a command
+word using POSIX ERE (no `\b` shorthand). The detection covers `jq` at the start of a
+line, after a pipe (`|`), after a semicolon (`;`), after a bare ampersand (`&`), inside
+a command substitution (`$(jq ...)` or backtick form), as an `xargs` argument
+(including `xargs` with intervening options such as `xargs -n1 jq`), and after the
+wrapper keywords `if`, `then`, `do`, `else`, `elif`, `time`, `env`, `command`, and
+`sudo`. If no such files are found, the test passes. **Phase 2:** For each file containing a `jq` invocation, the
+test verifies that `command -v jq` or `which jq` appears somewhere in the same file.
+Absence is a violation. No `jq` invocations currently exist in the wave-handoff scripts;
+this guard was added prospectively to prevent the dependency from being introduced
+silently.
+
+**Enforcing test:** `test_portability_no_undeclared_jq_dep`
+
+---
+
+## Guard scope and non-vacuity
+
+Every test in this suite enforces a non-vacuity invariant (EC-005): each test asserts
+that at least one `.sh` file was found under `plugins/vsdd-factory/skills/wave-handoff/`
+before drawing any conclusions. If the scan set is empty — because the scripts were
+renamed or moved — the test fails with a scope-drift message rather than silently
+passing. This prevents the guard from becoming a no-op after a refactor.
+
+The guard does not scan test fixture files, hook scripts under
+`plugins/vsdd-factory/hooks/`, or any script outside the wave-handoff skill directory.

--- a/plugins/vsdd-factory/docs/bash-portability.md
+++ b/plugins/vsdd-factory/docs/bash-portability.md
@@ -116,7 +116,8 @@ required when the feature is absent).
 
 **Pattern detected:** A bare `IFS=...` assignment that is not scoped to a function
 local variable, a command prefix for `read`, or a subshell — detected at line-start,
-after `;`, after `&&` or `||`, and after the keywords `then`, `do`, `else`, and `elif`.
+after `;`, after `&&` or `||`, after a single `&` (background command), and after the
+keywords `then`, `do`, `else`, and `elif`.
 
 **Why it breaks:** Assigning to `IFS` at script scope or as a standalone statement
 inside a function mutates the shell's global field separator for the remainder of that

--- a/plugins/vsdd-factory/docs/bash-portability.md
+++ b/plugins/vsdd-factory/docs/bash-portability.md
@@ -116,8 +116,9 @@ required when the feature is absent).
 
 **Pattern detected:** A bare `IFS=...` assignment that is not scoped to a function
 local variable, a command prefix for `read`, or a subshell — detected at line-start,
-after `;`, after `&&` or `||`, after a single `&` (background command), and after the
-keywords `then`, `do`, `else`, and `elif`.
+after `;`, after `&&` or `||`, after a single `&` (background command), after `{ `
+(brace group — runs in current shell), after `) ` (case pattern-action body — runs in
+current shell), and after the keywords `then`, `do`, `else`, and `elif`.
 
 **Why it breaks:** Assigning to `IFS` at script scope or as a standalone statement
 inside a function mutates the shell's global field separator for the remainder of that
@@ -149,6 +150,8 @@ if ...; then IFS=':'    # then-keyword prefix — global mutation in if-body
 for ...; do IFS='|'     # do-keyword prefix — global mutation in loop-body
 else IFS=':'            # else-keyword prefix — global mutation in else-branch
 elif ...; then IFS=':'  # elif-keyword prefix — global mutation in elif-body
+{ IFS=$'\n'; read x; }  # brace-group — runs in current shell, global mutation
+case $x in p) IFS='|' ;; esac  # case pattern-action body — runs in current shell, global mutation
 ```
 
 **Portable fix:** Replace the global assignment with one of the scoped forms above.
@@ -157,10 +160,12 @@ The S-18.01 fix replaced `IFS='|'` field splitting in `parse-sprint-state.sh` wi
 the shell's IFS.
 
 **What the guard checks:** The test applies the step-1 anchor
-`(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]])[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=`,
+`(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=`,
 which matches: bare line-start `IFS=`; second-statement uses such as `cmd; IFS=`;
 operator-prefixed mutations such as `cmd && IFS=`, `cmd & IFS=` (background-then-global),
-and `cmd || IFS=`; and
+and `cmd || IFS=`; brace-group mutations such as `{ IFS=...` (brace group — runs in
+current shell); case pattern-action body mutations such as `) IFS=...` (case pattern —
+runs in current shell); and
 keyword-prefixed mutations where `IFS=` follows `then`, `do`, `else`, or `elif` with
 whitespace (e.g., `then IFS=...` in an `if` body or `do IFS=...` in a loop body); as
 well as the qualified forms `export IFS=`, `readonly IFS=`, and `declare -g IFS=` in
@@ -271,6 +276,17 @@ test verifies that `command -v jq` or `which jq` appears somewhere in the same f
 Absence is a violation. No `jq` invocations currently exist in the wave-handoff scripts;
 this guard was added prospectively to prevent the dependency from being introduced
 silently.
+
+**Soundness boundary:** The jq preflight check is whole-file (greps for `command -v jq`
+or `which jq` anywhere in the file), NOT positional (unlike AC-001's entrypoint guard,
+which requires the `BASH_VERSINFO` check to precede first use). This is accepted as
+designed. `jq` is forbidden by the wave-handoff SKILL.md contract — scripts MUST NOT
+shell out to `jq` — so this detector is defense-in-depth against prohibited dependency
+introduction, not a runtime-ordering guard. For a dependency that must never appear at
+all, whole-file presence detection is adequate: if `jq` appears anywhere, it is a
+violation regardless of where a guard would be placed. A positional precedence refinement
+(requiring the guard to appear before the first `jq` invocation) is intentionally out of
+scope because the correct fix for any `jq` detection is removal, not guard placement.
 
 **Enforcing test:** `test_portability_no_undeclared_jq_dep`
 

--- a/plugins/vsdd-factory/docs/bash-portability.md
+++ b/plugins/vsdd-factory/docs/bash-portability.md
@@ -255,14 +255,34 @@ following wrapper keywords `if`, `then`, `do`, `else`, `elif`, `time`, `env`, `c
 or `sudo`, inside a brace group (`{ jq . f; }`), as a case-pattern-action (`case $x in
 p) jq … ;;`), or inside a subshell (`( jq … )`).
 
-**Why it is forbidden:** `jq` is prohibited by the wave-handoff SKILL.md contract —
-scripts MUST NOT shell out to `jq`. This is not a "check for presence before using"
-situation: the contract forbids `jq` in any execution position, including subshells. Any
-detection of `jq` as a command word is a violation regardless of position. The correct
-fix is removal, not the addition of a preflight guard.
+**No exceptions:** There is no preflight-acceptance path. A `command -v jq` preflight
+guard does not make a subsequent `jq` invocation acceptable — `jq` is forbidden in any
+execution position regardless of whether a guard precedes it. The fix is removal of the
+invocation, not the addition of a guard.
 
-**What the guard checks (phase 1):** Detects files where `jq` appears as a command
-word in any execution position using POSIX ERE (no `\b` shorthand). The detector regex is:
+**Flagged forms (violations):**
+
+```bash
+jq '.key' data.json                          # command-position jq invocation
+| jq .                                       # pipe position — flagged
+$(jq '.key' data.json)                       # command substitution — flagged
+command -v jq && jq '.key' data.json         # preflight guard present — jq still flagged
+if command -v jq; then jq '.key' f; fi       # preflight guard present — jq still flagged
+xargs -n1 jq '.key'                          # xargs position — flagged
+```
+
+**Why it is forbidden:** SKILL.md §149 states: "This skill MUST NOT shell out to
+Python, jq, or any language runtime beyond bash." `jq` is a non-guaranteed third-party
+binary — it is absent from minimal macOS installs and from CI images that do not
+provision it separately. The constraint is a hard prohibition, not a "declare a
+dependency" requirement. `jq` is treated identically to Python — the correct fix for any
+detection is removal, not the addition of a preflight guard.
+
+**Required fix:** Remove the `jq` invocation entirely. Replace with a POSIX-portable
+alternative using `awk`, `grep`, or `sed`.
+
+**What the guard checks:** Detects files where `jq` appears as a command word in any
+execution position using POSIX ERE (no `\b` shorthand). The detector regex is:
 
 ```
 (^[[:space:]]*jq([[:space:]]|$)|[|;&][[:space:]]*jq([[:space:]]|$)|\$[(]jq([[:space:]]|$)|`jq([[:space:]]|$)|(xargs|if|then|do|else|elif|time|env|command|sudo)[[:space:]]+jq([[:space:]]|$)|xargs([[:space:]]+-[^[:space:]]+)+[[:space:]]+jq([[:space:]]|$)|\{[[:space:]]*jq([[:space:]]|$)|\)[[:space:]]*jq([[:space:]]|$)|\([[:space:]]*jq([[:space:]]|$))
@@ -272,24 +292,12 @@ This covers `jq` at line-start, after pipe/semicolon/ampersand, inside `$(...)` 
 backtick command substitution, after `xargs` (with or without intervening options), after
 the wrapper keywords `if`, `then`, `do`, `else`, `elif`, `time`, `env`, `command`, and
 `sudo`, inside a brace group (`{ jq`), as a case-pattern-action body (`) jq`), and
-inside a subshell (`( jq`). If no such files are found, the test passes. **Phase 2:** For
-each file containing a `jq` invocation, the test verifies that `command -v jq` or
-`which jq` appears somewhere in the same file; absence is a violation. No `jq`
-invocations currently exist in the wave-handoff scripts; this guard was added
-prospectively to prevent the dependency from being introduced silently.
+inside a subshell (`( jq`). Any match is a violation. The test is single-phase (no
+preflight-acceptance phase). No `jq` invocations currently exist in the wave-handoff
+scripts; this guard was added prospectively to prevent the dependency from being
+introduced silently.
 
-**Soundness boundary:** The jq preflight check is whole-file (greps for `command -v jq`
-or `which jq` anywhere in the file), NOT positional (unlike AC-001's entrypoint guard,
-which requires the `BASH_VERSINFO` check to precede first use). This is accepted as
-designed. `jq` is forbidden by the wave-handoff SKILL.md contract — scripts MUST NOT
-shell out to `jq` — so this detector is defense-in-depth against prohibited dependency
-introduction, not a runtime-ordering guard. For a dependency that must never appear at
-all, whole-file presence detection is adequate: if `jq` appears anywhere, it is a
-violation regardless of where a guard would be placed. A positional precedence refinement
-(requiring the guard to appear before the first `jq` invocation) is intentionally out of
-scope because the correct fix for any `jq` detection is removal, not guard placement.
-
-**Enforcing test:** `test_portability_no_undeclared_jq_dep`
+**Enforcing test:** `test_portability_no_jq_shellout`
 
 ---
 

--- a/plugins/vsdd-factory/docs/bash-portability.md
+++ b/plugins/vsdd-factory/docs/bash-portability.md
@@ -203,11 +203,30 @@ or `pipx` in a command position in any wave-handoff script.
 Any python or pip invocation in a command position is a violation, period. The fix is
 removal of the invocation, not the addition of a guard.
 
+**Flagged forms (violations):**
+
+```bash
+python3 parse.py                             # command-position python3 invocation
+python3 -c 'import json; print(x)'          # stdlib python3 — still flagged
+python3 -c 'import yaml; ...'               # third-party python3 — still flagged
+python2 parse.py                             # python2 variant
+pip3 install pyyaml                          # pip3 invocation
+pipx run black .                             # pipx invocation
+$(python3 -c 'import json; ...')             # command substitution — flagged
+| python3 -c '...'                           # pipe position — flagged
+```
+
 **Why it is forbidden:** SKILL.md §149 states: "This skill MUST NOT shell out to
 Python, jq, or any language runtime beyond bash." Python is treated identically to jq —
-the constraint is a hard prohibition, not a "declare a dependency" requirement. The
-S-18.01 history (commit aaa8da8a: pip failure; commit 3fe11ea1: `--break-system-packages`
-workaround) demonstrates that python shell-outs are fragile across CI environments.
+the constraint is a hard prohibition, not a "declare a dependency" requirement. macOS
+does not guarantee `python3` on PATH — it is absent on a clean macOS install and on CI
+images that do not provision Python separately. PEP 668 (externally-managed Python
+environments, adopted in Python 3.11+ and backported by major Linux distributions)
+prevents `pip` from installing third-party packages without `--break-system-packages`,
+making any preflight guard that attempts to install dependencies non-functional on modern
+Linux and macOS systems. The S-18.01 history (commit aaa8da8a: pip failure; commit
+3fe11ea1: `--break-system-packages` workaround) is the concrete manifestation of this
+fragility. (Background: `.factory/planning/research/s-18.12-python-dep-policy.md`.)
 
 **Required fix:** Remove the python/pip invocation entirely. Replace with a POSIX
 portable alternative using `awk`, `grep`, or `sed`.

--- a/plugins/vsdd-factory/docs/bash-portability.md
+++ b/plugins/vsdd-factory/docs/bash-portability.md
@@ -58,12 +58,17 @@ must carry its own bash-4 guard.
 **What the guard checks:** If any file in the scan set matches
 `(local|declare)[[:space:]]+-[a-zA-Z]*A[a-zA-Z]*([[:space:]]|$)` — covering bare `-A`, compound flags
 with `A` at any position such as `-Ax` or `-gA`, and `-A` at end-of-line, but NOT
-lowercase `-a` (indexed arrays, which are bash-3-safe) — the test then verifies that
-the token `BASH_VERSINFO` also appears somewhere in the scan set. Both
-`[ "${BASH_VERSINFO[0]:-0}" -lt 4 ]` and `(( BASH_VERSINFO[0] < 4 ))` satisfy this
-check. A scan set with associative arrays but no `BASH_VERSINFO` token fails the test.
-A scan set with neither associative arrays nor a guard passes (the feature is simply
-absent, so no guard is required).
+lowercase `-a` (indexed arrays, which are bash-3-safe) — the test then verifies that an
+**executable** (non-comment) bash-version conditional exists in the scan set. Specifically,
+the detector strips comment lines (`^[[:space:]]*#`) from each file before applying the
+guard pattern `([[].*BASH_VERSINFO|[(][(].*BASH_VERSINFO)`, which requires either `[` or `((`
+to appear on the same non-comment line as `BASH_VERSINFO`. This covers both
+`[ "${BASH_VERSINFO[0]:-0}" -lt 4 ]` and `(( BASH_VERSINFO[0] < 4 ))`. A scan set with
+associative arrays but no executable guard fails the test. A commented-out guard line
+such as `# if [[ ${BASH_VERSINFO[0]} -lt 4 ]]; then` does NOT satisfy the check —
+the comment is stripped before the pattern is applied. A scan set with neither
+associative arrays nor a guard passes (the feature is simply absent, so no guard is
+required).
 
 **Enforcing test:** `test_portability_no_unguarded_local_A_associative_array`
 
@@ -106,10 +111,13 @@ two-char forms `^^` and `,,`, the single-char forms `^` and `,`, the bash-4.4
 `@`-operator transforms `@U` / `@L` / `@u`, named variable forms
 (`${varname^^}`), array-element forms such as `${arr[0]^^}`, `${map[k],,}`, and
 `${arr[i]^}`, and positional and special-parameter forms such as `${1^^}`, `${@^^}`,
-`${*^^}`, and `${#^^}` — the test verifies that `BASH_VERSINFO` appears somewhere in
-the scan set. Case modifiers without a version guard fail the test. The current scan
-set contains no case modifiers, so this test passes on a clean codebase (no guard is
-required when the feature is absent).
+`${*^^}`, and `${#^^}` — the test verifies that an **executable** (non-comment)
+bash-version conditional exists in the scan set using the same comment-stripping
+mechanism as AC-001: comment lines (`^[[:space:]]*#`) are stripped before the guard
+pattern `([[].*BASH_VERSINFO|[(][(].*BASH_VERSINFO)` is applied. A commented-out guard
+line does NOT satisfy the check. Case modifiers without an executable version guard fail
+the test. The current scan set contains no case modifiers, so this test passes on a
+clean codebase (no guard is required when the feature is absent).
 
 **Enforcing test:** `test_portability_no_unguarded_bash4_case_modifiers`
 

--- a/plugins/vsdd-factory/docs/bash-portability.md
+++ b/plugins/vsdd-factory/docs/bash-portability.md
@@ -72,10 +72,12 @@ absent, so no guard is required).
 ## 2. Unguarded bash 4+ case modifiers (AC-002)
 
 **Pattern detected:** `${varname^^}` (to-uppercase), `${varname,,}` (to-lowercase),
-`${varname^}` (first-character uppercase), or `${varname,}` (first-character lowercase)
-in any wave-handoff script, including array-element forms such as `${arr[0]^^}`,
-`${map[k],,}`, and `${arr[i]^}`, and positional and special parameters such as
-`${1^^}`, `${@^^}`, `${*^^}`, and `${#^^}`.
+`${varname^}` (first-character uppercase), `${varname,}` (first-character lowercase),
+`${varname@U}` (bash-4.4 to-uppercase transform), `${varname@L}` (bash-4.4
+to-lowercase transform), or `${varname@u}` (bash-4.4 first-character uppercase
+transform) in any wave-handoff script, including array-element forms such as
+`${arr[0]^^}`, `${map[k],,}`, and `${arr[i]^}`, and positional and special parameters
+such as `${1^^}`, `${@^^}`, `${*^^}`, and `${#^^}`.
 
 **Why it breaks:** These parameter expansion operators were introduced in bash 4.0. On
 bash 3.2 (macOS system bash) they produce a **runtime** `bad substitution` error at the
@@ -99,8 +101,9 @@ upper="$(printf '%s' "$var" | awk '{print toupper($0)}')"
 `wave-handoff.sh` before any lib script is sourced.
 
 **What the guard checks:** If any file matches the pattern
-`\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?)` — covering the
-two-char forms `^^` and `,,`, the single-char forms `^` and `,`, named variable forms
+`\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?|@[ULu])` — covering the
+two-char forms `^^` and `,,`, the single-char forms `^` and `,`, the bash-4.4
+`@`-operator transforms `@U` / `@L` / `@u`, named variable forms
 (`${varname^^}`), array-element forms such as `${arr[0]^^}`, `${map[k],,}`, and
 `${arr[i]^}`, and positional and special-parameter forms such as `${1^^}`, `${@^^}`,
 `${*^^}`, and `${#^^}` — the test verifies that `BASH_VERSINFO` appears somewhere in
@@ -161,21 +164,24 @@ the shell's IFS.
 
 **What the guard checks:** The test applies the step-1 anchor
 `(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=`,
-which matches: bare line-start `IFS=`; second-statement uses such as `cmd; IFS=`;
-operator-prefixed mutations such as `cmd && IFS=`, `cmd & IFS=` (background-then-global),
-and `cmd || IFS=`; brace-group mutations such as `{ IFS=...` (brace group — runs in
-current shell); case pattern-action body mutations such as `) IFS=...` (case pattern —
-runs in current shell); and
+which anchors the positions where `IFS=` mutates the current (parent) shell: bare
+line-start `IFS=`; second-statement uses such as `cmd; IFS=`; operator-prefixed
+mutations such as `cmd && IFS=`, `cmd & IFS=` (background-then-global), and
+`cmd || IFS=`; brace-group mutations such as `{ IFS=...` (brace group — runs in the
+current shell, not a subshell); case pattern-action body mutations such as `) IFS=...`
+(case pattern-action body — runs in the current shell, not a subshell); and
 keyword-prefixed mutations where `IFS=` follows `then`, `do`, `else`, or `elif` with
-whitespace (e.g., `then IFS=...` in an `if` body or `do IFS=...` in a loop body); as
-well as the qualified forms `export IFS=`, `readonly IFS=`, and `declare -g IFS=` in
-any of those positions. The following forms are exempted and not flagged: `local IFS=`
-(function-scoped), `while IFS= read` and `IFS=... read` (command-prefix scoped to the
-single `read` call), and `(IFS=...; ...)` (subshell-scoped). The command-prefix
-exemption applies only to the no-separator form `IFS=val read` — the exemption does not
-cross `;`, `&`, or `|` statement separators, so `IFS=val; read` (global assignment
-followed by a separate `read` statement) IS flagged. Any match not covered by an
-exemption is reported as a violation.
+whitespace (e.g., `then IFS=...` in an `if` body or `do IFS=...` in a loop body). The
+subshell form `( IFS=...; ... )` is intentionally excluded from the anchor: `IFS` set
+inside a subshell is scoped to that subshell and does not leak back to the parent
+shell. The anchor covers the qualified forms `export IFS=`, `readonly IFS=`, and
+`declare -g IFS=` in any of those positions. The following forms are exempted and not
+flagged: `local IFS=` (function-scoped), `while IFS= read` and `IFS=... read`
+(command-prefix scoped to the single `read` call), and `(IFS=...; ...)` (subshell-scoped,
+as above). The command-prefix exemption applies only to the no-separator form `IFS=val read`
+— the exemption does not cross `;`, `&`, or `|` statement separators, so `IFS=val; read`
+(global assignment followed by a separate `read` statement) IS flagged. Any match not
+covered by an exemption is reported as a violation.
 
 **Enforcing test:** `test_portability_no_global_ifs_mutation`
 
@@ -231,8 +237,9 @@ immediately. **Phase 2 (if
 matches found):** The test first flags any occurrence of `--break-system-packages` as
 an explicit violation. For remaining matches without that flag, it checks whether the
 file contains an acceptable preflight guard matching
-`(python[0-9.]*[[:space:]]+-c[[:space:]]+"import yaml"|command[[:space:]]+-v[[:space:]]+python[0-9.]*)`.
-This covers both bare `python3 -c "import yaml"` and versioned-binary forms such as
+`(python[0-9.]*[[:space:]]+-c[[:space:]]+["']import yaml["']|command[[:space:]]+-v[[:space:]]+python[0-9.]*)`.
+This covers both bare `python3 -c "import yaml"` and `python3 -c 'import yaml'`
+(single or double quotes accepted), versioned-binary forms such as
 `python3.11 -c "import yaml"`, and both `command -v python3` and versioned forms such as
 `command -v python3.11`; absence of any such guard is a violation.
 
@@ -240,42 +247,36 @@ This covers both bare `python3 -c "import yaml"` and versioned-binary forms such
 
 ### AC-005 — jq
 
-**Pattern detected:** `jq` appearing as a standalone command token: at the start of a
-line, after a pipe (`|`), after a semicolon (`;`), after an ampersand (`&`), inside a
-command substitution (`$(jq ...)` or backtick form), as an argument to `xargs`
-(including `xargs` with intervening options such as `xargs -n1 jq`), or following
-wrapper keywords `if`, `then`, `do`, `else`, `elif`, `time`, `env`, `command`, or
-`sudo`.
+**Pattern detected:** `jq` appearing as a standalone command token in ANY execution
+position: at the start of a line, after a pipe (`|`), after a semicolon (`;`), after an
+ampersand (`&`), inside a command substitution (`$(jq ...)` or backtick form), as an
+argument to `xargs` (including `xargs` with intervening options such as `xargs -n1 jq`),
+following wrapper keywords `if`, `then`, `do`, `else`, `elif`, `time`, `env`, `command`,
+or `sudo`, inside a brace group (`{ jq . f; }`), as a case-pattern-action (`case $x in
+p) jq … ;;`), or inside a subshell (`( jq … )`).
 
-**Why it breaks:** `jq` is not installed by default on all macOS and Linux CI images.
-Scripts that invoke `jq` without checking for its presence fail with `command not found`
-at runtime on any system that does not have it, often with a misleading error that
-obscures the real cause.
-
-**Required fix:** Add a preflight guard before the first `jq` invocation:
-
-```bash
-command -v jq >/dev/null 2>&1 || {
-  echo "ERROR: jq is required; install with brew install jq" >&2
-  exit 1
-}
-```
-
-Both `command -v jq` and `which jq` satisfy the guard. The `command -v` form is
-preferred because it is POSIX-portable (the `which` form is not POSIX but is accepted
-as a common fallback).
+**Why it is forbidden:** `jq` is prohibited by the wave-handoff SKILL.md contract —
+scripts MUST NOT shell out to `jq`. This is not a "check for presence before using"
+situation: the contract forbids `jq` in any execution position, including subshells. Any
+detection of `jq` as a command word is a violation regardless of position. The correct
+fix is removal, not the addition of a preflight guard.
 
 **What the guard checks (phase 1):** Detects files where `jq` appears as a command
-word using POSIX ERE (no `\b` shorthand). The detection covers `jq` at the start of a
-line, after a pipe (`|`), after a semicolon (`;`), after a bare ampersand (`&`), inside
-a command substitution (`$(jq ...)` or backtick form), as an `xargs` argument
-(including `xargs` with intervening options such as `xargs -n1 jq`), and after the
-wrapper keywords `if`, `then`, `do`, `else`, `elif`, `time`, `env`, `command`, and
-`sudo`. If no such files are found, the test passes. **Phase 2:** For each file containing a `jq` invocation, the
-test verifies that `command -v jq` or `which jq` appears somewhere in the same file.
-Absence is a violation. No `jq` invocations currently exist in the wave-handoff scripts;
-this guard was added prospectively to prevent the dependency from being introduced
-silently.
+word in any execution position using POSIX ERE (no `\b` shorthand). The detector regex is:
+
+```
+(^[[:space:]]*jq([[:space:]]|$)|[|;&][[:space:]]*jq([[:space:]]|$)|\$[(]jq([[:space:]]|$)|`jq([[:space:]]|$)|(xargs|if|then|do|else|elif|time|env|command|sudo)[[:space:]]+jq([[:space:]]|$)|xargs([[:space:]]+-[^[:space:]]+)+[[:space:]]+jq([[:space:]]|$)|\{[[:space:]]*jq([[:space:]]|$)|\)[[:space:]]*jq([[:space:]]|$)|\([[:space:]]*jq([[:space:]]|$))
+```
+
+This covers `jq` at line-start, after pipe/semicolon/ampersand, inside `$(...)` or
+backtick command substitution, after `xargs` (with or without intervening options), after
+the wrapper keywords `if`, `then`, `do`, `else`, `elif`, `time`, `env`, `command`, and
+`sudo`, inside a brace group (`{ jq`), as a case-pattern-action body (`) jq`), and
+inside a subshell (`( jq`). If no such files are found, the test passes. **Phase 2:** For
+each file containing a `jq` invocation, the test verifies that `command -v jq` or
+`which jq` appears somewhere in the same file; absence is a violation. No `jq`
+invocations currently exist in the wave-handoff scripts; this guard was added
+prospectively to prevent the dependency from being introduced silently.
 
 **Soundness boundary:** The jq preflight check is whole-file (greps for `command -v jq`
 or `which jq` anywhere in the file), NOT positional (unlike AC-001's entrypoint guard,

--- a/plugins/vsdd-factory/docs/bash-portability.md
+++ b/plugins/vsdd-factory/docs/bash-portability.md
@@ -189,61 +189,42 @@ covered by an exemption is reported as a violation.
 
 ## 4. Undeclared runtime dependencies (AC-004 and AC-005)
 
-Wave-handoff scripts must not invoke external tools without a preflight availability
-check. Two specific tools are guarded: `python3`/PyYAML (AC-004) and `jq` (AC-005).
+Wave-handoff scripts must not invoke external tools. Two tools are guarded: python/pip
+(AC-004, any invocation is a violation) and `jq` (AC-005, any invocation is a violation).
 
-### AC-004 — python3 / PyYAML
+### AC-004 — python / pip shell-out prohibition (F-P11-001 Option A)
 
-**Pattern detected:** Any invocation of `python`, `python2`, `python3`, or a
-version-suffixed variant such as `python3.11` or `python3.12`, followed on the same
-line by a yaml token; any invocation of `pip`, `pip2`, `pip3`, or `pipx` followed by
-a pyyaml token (case-insensitive, so both `pyyaml` and `PyYAML` are matched); or a
-bare `import yaml` statement in any wave-handoff script.
+**Pattern detected:** Any invocation of `python`, `python2`, `python3`, a
+version-suffixed variant such as `python3.11` or `python3.12`, `pip`, `pip2`, `pip3`,
+or `pipx` in a command position in any wave-handoff script.
 
-**Exception (not flagged):** `python3` invocations that use only stdlib modules (`json`,
-`os`, `sys`, `re`, etc.) are fine and are not flagged. The guard targets only external
-pip packages.
+**No exceptions:** There is no stdlib exemption and no preflight-acceptance path.
+`python3 -c 'import json'` is a violation. `python3 -c 'import yaml'` is a violation.
+Any python or pip invocation in a command position is a violation, period. The fix is
+removal of the invocation, not the addition of a guard.
 
-**Why it breaks:** macOS GitHub Actions runners enforce PEP 668 "externally managed
-environment" isolation, which blocks `pip install` commands from modifying the system
-Python. The S-18.01 history has two entries for this failure: commit aaa8da8a (original
-pip failure) and commit 3fe11ea1 (attempted workaround with `--break-system-packages`).
-The `--break-system-packages` flag is explicitly not accepted as a long-term resolution
-in wave-handoff scripts — it works around the runner policy rather than eliminating the
-dependency.
+**Why it is forbidden:** SKILL.md §149 states: "This skill MUST NOT shell out to
+Python, jq, or any language runtime beyond bash." Python is treated identically to jq —
+the constraint is a hard prohibition, not a "declare a dependency" requirement. The
+S-18.01 history (commit aaa8da8a: pip failure; commit 3fe11ea1: `--break-system-packages`
+workaround) demonstrates that python shell-outs are fragile across CI environments.
 
-**Required fix:** Either add a preflight check before the first PyYAML invocation:
+**Required fix:** Remove the python/pip invocation entirely. Replace with a POSIX
+portable alternative using `awk`, `grep`, or `sed`.
 
-```bash
-python3 -c "import yaml" 2>/dev/null || {
-  echo "ERROR: PyYAML is required (pip install pyyaml)" >&2
-  exit 1
-}
+**What the guard checks:** Detects `python[0-9.]*` and `pip[0-9x]*` as command tokens
+in all execution positions using command-position anchoring analogous to the jq detector
+(AC-005). The detector regex is:
+
+```
+(^[[:space:]]*(python[0-9.]*|pip[0-9x]*)([[:space:]]|$)|[|;&][[:space:]]*(python[0-9.]*|pip[0-9x]*)([[:space:]]|$)|\$[(](python[0-9.]*|pip[0-9x]*)([[:space:]]|$)|`(python[0-9.]*|pip[0-9x]*)([[:space:]]|$)|(xargs|if|then|do|else|elif|time|env|command|sudo)[[:space:]]+(python[0-9.]*|pip[0-9x]*)([[:space:]]|$)|xargs([[:space:]]+-[^[:space:]]+)+[[:space:]]+(python[0-9.]*|pip[0-9x]*)([[:space:]]|$)|\{[[:space:]]*(python[0-9.]*|pip[0-9x]*)([[:space:]]|$)|\)[[:space:]]*(python[0-9.]*|pip[0-9x]*)([[:space:]]|$)|\([[:space:]]*(python[0-9.]*|pip[0-9x]*)([[:space:]]|$))
 ```
 
-or replace yaml parsing with a POSIX-portable alternative (`awk` or `sed` key
-extraction). The current wave-handoff implementation uses `awk`-based YAML parsing and
-contains no `import yaml` invocations, so this test passes on a clean codebase.
+Any match is a violation. The test is single-phase (no preflight-acceptance phase).
+Variable names that start with `python` (e.g., `python_bin=python3.11`) do not match
+because `_bin` immediately follows `python`, not a space or end-of-line.
 
-**What the guard checks (phase 1):** Detects files containing any of: a `python`,
-`python2`, `python3`, or version-suffixed binary (`python3.11`, `python3.12`, etc.)
-invocation followed anywhere on the same line by a case-insensitive yaml token (e.g.,
-`yaml`, `Yaml`, `YAML`) — the python arm uses the pattern `python[0-9.]*` to cover all
-such variants; a `pip`, `pip2`, `pip3`, or `pipx` invocation followed by a
-case-insensitive `pyyaml` token — the pyyaml token match is case-insensitive so the
-canonical PyPI name `PyYAML` (as in `pip3 install PyYAML`) is detected alongside
-lowercase `pyyaml`; or a bare `import yaml` statement. If none found, the test passes
-immediately. **Phase 2 (if
-matches found):** The test first flags any occurrence of `--break-system-packages` as
-an explicit violation. For remaining matches without that flag, it checks whether the
-file contains an acceptable preflight guard matching
-`(python[0-9.]*[[:space:]]+-c[[:space:]]+["']import yaml["']|command[[:space:]]+-v[[:space:]]+python[0-9.]*)`.
-This covers both bare `python3 -c "import yaml"` and `python3 -c 'import yaml'`
-(single or double quotes accepted), versioned-binary forms such as
-`python3.11 -c "import yaml"`, and both `command -v python3` and versioned forms such as
-`command -v python3.11`; absence of any such guard is a violation.
-
-**Enforcing test:** `test_portability_no_undeclared_pyyaml_dep`
+**Enforcing test:** `test_portability_no_python_shellout`
 
 ### AC-005 — jq
 

--- a/plugins/vsdd-factory/tests/wave-handoff.bats
+++ b/plugins/vsdd-factory/tests/wave-handoff.bats
@@ -4060,13 +4060,14 @@ EOF
   # Uses synthetic temp files in BATS_TEST_TMPDIR; no real wave-handoff scripts are executed.
   # Broadened detector: covers -A, -Ax (combined flags), -gA (prefix flags), and -A at EOL.
   # Distinguishes -A (associative, bash 4+) from -a (indexed, bash 3 safe).
-  local pc_bad_arr pc_bad_Ax pc_bad_gA pc_good_arr pc_bad_guard pc_good_guard
+  local pc_bad_arr pc_bad_Ax pc_bad_gA pc_good_arr pc_bad_guard pc_good_guard pc_commented_guard
   pc_bad_arr="${BATS_TEST_TMPDIR}/pc_ac001_bad_arr.sh"
   pc_bad_Ax="${BATS_TEST_TMPDIR}/pc_ac001_bad_Ax.sh"
   pc_bad_gA="${BATS_TEST_TMPDIR}/pc_ac001_bad_gA.sh"
   pc_good_arr="${BATS_TEST_TMPDIR}/pc_ac001_good_arr.sh"
   pc_bad_guard="${BATS_TEST_TMPDIR}/pc_ac001_bad_guard.sh"
   pc_good_guard="${BATS_TEST_TMPDIR}/pc_ac001_good_guard.sh"
+  pc_commented_guard="${BATS_TEST_TMPDIR}/pc_ac001_commented_guard.sh"
   local array_re='(local|declare)[[:space:]]+-[a-zA-Z]*A[a-zA-Z]*([[:space:]]|$)'
   local guard_re='([[].*BASH_VERSINFO|[(][(].*BASH_VERSINFO)'
   printf 'declare -A my_map\n' > "$pc_bad_arr"
@@ -4075,6 +4076,9 @@ EOF
   printf 'declare -a my_arr\n' > "$pc_good_arr"
   printf '# removed the BASH_VERSINFO guard\n' > "$pc_bad_guard"
   printf 'if [ "${BASH_VERSINFO[0]:-0}" -lt 4 ]; then\n  exit 1\nfi\n' > "$pc_good_guard"
+  # Commented-out executable guard: the entire guard line is commented out.
+  # This is the F-P14-001 regression trigger — guard_re alone matches it; comment-stripping must not.
+  printf '# if [[ ${BASH_VERSINFO[0]} -lt 4 ]]; then\nlocal -A map\n' > "$pc_commented_guard"
   # Array-detector: BAD sample (declare -A) MUST match.
   grep -qE "$array_re" "$pc_bad_arr" || {
     echo "FAIL (AC-001 positive-control): array-detector did not match 'declare -A my_map'." >&2
@@ -4114,14 +4118,22 @@ EOF
     echo "FAIL (AC-001 positive-control): array-detector falsely matched 'declare -a' (POSIX indexed array; bash-3-safe)." >&2
     false
   }
-  # Guard-detector: executable conditional MUST match ([ precedes BASH_VERSINFO on the line).
-  grep -qE "$guard_re" "$pc_good_guard" || {
+  # Guard-detector: executable conditional MUST match (non-comment [ or (( precedes BASH_VERSINFO).
+  grep -vE '^[[:space:]]*#' "$pc_good_guard" | grep -qE "$guard_re" || {
     echo "FAIL (AC-001 positive-control): guard-detector did not match 'if [ ... BASH_VERSINFO' form." >&2
     false
   }
-  # Guard-detector: BASH_VERSINFO in a comment MUST NOT match (prevents paper-fix false-pass).
-  ! grep -qE "$guard_re" "$pc_bad_guard" || {
-    echo "FAIL (AC-001 positive-control): guard-detector falsely matched BASH_VERSINFO in a comment." >&2
+  # Guard-detector: BASH_VERSINFO in a prose comment MUST NOT match (prevents paper-fix false-pass).
+  ! grep -vE '^[[:space:]]*#' "$pc_bad_guard" | grep -qE "$guard_re" || {
+    echo "FAIL (AC-001 positive-control): guard-detector falsely matched BASH_VERSINFO in a prose comment." >&2
+    false
+  }
+  # Guard-detector: a commented-out executable guard MUST NOT match (F-P14-001).
+  # The regression: commenting out 'if [[ ${BASH_VERSINFO[0]} -lt 4 ]]; then' leaves a line
+  # that still contains '[' before BASH_VERSINFO — guard_re alone would match it falsely.
+  ! grep -vE '^[[:space:]]*#' "$pc_commented_guard" | grep -qE "$guard_re" || {
+    echo "FAIL (AC-001 positive-control / F-P14-001): guard-detector falsely matched BASH_VERSINFO in a commented-out guard." >&2
+    echo "  Commenting out 'if [[ ... BASH_VERSINFO' must not satisfy the guard oracle." >&2
     false
   }
   # -------------------------------------------
@@ -4145,13 +4157,14 @@ EOF
   fi
 
   # Associative arrays are used; verify the bash version guard exists in the scan set.
-  # Acceptable guard forms: BASH_VERSINFO inside an executable conditional.
-  # "[ ${BASH_VERSINFO[0]:-0} -lt 4 ]" — [ precedes BASH_VERSINFO on the same line.
-  # "(( BASH_VERSINFO[0] < 4 ))" — (( precedes BASH_VERSINFO on the same line.
-  # A bare comment like "# removed the BASH_VERSINFO guard" does NOT satisfy the oracle.
+  # Acceptable guard forms: BASH_VERSINFO inside an executable (non-comment) conditional.
+  # "[ ${BASH_VERSINFO[0]:-0} -lt 4 ]" — [ precedes BASH_VERSINFO on the same non-comment line.
+  # "(( BASH_VERSINFO[0] < 4 ))" — (( precedes BASH_VERSINFO on the same non-comment line.
+  # A commented-out guard like "# if [[ ${BASH_VERSINFO[0]} -lt 4 ]]; then" does NOT satisfy
+  # the oracle — comment lines are stripped before guard_re is applied (F-P14-001).
   local has_guard=0
   for f in "${sh_files[@]}"; do
-    if grep -qE "$guard_re" "$f" 2>/dev/null; then
+    if grep -vE '^[[:space:]]*#' "$f" 2>/dev/null | grep -qE "$guard_re"; then
       has_guard=1
       break
     fi
@@ -4160,7 +4173,7 @@ EOF
   [ "$has_guard" -eq 1 ] || {
     echo "FAIL (AC-001): associative arrays (local -A / declare -A) found in wave-handoff" >&2
     echo "  scripts but no executable bash version guard (BASH_VERSINFO inside if/[/(()" >&2
-    echo "  found in the scan set. A bare comment mentioning BASH_VERSINFO is insufficient." >&2
+    echo "  found in the scan set. A commented-out guard is insufficient." >&2
     echo "  The S-18.01 fix (ea7328ac) added the guard to wave-handoff.sh. It has been lost." >&2
     echo "  Fix: restore in wave-handoff.sh (before sourcing lib scripts):" >&2
     echo "    if [ \"\${BASH_VERSINFO[0]:-0}\" -lt 4 ]; then" >&2
@@ -4195,11 +4208,13 @@ EOF
 
   # Detector: does the entrypoint have a guard BEFORE its first source line?
   # Returns 0 (PASS) when guard_line < first_source_line.
+  # Comment lines are stripped before guard_re is applied so a commented-out guard
+  # (e.g. "# if [[ ${BASH_VERSINFO[0]} -lt 4 ]]; then") does NOT satisfy the oracle (F-P14-001).
   _ep_guard_precedes_source() {
     local ep_file="$1"
     local guard_line first_src_line
-    guard_line="$(grep -nE "$guard_re" "$ep_file" 2>/dev/null \
-      | head -1 | cut -d: -f1)"
+    guard_line="$(grep -nvE '^[[:space:]]*#' "$ep_file" 2>/dev/null \
+      | grep -E "$guard_re" | head -1 | cut -d: -f1)"
     first_src_line="$(grep -nE '^[[:space:]]*(source|\.)[[:space:]]+' "$ep_file" 2>/dev/null \
       | head -1 | cut -d: -f1)"
     # No source line at all — entrypoint does not source libs; skip (not an entrypoint)
@@ -4403,6 +4418,24 @@ EOF
     echo "FAIL (AC-002 positive-control): case-modifier-detector falsely matched plain '\${VAR}'." >&2
     false
   }
+  # Guard-detector controls (F-P14-001 fix): comment lines must be stripped before applying
+  # guard_re so a commented-out guard does not falsely satisfy the oracle.
+  local pc_good_guard_ac002 pc_commented_guard_ac002
+  pc_good_guard_ac002="${BATS_TEST_TMPDIR}/pc_ac002_good_guard.sh"
+  pc_commented_guard_ac002="${BATS_TEST_TMPDIR}/pc_ac002_commented_guard.sh"
+  printf 'if [ "${BASH_VERSINFO[0]:-0}" -lt 4 ]; then\n  exit 1\nfi\n' > "$pc_good_guard_ac002"
+  printf '# if [[ ${BASH_VERSINFO[0]} -lt 4 ]]; then\n' > "$pc_commented_guard_ac002"
+  # Executable guard MUST be detected after comment-stripping.
+  grep -vE '^[[:space:]]*#' "$pc_good_guard_ac002" | grep -qE "$guard_re" || {
+    echo "FAIL (AC-002 guard positive-control): guard-detector did not match executable conditional." >&2
+    false
+  }
+  # Commented-out guard MUST NOT be detected (F-P14-001).
+  ! grep -vE '^[[:space:]]*#' "$pc_commented_guard_ac002" | grep -qE "$guard_re" || {
+    echo "FAIL (AC-002 guard positive-control / F-P14-001): guard-detector falsely matched BASH_VERSINFO in a commented-out guard." >&2
+    echo "  Commenting out 'if [[ ... BASH_VERSINFO' must not satisfy the guard oracle." >&2
+    false
+  }
   # -------------------------------------------
 
   # Collect all uses of bash 4+ case modifiers — bash 4+ only, syntax error on bash 3.2.
@@ -4434,11 +4467,12 @@ EOF
   fi
 
   # Case modifiers are used; verify an executable bash version guard exists in the scan set.
-  # Acceptable forms: BASH_VERSINFO inside an if-conditional ([ or (( precedes it on the line).
-  # A bare comment mentioning BASH_VERSINFO is insufficient.
+  # Acceptable forms: BASH_VERSINFO inside an executable (non-comment) conditional.
+  # A commented-out guard like "# if [[ ${BASH_VERSINFO[0]} -lt 4 ]]; then" does NOT satisfy
+  # the oracle — comment lines are stripped before guard_re is applied (F-P14-001).
   local has_guard=0
   for f in "${sh_files[@]}"; do
-    if grep -qE "$guard_re" "$f" 2>/dev/null; then
+    if grep -vE '^[[:space:]]*#' "$f" 2>/dev/null | grep -qE "$guard_re"; then
       has_guard=1
       break
     fi
@@ -4447,7 +4481,7 @@ EOF
   [ "$has_guard" -eq 1 ] || {
     echo "FAIL (AC-002): bash 4+ case modifiers (\${var^}, \${var^^}, \${var,}, \${var,,}, \${var@U}, \${var@L}, \${var@u}) found in" >&2
     echo "  wave-handoff scripts without an executable bash version guard (BASH_VERSINFO in if/[/(()" >&2
-    echo "  found in the scan set." >&2
+    echo "  found in the scan set. A commented-out guard is insufficient." >&2
     echo "  Fix: either remove case modifiers (use 'tr a-z A-Z' or awk for case conversion)" >&2
     echo "  or add a bash 4+ version check to wave-handoff.sh before sourcing lib scripts." >&2
     echo "  Violations:" >&2

--- a/plugins/vsdd-factory/tests/wave-handoff.bats
+++ b/plugins/vsdd-factory/tests/wave-handoff.bats
@@ -4913,6 +4913,11 @@ EOF
   local pc_bad_py3 pc_bad_py2 pc_bad_pip3 pc_bad_pipx pc_bad_py311 pc_bad_stdlib
   local pc_bad_py3_cmdsubst pc_bad_sudo_py3
   local pc_good_py_var pc_good_comment pc_good_echo_py
+  local pc_bad_py3_pipe pc_bad_py3_and pc_bad_py3_backtick
+  local pc_bad_py3_if pc_bad_py3_then pc_bad_py3_do pc_bad_py3_else pc_bad_py3_elif
+  local pc_bad_py3_time pc_bad_py3_env pc_bad_py3_command pc_bad_py3_xargs
+  local pc_bad_py3_xargs_opts pc_bad_py3_brace pc_bad_py3_case_paren pc_bad_py3_subshell
+  local pc_bad_pip3_and pc_good_other_cmdsubst_py
 
   pc_bad_py3="${BATS_TEST_TMPDIR}/pc_ac004_bad_py3.sh"
   pc_bad_py2="${BATS_TEST_TMPDIR}/pc_ac004_bad_py2.sh"
@@ -4925,6 +4930,24 @@ EOF
   pc_good_py_var="${BATS_TEST_TMPDIR}/pc_ac004_good_py_var.sh"
   pc_good_comment="${BATS_TEST_TMPDIR}/pc_ac004_good_comment.sh"
   pc_good_echo_py="${BATS_TEST_TMPDIR}/pc_ac004_good_echo_py.sh"
+  pc_bad_py3_pipe="${BATS_TEST_TMPDIR}/pc_ac004_bad_py3_pipe.sh"
+  pc_bad_py3_and="${BATS_TEST_TMPDIR}/pc_ac004_bad_py3_and.sh"
+  pc_bad_py3_backtick="${BATS_TEST_TMPDIR}/pc_ac004_bad_py3_backtick.sh"
+  pc_bad_py3_if="${BATS_TEST_TMPDIR}/pc_ac004_bad_py3_if.sh"
+  pc_bad_py3_then="${BATS_TEST_TMPDIR}/pc_ac004_bad_py3_then.sh"
+  pc_bad_py3_do="${BATS_TEST_TMPDIR}/pc_ac004_bad_py3_do.sh"
+  pc_bad_py3_else="${BATS_TEST_TMPDIR}/pc_ac004_bad_py3_else.sh"
+  pc_bad_py3_elif="${BATS_TEST_TMPDIR}/pc_ac004_bad_py3_elif.sh"
+  pc_bad_py3_time="${BATS_TEST_TMPDIR}/pc_ac004_bad_py3_time.sh"
+  pc_bad_py3_env="${BATS_TEST_TMPDIR}/pc_ac004_bad_py3_env.sh"
+  pc_bad_py3_command="${BATS_TEST_TMPDIR}/pc_ac004_bad_py3_command.sh"
+  pc_bad_py3_xargs="${BATS_TEST_TMPDIR}/pc_ac004_bad_py3_xargs.sh"
+  pc_bad_py3_xargs_opts="${BATS_TEST_TMPDIR}/pc_ac004_bad_py3_xargs_opts.sh"
+  pc_bad_py3_brace="${BATS_TEST_TMPDIR}/pc_ac004_bad_py3_brace.sh"
+  pc_bad_py3_case_paren="${BATS_TEST_TMPDIR}/pc_ac004_bad_py3_case_paren.sh"
+  pc_bad_py3_subshell="${BATS_TEST_TMPDIR}/pc_ac004_bad_py3_subshell.sh"
+  pc_bad_pip3_and="${BATS_TEST_TMPDIR}/pc_ac004_bad_pip3_and.sh"
+  pc_good_other_cmdsubst_py="${BATS_TEST_TMPDIR}/pc_ac004_good_other_cmdsubst.sh"
 
   printf 'python3 script.py\n' > "$pc_bad_py3"
   printf 'python2 -c "import os; os.system(\"id\")"\n' > "$pc_bad_py2"
@@ -4944,6 +4967,25 @@ EOF
   printf '# python3 is not used in this script\n' > "$pc_good_comment"
   # GOOD: python3 as argument to echo — NOT a command invocation.
   printf 'echo "install python3 first"\n' > "$pc_good_echo_py"
+  # F-P12-001 arm fixtures: arms 2, 4, 5-remaining, 6, 7, 8, 9 + pip variant + negative cmdsubst.
+  printf 'cmd | python3 script.py\n' > "$pc_bad_py3_pipe"
+  printf 'cmd && python3 script.py\n' > "$pc_bad_py3_and"
+  printf '`python3 script.py`\n' > "$pc_bad_py3_backtick"
+  printf 'if python3 check.py\n' > "$pc_bad_py3_if"
+  printf 'then python3 run.py\n' > "$pc_bad_py3_then"
+  printf 'do python3 process.py\n' > "$pc_bad_py3_do"
+  printf 'else python3 fallback.py\n' > "$pc_bad_py3_else"
+  printf 'elif python3 check.py\n' > "$pc_bad_py3_elif"
+  printf 'time python3 bench.py\n' > "$pc_bad_py3_time"
+  printf 'env python3 script.py\n' > "$pc_bad_py3_env"
+  printf 'command python3 script.py\n' > "$pc_bad_py3_command"
+  printf 'xargs python3 process.py\n' > "$pc_bad_py3_xargs"
+  printf 'find . -name "*.py" | xargs -n1 python3\n' > "$pc_bad_py3_xargs_opts"
+  printf '{ python3 script.py; }\n' > "$pc_bad_py3_brace"
+  printf 'case $x in *) python3 script.py ;; esac\n' > "$pc_bad_py3_case_paren"
+  printf '( python3 script.py )\n' > "$pc_bad_py3_subshell"
+  printf 'cmd && pip3 install requests\n' > "$pc_bad_pip3_and"
+  printf 'result=$(other_cmd script.py)\n' > "$pc_good_other_cmdsubst_py"
 
   # BAD: bare line-start 'python3 script.py' MUST be detected.
   grep -qE "$python_re" "$pc_bad_py3" || {
@@ -5005,6 +5047,116 @@ EOF
   ! grep -qE "$python_re" "$pc_good_echo_py" || {
     echo "FAIL (AC-004 negative-control): python-detector falsely matched 'echo \"install python3 first\"'." >&2
     echo "  python3 as an argument to echo is not a python shell-out." >&2
+    false
+  }
+  # F-P12-001 positive controls: per-arm coverage for arms 2, 4, 5-remaining, 6, 7, 8, 9.
+  # BAD (F-P12-001 arm 2): 'cmd | python3 ...' pipe MUST be detected ([|;&] arm).
+  grep -qE "$python_re" "$pc_bad_py3_pipe" || {
+    echo "FAIL (AC-004 positive-control / F-P12-001): python-detector did not match 'cmd | python3 ...' (pipe)." >&2
+    echo "  The [|;&][[:space:]]*(python[0-9.]*|pip[0-9x]*)([[:space:]]|\$) arm must match pipe." >&2
+    false
+  }
+  # BAD (F-P12-001 arm 2): 'cmd && python3 ...' and-chain MUST be detected ([|;&] arm).
+  grep -qE "$python_re" "$pc_bad_py3_and" || {
+    echo "FAIL (AC-004 positive-control / F-P12-001): python-detector did not match 'cmd && python3 ...' (and-chain)." >&2
+    echo "  & in [|;&] catches both && and || forms." >&2
+    false
+  }
+  # BAD (F-P12-001 arm 4): backtick '\`python3 ...\`' MUST be detected.
+  grep -qE "$python_re" "$pc_bad_py3_backtick" || {
+    echo "FAIL (AC-004 positive-control / F-P12-001): python-detector did not match backtick '\`python3 ...\`' form." >&2
+    echo "  The \`(python[0-9.]*|pip[0-9x]*)([[:space:]]|\$) arm must match backtick substitution." >&2
+    false
+  }
+  # BAD (F-P12-001 arm 5): 'if python3 ...' MUST be detected (keyword wrapper arm).
+  grep -qE "$python_re" "$pc_bad_py3_if" || {
+    echo "FAIL (AC-004 positive-control / F-P12-001): python-detector did not match 'if python3 ...' form." >&2
+    echo "  'if' must be in the keyword wrapper group (xargs|if|then|do|else|elif|time|env|command|sudo)." >&2
+    false
+  }
+  # BAD (F-P12-001 arm 5): 'then python3 ...' MUST be detected (keyword wrapper arm).
+  grep -qE "$python_re" "$pc_bad_py3_then" || {
+    echo "FAIL (AC-004 positive-control / F-P12-001): python-detector did not match 'then python3 ...' form." >&2
+    echo "  'then' must be in the keyword wrapper group." >&2
+    false
+  }
+  # BAD (F-P12-001 arm 5): 'do python3 ...' MUST be detected (keyword wrapper arm).
+  grep -qE "$python_re" "$pc_bad_py3_do" || {
+    echo "FAIL (AC-004 positive-control / F-P12-001): python-detector did not match 'do python3 ...' form." >&2
+    echo "  'do' must be in the keyword wrapper group." >&2
+    false
+  }
+  # BAD (F-P12-001 arm 5): 'else python3 ...' MUST be detected (keyword wrapper arm).
+  grep -qE "$python_re" "$pc_bad_py3_else" || {
+    echo "FAIL (AC-004 positive-control / F-P12-001): python-detector did not match 'else python3 ...' form." >&2
+    echo "  'else' must be in the keyword wrapper group (genuine command position, same as jq)." >&2
+    false
+  }
+  # BAD (F-P12-001 arm 5): 'elif python3 ...' MUST be detected (keyword wrapper arm).
+  grep -qE "$python_re" "$pc_bad_py3_elif" || {
+    echo "FAIL (AC-004 positive-control / F-P12-001): python-detector did not match 'elif python3 ...' form." >&2
+    echo "  'elif' must be in the keyword wrapper group." >&2
+    false
+  }
+  # BAD (F-P12-001 arm 5): 'time python3 ...' MUST be detected (keyword wrapper arm — O-3 addition).
+  grep -qE "$python_re" "$pc_bad_py3_time" || {
+    echo "FAIL (AC-004 positive-control / F-P12-001): python-detector did not match 'time python3 ...' form." >&2
+    echo "  'time' must be in the keyword wrapper group (added at O-3)." >&2
+    false
+  }
+  # BAD (F-P12-001 arm 5): 'env python3 ...' MUST be detected (keyword wrapper arm — O-3 addition).
+  grep -qE "$python_re" "$pc_bad_py3_env" || {
+    echo "FAIL (AC-004 positive-control / F-P12-001): python-detector did not match 'env python3 ...' form." >&2
+    echo "  'env' must be in the keyword wrapper group (added at O-3)." >&2
+    false
+  }
+  # BAD (F-P12-001 arm 5): 'command python3 ...' MUST be detected (keyword wrapper arm — O-3 addition).
+  grep -qE "$python_re" "$pc_bad_py3_command" || {
+    echo "FAIL (AC-004 positive-control / F-P12-001): python-detector did not match 'command python3 ...' form." >&2
+    echo "  'command' must be in the keyword wrapper group (added at O-3)." >&2
+    false
+  }
+  # BAD (F-P12-001 arm 5): 'xargs python3 ...' MUST be detected (keyword wrapper arm, direct xargs).
+  grep -qE "$python_re" "$pc_bad_py3_xargs" || {
+    echo "FAIL (AC-004 positive-control / F-P12-001): python-detector did not match 'xargs python3 ...' form." >&2
+    echo "  'xargs' must be in the keyword wrapper group for the direct (no-option) form." >&2
+    false
+  }
+  # BAD (F-P12-001 arm 6): 'xargs -n1 python3' MUST be detected (xargs-with-options arm).
+  grep -qE "$python_re" "$pc_bad_py3_xargs_opts" || {
+    echo "FAIL (AC-004 positive-control / F-P12-001): python-detector did not match 'xargs -n1 python3' form." >&2
+    echo "  The xargs-with-options arm 'xargs([[:space:]]+-[^[:space:]]+)+[[:space:]]+(python...)([[:space:]]|\$)' is required." >&2
+    false
+  }
+  # BAD (F-P12-001 arm 7): '{ python3 ...; }' brace-group MUST be detected.
+  grep -qE "$python_re" "$pc_bad_py3_brace" || {
+    echo "FAIL (AC-004 positive-control / F-P12-001): python-detector did not match '{ python3 ...; }' brace-group form." >&2
+    echo "  Brace groups run in the current shell; arm: \\{[[:space:]]*(python[0-9.]*|pip[0-9x]*)([[:space:]]|\$)" >&2
+    false
+  }
+  # BAD (F-P12-001 arm 8): 'case $x in *) python3 ...' case-pattern-body MUST be detected.
+  grep -qE "$python_re" "$pc_bad_py3_case_paren" || {
+    echo "FAIL (AC-004 positive-control / F-P12-001): python-detector did not match 'case ... ) python3' case-body form." >&2
+    echo "  Case pattern-action bodies run in the current shell; arm: \\)[[:space:]]*(python[0-9.]*|pip[0-9x]*)([[:space:]]|\$)" >&2
+    false
+  }
+  # BAD (F-P12-001 arm 9): '( python3 ... )' subshell MUST be detected.
+  grep -qE "$python_re" "$pc_bad_py3_subshell" || {
+    echo "FAIL (AC-004 positive-control / F-P12-001): python-detector did not match '( python3 ... )' subshell form." >&2
+    echo "  python3 in a subshell still executes; arm: \\([[:space:]]*(python[0-9.]*|pip[0-9x]*)([[:space:]]|\$)" >&2
+    false
+  }
+  # BAD (F-P12-001 pip variant, arm 2): 'cmd && pip3 install ...' MUST be detected.
+  grep -qE "$python_re" "$pc_bad_pip3_and" || {
+    echo "FAIL (AC-004 positive-control / F-P12-001): python-detector did not match 'cmd && pip3 install ...' (pip3 and-chain)." >&2
+    echo "  pip[0-9x]* must be detected in the [|;&] arm, same as python[0-9.]*." >&2
+    false
+  }
+  # GOOD (F-P12-001 negative control): '\$(other_cmd ...)' MUST NOT be detected.
+  # The \$( arm only fires when python[0-9.]* or pip[0-9x]* immediately follows '$(', not other commands.
+  ! grep -qE "$python_re" "$pc_good_other_cmdsubst_py" || {
+    echo "FAIL (AC-004 negative-control / F-P12-001): python-detector falsely matched '\$(other_cmd script.py)'." >&2
+    echo "  The \\\$( arm must require python[0-9.]*/pip[0-9x]* as the immediate next token after '\$(', not any command." >&2
     false
   }
   # -------------------------------------------

--- a/plugins/vsdd-factory/tests/wave-handoff.bats
+++ b/plugins/vsdd-factory/tests/wave-handoff.bats
@@ -4137,7 +4137,10 @@ EOF
   done
 
   # If no associative arrays are used anywhere, the scan set is compliant.
-  [ "$has_arrays" -eq 1 ] || return 0
+  if [ "$has_arrays" -eq 0 ]; then
+    echo "AC-001: scanned=${#sh_files[@]} files"
+    return 0
+  fi
 
   # Associative arrays are used; verify the bash version guard exists in the scan set.
   # Acceptable guard forms: BASH_VERSINFO inside an executable conditional.
@@ -4165,6 +4168,88 @@ EOF
     echo "    fi" >&2
     false
   }
+
+  # --- F-P6-001: ENTRYPOINT-GUARD SOUNDNESS ASSERTION ---
+  # EC-006 requirement: any NEW, separate entrypoint that sources a sibling lib which uses
+  # local -A / declare -A WITHOUT its own bash-4 guard is a FAIL, even if another entrypoint
+  # in the scan set already has a guard.
+  #
+  # Structural check (real scripts): for each entrypoint .sh that sources a sibling lib,
+  # assert the BASH_VERSINFO guard appears at a line number LOWER than its first source/. line.
+  # An entrypoint is any .sh file whose name matches the skill top-level (not under lib/).
+  #
+  # Step 1: Synthetic positive-control — unguarded entrypoint sourcing a lib with local -A
+  # MUST trigger a FAIL from the positional detector.
+  local pc_unguarded_ep pc_guarded_ep pc_lib_with_arr
+  pc_unguarded_ep="${BATS_TEST_TMPDIR}/pc_ac001_unguarded_ep.sh"
+  pc_guarded_ep="${BATS_TEST_TMPDIR}/pc_ac001_guarded_ep.sh"
+  pc_lib_with_arr="${BATS_TEST_TMPDIR}/pc_ac001_lib_with_arr.sh"
+  # The lib uses local -A (bash 4+ only)
+  printf 'local -A my_map\n' > "$pc_lib_with_arr"
+  # Unguarded entrypoint: sources the lib but has no BASH_VERSINFO guard
+  printf 'source "%s"\n' "$pc_lib_with_arr" > "$pc_unguarded_ep"
+  # Guarded entrypoint: guard (line 1) appears BEFORE the source (line 2) — must PASS
+  printf 'if [ "${BASH_VERSINFO[0]:-0}" -lt 4 ]; then exit 1; fi\nsource "%s"\n' "$pc_lib_with_arr" > "$pc_guarded_ep"
+
+  # Detector: does the entrypoint have a guard BEFORE its first source line?
+  # Returns 0 (PASS) when guard_line < first_source_line.
+  _ep_guard_precedes_source() {
+    local ep_file="$1"
+    local guard_line first_src_line
+    guard_line="$(grep -nE '([[].*BASH_VERSINFO|[(][(].*BASH_VERSINFO)' "$ep_file" 2>/dev/null \
+      | head -1 | cut -d: -f1)"
+    first_src_line="$(grep -nE '^[[:space:]]*(source|\.)[[:space:]]+' "$ep_file" 2>/dev/null \
+      | head -1 | cut -d: -f1)"
+    # No source line at all — entrypoint does not source libs; skip (not an entrypoint)
+    [ -n "$first_src_line" ] || return 0
+    # Has source but no guard — FAIL
+    [ -n "$guard_line" ] || return 1
+    # Guard must precede first source
+    [ "$guard_line" -lt "$first_src_line" ]
+  }
+
+  # Unguarded entrypoint MUST FAIL the positional check (positive-control for soundness).
+  _ep_guard_precedes_source "$pc_unguarded_ep" && {
+    echo "FAIL (AC-001 F-P6-001 positive-control): positional guard detector PASSED on an" >&2
+    echo "  unguarded entrypoint that sources a lib containing local -A. Detector is unsound." >&2
+    echo "  An entrypoint that sources a bash-4 lib WITHOUT a preceding BASH_VERSINFO guard" >&2
+    echo "  MUST be rejected (EC-006)." >&2
+    false
+  }
+
+  # Guarded entrypoint MUST PASS the positional check (negative-control for non-vacuity,
+  # POLICY 11: test must be non-tautological).
+  _ep_guard_precedes_source "$pc_guarded_ep" || {
+    echo "FAIL (AC-001 F-P6-001 positive-control): positional guard detector FAILED on a" >&2
+    echo "  correctly guarded entrypoint (guard precedes first source line). Detector is broken." >&2
+    false
+  }
+
+  # Step 2: Apply the structural check to all real entrypoint scripts under wave-handoff/.
+  # Entrypoints are .sh files NOT under lib/ (direct children of the skill root).
+  local ep_violations=()
+  for f in "${sh_files[@]}"; do
+    # Only inspect files directly under the skill root (not in lib/ subdirectory)
+    local rel="${f#${wave_handoff_skill_dir}/}"
+    [[ "$rel" != lib/* ]] || continue
+    # Only process files that actually source sibling libs (skip pure helpers)
+    grep -qE '^[[:space:]]*(source|\.)[[:space:]]+' "$f" 2>/dev/null || continue
+
+    _ep_guard_precedes_source "$f" || {
+      ep_violations+=("$rel")
+    }
+  done
+
+  [ "${#ep_violations[@]}" -eq 0 ] || {
+    echo "FAIL (AC-001 F-P6-001): entrypoint script(s) source sibling libs that use bash 4+" >&2
+    echo "  syntax but the BASH_VERSINFO guard does NOT appear before the first source line." >&2
+    echo "  EC-006: every entrypoint that sources bash-4 libs must guard BEFORE sourcing." >&2
+    local viol
+    for viol in "${ep_violations[@]}"; do echo "  ${viol}" >&2; done
+    false
+  }
+
+  echo "AC-001: scanned=${#sh_files[@]} files"
 }
 
 # ---------------------------------------------------------------------------
@@ -4239,6 +4324,17 @@ EOF
     echo "  The var-name class must cover [0-9]+ (positional) and [@*#] (special) as alternatives." >&2
     false
   }
+  # O-1: ${#^^} positive control — the # special parameter with a case modifier.
+  # bash-portability.md §2 claims ${#^^} is covered by the [@*#] class; verify explicitly.
+  local pc_bad_hash_modifier
+  pc_bad_hash_modifier="${BATS_TEST_TMPDIR}/pc_ac002_bad_hash_modifier.sh"
+  printf 'echo "${#^^}"\n' > "$pc_bad_hash_modifier"
+  grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?)' "$pc_bad_hash_modifier" || {
+    echo "FAIL (AC-002 positive-control / O-1): case-modifier-detector did not match '\${#^^}'." >&2
+    echo "  bash-portability.md §2 states \${#^^} is covered by the [@*#] class." >&2
+    echo "  The # special parameter with a case modifier is bash 4+ only." >&2
+    false
+  }
   # Plain expansion (\${VAR}) MUST NOT match.
   ! grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?)' "$pc_good_plain" || {
     echo "FAIL (AC-002 positive-control): case-modifier-detector falsely matched plain '\${VAR}'." >&2
@@ -4268,7 +4364,10 @@ EOF
   done
 
   # No case modifiers found — compliant.
-  [ "${#modifier_files[@]}" -gt 0 ] || return 0
+  if [ "${#modifier_files[@]}" -eq 0 ]; then
+    echo "AC-002: scanned=${#sh_files[@]} files"
+    return 0
+  fi
 
   # Case modifiers are used; verify an executable bash version guard exists in the scan set.
   # Acceptable forms: BASH_VERSINFO inside an if-conditional ([ or (( precedes it on the line).
@@ -4292,6 +4391,7 @@ EOF
     for v in "${violations[@]}"; do echo "  ${v}" >&2; done
     false
   }
+  echo "AC-002: scanned=${#sh_files[@]} files"
 }
 
 # ---------------------------------------------------------------------------
@@ -4566,6 +4666,7 @@ EOF
     for v in "${violations[@]}"; do echo "  ${v}" >&2; done
     false
   fi
+  echo "AC-003: scanned=${#sh_files[@]} files"
 }
 
 # ---------------------------------------------------------------------------
@@ -4696,7 +4797,10 @@ EOF
   done
 
   # No python/pyyaml invocations — compliant (EC-002: stdlib-only python3 is fine).
-  [ "${#dep_files[@]}" -gt 0 ] || return 0
+  if [ "${#dep_files[@]}" -eq 0 ]; then
+    echo "AC-004: scanned=${#sh_files[@]} files"
+    return 0
+  fi
 
   # Phase 2: for each file with a pyyaml/python-yaml invocation, audit for acceptability.
   # Unacceptable form: --break-system-packages (PEP 668 workaround; not a long-term fix).
@@ -4742,6 +4846,7 @@ EOF
     for v in "${violations[@]}"; do echo "  ${v}" >&2; done
     false
   fi
+  echo "AC-004: scanned=${#sh_files[@]} files"
 }
 
 # ---------------------------------------------------------------------------
@@ -4865,7 +4970,10 @@ EOF
   done
 
   # No jq invocations — compliant.
-  [ "${#jq_files[@]}" -gt 0 ] || return 0
+  if [ "${#jq_files[@]}" -eq 0 ]; then
+    echo "AC-005: scanned=${#sh_files[@]} files"
+    return 0
+  fi
 
   # Phase 2: for each file with jq invocations, verify a preflight guard exists.
   # Acceptable preflight forms:
@@ -4893,6 +5001,7 @@ EOF
     for v in "${violations[@]}"; do echo "  ${v}" >&2; done
     false
   fi
+  echo "AC-005: scanned=${#sh_files[@]} files"
 }
 
 # ---------------------------------------------------------------------------

--- a/plugins/vsdd-factory/tests/wave-handoff.bats
+++ b/plugins/vsdd-factory/tests/wave-handoff.bats
@@ -3973,8 +3973,11 @@ EOF
     # Patterns: the backslash appears literally in the grep/sed argument.
     #
     # Use grep -n to get line numbers for diagnostic output.
+    # D-740 O-3: comment-strip pre-filter for parity with the guard oracle (which strips
+    # comment lines before matching) — a comment mentioning \s/\d/etc. must not false-match.
     local hits
-    hits="$(grep -nE "(grep|sed).*(['\"])[^'\"]*\\\\[sSdDwWb][^'\"]*\2" "$f" 2>/dev/null || true)"
+    hits="$(grep -nvE '^[[:space:]]*#' "$f" 2>/dev/null \
+        | grep -E "(grep|sed).*(['\"])[^'\"]*\\\\[sSdDwWb][^'\"]*\2" || true)"
     if [ -n "$hits" ]; then
       while IFS= read -r hit; do
         violations+=("${rel}: ${hit}")
@@ -3983,7 +3986,8 @@ EOF
 
     # Also detect grep -P or grep --perl-regexp (GNU-only)
     local phits
-    phits="$(grep -nE "grep[[:space:]]+(-[a-zA-Z]*P|--perl-regexp)" "$f" 2>/dev/null || true)"
+    phits="$(grep -nvE '^[[:space:]]*#' "$f" 2>/dev/null \
+        | grep -E "grep[[:space:]]+(-[a-zA-Z]*P|--perl-regexp)" || true)"
     if [ -n "$phits" ]; then
       while IFS= read -r hit; do
         violations+=("${rel}: ${hit}")
@@ -4450,7 +4454,9 @@ EOF
   local f
   for f in "${sh_files[@]}"; do
     local hits
-    hits="$(grep -nE "$case_mod_re" "$f" 2>/dev/null || true)"
+    # D-740 O-3: comment-strip pre-filter for parity with the guard oracle (which strips
+    # comment lines before matching) — a comment mentioning ${var^^} must not false-match.
+    hits="$(grep -nvE '^[[:space:]]*#' "$f" 2>/dev/null | grep -E "$case_mod_re" || true)"
     if [ -n "$hits" ]; then
       local rel="${f#${wave_handoff_skill_dir}/}"
       modifier_files+=("$f")
@@ -4877,7 +4883,10 @@ EOF
   for f in "${sh_files[@]}"; do
     local rel="${f#${wave_handoff_skill_dir}/}"
     local hits
-    hits="$(grep -nE "$ifs_step1_re" "$f" 2>/dev/null \
+    # D-740 O-3: comment-strip pre-filter for parity with the guard oracle (which strips
+    # comment lines before matching) — a comment mentioning 'cmd; IFS=...' must not false-match.
+    hits="$(grep -nvE '^[[:space:]]*#' "$f" 2>/dev/null \
+      | grep -E "$ifs_step1_re" \
       | grep -vE "$ifs_step2_re" \
       | grep -vE "$ifs_step3_re" \
       || true)"
@@ -5245,8 +5254,10 @@ EOF
   for f in "${sh_files[@]}"; do
     local rel="${f#${wave_handoff_skill_dir}/}"
     local hits
-    hits="$(grep -nE "$python_re" \
-        "$f" 2>/dev/null || true)"
+    # D-740 O-3: comment-strip pre-filter for parity with the guard oracle (which strips
+    # comment lines before matching) — a comment mentioning 'cmd | python3 ...' must not false-match.
+    hits="$(grep -nvE '^[[:space:]]*#' "$f" 2>/dev/null \
+        | grep -E "$python_re" || true)"
     if [ -n "$hits" ]; then
       while IFS= read -r hit; do
         violations+=("${rel}: python/pip shell-out: ${hit}")
@@ -5549,8 +5560,10 @@ EOF
   for f in "${sh_files[@]}"; do
     local rel="${f#${wave_handoff_skill_dir}/}"
     local hits
-    hits="$(grep -nE "$jq_re" \
-        "$f" 2>/dev/null || true)"
+    # D-740 O-3: comment-strip pre-filter for parity with the guard oracle (which strips
+    # comment lines before matching) — a comment mentioning 'cmd | jq ...' must not false-match.
+    hits="$(grep -nvE '^[[:space:]]*#' "$f" 2>/dev/null \
+        | grep -E "$jq_re" || true)"
     if [ -n "$hits" ]; then
       while IFS= read -r hit; do
         violations+=("${rel}: jq shell-out: ${hit}")

--- a/plugins/vsdd-factory/tests/wave-handoff.bats
+++ b/plugins/vsdd-factory/tests/wave-handoff.bats
@@ -4067,6 +4067,8 @@ EOF
   pc_good_arr="${BATS_TEST_TMPDIR}/pc_ac001_good_arr.sh"
   pc_bad_guard="${BATS_TEST_TMPDIR}/pc_ac001_bad_guard.sh"
   pc_good_guard="${BATS_TEST_TMPDIR}/pc_ac001_good_guard.sh"
+  local array_re='(local|declare)[[:space:]]+-[a-zA-Z]*A[a-zA-Z]*([[:space:]]|$)'
+  local guard_re='([[].*BASH_VERSINFO|[(][(].*BASH_VERSINFO)'
   printf 'declare -A my_map\n' > "$pc_bad_arr"
   printf 'declare -Ax my_map\n' > "$pc_bad_Ax"
   printf 'declare -gA my_map\n' > "$pc_bad_gA"
@@ -4074,17 +4076,17 @@ EOF
   printf '# removed the BASH_VERSINFO guard\n' > "$pc_bad_guard"
   printf 'if [ "${BASH_VERSINFO[0]:-0}" -lt 4 ]; then\n  exit 1\nfi\n' > "$pc_good_guard"
   # Array-detector: BAD sample (declare -A) MUST match.
-  grep -qE '(local|declare)[[:space:]]+-[a-zA-Z]*A[a-zA-Z]*([[:space:]]|$)' "$pc_bad_arr" || {
+  grep -qE "$array_re" "$pc_bad_arr" || {
     echo "FAIL (AC-001 positive-control): array-detector did not match 'declare -A my_map'." >&2
     false
   }
   # Array-detector: BAD sample (declare -Ax, combined flag) MUST match.
-  grep -qE '(local|declare)[[:space:]]+-[a-zA-Z]*A[a-zA-Z]*([[:space:]]|$)' "$pc_bad_Ax" || {
+  grep -qE "$array_re" "$pc_bad_Ax" || {
     echo "FAIL (AC-001 positive-control): array-detector did not match 'declare -Ax my_map' (combined-flag form)." >&2
     false
   }
   # Array-detector: BAD sample (declare -gA, flag prefix) MUST match.
-  grep -qE '(local|declare)[[:space:]]+-[a-zA-Z]*A[a-zA-Z]*([[:space:]]|$)' "$pc_bad_gA" || {
+  grep -qE "$array_re" "$pc_bad_gA" || {
     echo "FAIL (AC-001 positive-control): array-detector did not match 'declare -gA my_map' (flag-prefix form)." >&2
     false
   }
@@ -4094,7 +4096,7 @@ EOF
   local pc_bad_eol_A
   pc_bad_eol_A="${BATS_TEST_TMPDIR}/pc_ac001_bad_eol_A.sh"
   printf 'declare -A\n' > "$pc_bad_eol_A"
-  grep -qE '(local|declare)[[:space:]]+-[a-zA-Z]*A[a-zA-Z]*([[:space:]]|$)' "$pc_bad_eol_A" || {
+  grep -qE "$array_re" "$pc_bad_eol_A" || {
     echo "FAIL (AC-001 positive-control): array-detector did not match 'declare -A' at end-of-line (EOL -A form)." >&2
     echo "  The ([[:space:]]|$) suffix's \$ branch must fire when no var name follows the -A flag." >&2
     false
@@ -4103,22 +4105,22 @@ EOF
   local pc_bad_eol_local_A
   pc_bad_eol_local_A="${BATS_TEST_TMPDIR}/pc_ac001_bad_eol_local_A.sh"
   printf 'local -A\n' > "$pc_bad_eol_local_A"
-  grep -qE '(local|declare)[[:space:]]+-[a-zA-Z]*A[a-zA-Z]*([[:space:]]|$)' "$pc_bad_eol_local_A" || {
+  grep -qE "$array_re" "$pc_bad_eol_local_A" || {
     echo "FAIL (AC-001 positive-control): array-detector did not match 'local -A' at end-of-line (EOL -A form)." >&2
     false
   }
   # Array-detector: GOOD sample (declare -a, POSIX indexed array) MUST NOT match.
-  ! grep -qE '(local|declare)[[:space:]]+-[a-zA-Z]*A[a-zA-Z]*([[:space:]]|$)' "$pc_good_arr" || {
+  ! grep -qE "$array_re" "$pc_good_arr" || {
     echo "FAIL (AC-001 positive-control): array-detector falsely matched 'declare -a' (POSIX indexed array; bash-3-safe)." >&2
     false
   }
   # Guard-detector: executable conditional MUST match ([ precedes BASH_VERSINFO on the line).
-  grep -qE '([[].*BASH_VERSINFO|[(][(].*BASH_VERSINFO)' "$pc_good_guard" || {
+  grep -qE "$guard_re" "$pc_good_guard" || {
     echo "FAIL (AC-001 positive-control): guard-detector did not match 'if [ ... BASH_VERSINFO' form." >&2
     false
   }
   # Guard-detector: BASH_VERSINFO in a comment MUST NOT match (prevents paper-fix false-pass).
-  ! grep -qE '([[].*BASH_VERSINFO|[(][(].*BASH_VERSINFO)' "$pc_bad_guard" || {
+  ! grep -qE "$guard_re" "$pc_bad_guard" || {
     echo "FAIL (AC-001 positive-control): guard-detector falsely matched BASH_VERSINFO in a comment." >&2
     false
   }
@@ -4130,7 +4132,7 @@ EOF
   local has_arrays=0
   local f
   for f in "${sh_files[@]}"; do
-    if grep -qE '(local|declare)[[:space:]]+-[a-zA-Z]*A[a-zA-Z]*([[:space:]]|$)' "$f" 2>/dev/null; then
+    if grep -qE "$array_re" "$f" 2>/dev/null; then
       has_arrays=1
       break
     fi
@@ -4149,7 +4151,7 @@ EOF
   # A bare comment like "# removed the BASH_VERSINFO guard" does NOT satisfy the oracle.
   local has_guard=0
   for f in "${sh_files[@]}"; do
-    if grep -qE '([[].*BASH_VERSINFO|[(][(].*BASH_VERSINFO)' "$f" 2>/dev/null; then
+    if grep -qE "$guard_re" "$f" 2>/dev/null; then
       has_guard=1
       break
     fi
@@ -4196,7 +4198,7 @@ EOF
   _ep_guard_precedes_source() {
     local ep_file="$1"
     local guard_line first_src_line
-    guard_line="$(grep -nE '([[].*BASH_VERSINFO|[(][(].*BASH_VERSINFO)' "$ep_file" 2>/dev/null \
+    guard_line="$(grep -nE "$guard_re" "$ep_file" 2>/dev/null \
       | head -1 | cut -d: -f1)"
     first_src_line="$(grep -nE '^[[:space:]]*(source|\.)[[:space:]]+' "$ep_file" 2>/dev/null \
       | head -1 | cut -d: -f1)"
@@ -4307,6 +4309,8 @@ EOF
   pc_good_arr_expand="${BATS_TEST_TMPDIR}/pc_ac002_good_arr_expand.sh"
   pc_good_bash_source="${BATS_TEST_TMPDIR}/pc_ac002_good_bash_source.sh"
   pc_good_pct_expansion="${BATS_TEST_TMPDIR}/pc_ac002_good_pct_expansion.sh"
+  local case_mod_re='\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?|@[ULu])'
+  local guard_re='([[].*BASH_VERSINFO|[(][(].*BASH_VERSINFO)'
   printf 'echo "${VAR^^}"\n' > "$pc_bad_dbl"
   printf 'echo "${lower,}"\n' > "$pc_bad_single"
   printf 'echo "${arr[0]^^}"\necho "${map[k],,}"\necho "${arr[i]^}"\n' > "$pc_bad_arr_elem"
@@ -4319,23 +4323,23 @@ EOF
   printf 'dir=$(dirname "${BASH_SOURCE[0]}")\n' > "$pc_good_bash_source"
   printf 'echo "${var%%:*}"\n' > "$pc_good_pct_expansion"
   # Doubled modifier (${VAR^^}) MUST match.
-  grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?|@[ULu])' "$pc_bad_dbl" || {
+  grep -qE "$case_mod_re" "$pc_bad_dbl" || {
     echo "FAIL (AC-002 positive-control): case-modifier-detector did not match '\${VAR^^}'." >&2
     false
   }
   # Single-char modifier (${lower,}) MUST match — bash 4+ only, same as doubled form.
-  grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?|@[ULu])' "$pc_bad_single" || {
+  grep -qE "$case_mod_re" "$pc_bad_single" || {
     echo "FAIL (AC-002 positive-control): case-modifier-detector did not match '\${lower,}'." >&2
     false
   }
   # Array-element modifiers (${arr[0]^^}, ${map[k],,}, ${arr[i]^}) MUST match.
-  grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?|@[ULu])' "$pc_bad_arr_elem" || {
+  grep -qE "$case_mod_re" "$pc_bad_arr_elem" || {
     echo "FAIL (AC-002 positive-control): case-modifier-detector did not match array-element forms (\${arr[0]^^}, \${map[k],,}, \${arr[i]^})." >&2
     false
   }
   # Positional/special param modifiers (${1^^}, ${@^^}) MUST match (O-3 broadening).
   # These are bash 4+ only and cause syntax errors on bash 3.2.
-  grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?|@[ULu])' "$pc_bad_positional" || {
+  grep -qE "$case_mod_re" "$pc_bad_positional" || {
     echo "FAIL (AC-002 positive-control): case-modifier-detector did not match positional/special forms (\${1^^}, \${@^^})." >&2
     echo "  The var-name class must cover [0-9]+ (positional) and [@*#] (special) as alternatives." >&2
     false
@@ -4345,7 +4349,7 @@ EOF
   local pc_bad_hash_modifier
   pc_bad_hash_modifier="${BATS_TEST_TMPDIR}/pc_ac002_bad_hash_modifier.sh"
   printf 'echo "${#^^}"\n' > "$pc_bad_hash_modifier"
-  grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?|@[ULu])' "$pc_bad_hash_modifier" || {
+  grep -qE "$case_mod_re" "$pc_bad_hash_modifier" || {
     echo "FAIL (AC-002 positive-control / O-1): case-modifier-detector did not match '\${#^^}'." >&2
     echo "  bash-portability.md §2 states \${#^^} is covered by the [@*#] class." >&2
     echo "  The # special parameter with a case modifier is bash 4+ only." >&2
@@ -4354,16 +4358,16 @@ EOF
   # O-1 (F-P8): bash-4.4 @-operator case transforms MUST match.
   # ${var@U} (uppercase), ${var@L} (lowercase), ${var@u} (titlecase) cause "bad substitution"
   # on bash 3.2 — they are squarely in this story's bash-4+ feature detection scope.
-  grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?|@[ULu])' "$pc_bad_at_upper" || {
+  grep -qE "$case_mod_re" "$pc_bad_at_upper" || {
     echo "FAIL (AC-002 positive-control / O-1): case-modifier-detector did not match '\${v@U}' (bash-4.4 uppercase operator)." >&2
     echo "  Terminal alternation must include @[ULu] to cover bash-4.4 parameter-transformation operators." >&2
     false
   }
-  grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?|@[ULu])' "$pc_bad_at_lower" || {
+  grep -qE "$case_mod_re" "$pc_bad_at_lower" || {
     echo "FAIL (AC-002 positive-control / O-1): case-modifier-detector did not match '\${v@L}' (bash-4.4 lowercase operator)." >&2
     false
   }
-  grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?|@[ULu])' "$pc_bad_at_title" || {
+  grep -qE "$case_mod_re" "$pc_bad_at_title" || {
     echo "FAIL (AC-002 positive-control / O-1): case-modifier-detector did not match '\${v@u}' (bash-4.4 titlecase operator)." >&2
     false
   }
@@ -4373,29 +4377,29 @@ EOF
   local pc_bad_star_modifier
   pc_bad_star_modifier="${BATS_TEST_TMPDIR}/pc_ac002_bad_star_modifier.sh"
   printf 'echo "${*^^}"\n' > "$pc_bad_star_modifier"
-  grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?|@[ULu])' "$pc_bad_star_modifier" || {
+  grep -qE "$case_mod_re" "$pc_bad_star_modifier" || {
     echo "FAIL (AC-002 positive-control / O-3): case-modifier-detector did not match '\${*^^}' (star special param)." >&2
     echo "  The [@*#] class must cover * as an independent branch; \${*^^} is bash 4+ only." >&2
     false
   }
   # Over-match guards: ${arr[@]} (array expand-all), ${BASH_SOURCE[0]}, ${var%%:*} MUST NOT match.
   # ${arr[@]}: the [@] is an array subscript consumed by the (\[[^]]*\])? group; no modifier follows.
-  ! grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?|@[ULu])' "$pc_good_arr_expand" || {
+  ! grep -qE "$case_mod_re" "$pc_good_arr_expand" || {
     echo "FAIL (AC-002 negative-control / O-1): case-modifier-detector falsely matched '\${arr[@]}' (array expand-all)." >&2
     echo "  The [@] subscript must be consumed by the optional index group; no modifier follows." >&2
     false
   }
-  ! grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?|@[ULu])' "$pc_good_bash_source" || {
+  ! grep -qE "$case_mod_re" "$pc_good_bash_source" || {
     echo "FAIL (AC-002 negative-control / O-1): case-modifier-detector falsely matched '\${BASH_SOURCE[0]}'." >&2
     echo "  The [0] subscript must be consumed by the optional index group; no modifier follows." >&2
     false
   }
-  ! grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?|@[ULu])' "$pc_good_pct_expansion" || {
+  ! grep -qE "$case_mod_re" "$pc_good_pct_expansion" || {
     echo "FAIL (AC-002 negative-control / O-1): case-modifier-detector falsely matched '\${var%%:*}' (suffix-removal operator)." >&2
     false
   }
   # Plain expansion (\${VAR}) MUST NOT match.
-  ! grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?|@[ULu])' "$pc_good_plain" || {
+  ! grep -qE "$case_mod_re" "$pc_good_plain" || {
     echo "FAIL (AC-002 positive-control): case-modifier-detector falsely matched plain '\${VAR}'." >&2
     false
   }
@@ -4413,7 +4417,7 @@ EOF
   local f
   for f in "${sh_files[@]}"; do
     local hits
-    hits="$(grep -nE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?|@[ULu])' "$f" 2>/dev/null || true)"
+    hits="$(grep -nE "$case_mod_re" "$f" 2>/dev/null || true)"
     if [ -n "$hits" ]; then
       local rel="${f#${wave_handoff_skill_dir}/}"
       modifier_files+=("$f")
@@ -4434,7 +4438,7 @@ EOF
   # A bare comment mentioning BASH_VERSINFO is insufficient.
   local has_guard=0
   for f in "${sh_files[@]}"; do
-    if grep -qE '([[].*BASH_VERSINFO|[(][(].*BASH_VERSINFO)' "$f" 2>/dev/null; then
+    if grep -qE "$guard_re" "$f" 2>/dev/null; then
       has_guard=1
       break
     fi
@@ -4515,7 +4519,7 @@ EOF
   # F-P3-001 fix: step-3 exclusion tightened to not cross statement separators.
   # OLD (greedy — false-negative): 'IFS=[^[:space:]]*[[:space:]]+read([[:space:]]|$)'
   #   [^[:space:]]* crosses ; so 'IFS='|'; read x' was wrongly excluded.
-  # NEW (safe — stops at ;, &, |): 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)'
+  # NEW (safe — stops at ;, &, |): "$ifs_step3_re"
   #
   # Step-1 pattern (extended): (^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=
   #   ^                   — bare global assignment at start of line
@@ -4532,8 +4536,8 @@ EOF
   #                          requires at least one space after ); benign forms like foo() {
   #                          are not followed by IFS= and do not match
   #   export/readonly/declare -g prefixes — keyword-prefixed global mutations
-  # Step-2 (exclude): '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' — local scoped / subshell-open
-  # Step-3 (exclude): 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' — command-prefix for read
+  # Step-2 (exclude): "$ifs_step2_re" — local scoped / subshell-open
+  # Step-3 (exclude): "$ifs_step3_re" — command-prefix for read
   #   [^[:space:];&|]* — matches only non-separator chars; stops at ; & | before crossing them
   local pc_bad_ifs pc_bad_export_ifs pc_bad_semi_ifs pc_bad_semi_read pc_good_local_ifs pc_good_prefix_ifs
   local pc_bad_readonly_ifs pc_bad_declare_g_ifs pc_bad_and_ifs pc_bad_then_ifs pc_bad_bg_ifs
@@ -4581,11 +4585,14 @@ EOF
   printf "foo() { echo hello; }\n" > "$pc_good_func_def_brace"
   # GOOD: closing paren without IFS=: 'result=$(cmd); echo $result' — ) not followed by IFS=
   printf 'result=$(cmd); echo "$result"\n' > "$pc_good_close_paren_no_ifs"
+  local ifs_step1_re='(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS='
+  local ifs_step2_re='^[0-9]+:[[:space:]]*(local[[:space:]]|[(])'
+  local ifs_step3_re='IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)'
   # BAD: bare global IFS= MUST pass through the three-step filter (produces a violation).
   local pc_bad_ifs_hits
-  pc_bad_ifs_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_ifs" 2>/dev/null \
-    | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
-    | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+  pc_bad_ifs_hits="$(grep -nE "$ifs_step1_re" "$pc_bad_ifs" 2>/dev/null \
+    | grep -vE "$ifs_step2_re" \
+    | grep -vE "$ifs_step3_re" \
     || true)"
   [ -n "$pc_bad_ifs_hits" ] || {
     echo "FAIL (AC-003 positive-control): IFS-detector did not flag bare global 'IFS=|' assignment." >&2
@@ -4593,9 +4600,9 @@ EOF
   }
   # BAD: 'export IFS=' MUST be flagged (keyword-prefixed global mutation).
   local pc_bad_export_hits
-  pc_bad_export_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_export_ifs" 2>/dev/null \
-    | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
-    | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+  pc_bad_export_hits="$(grep -nE "$ifs_step1_re" "$pc_bad_export_ifs" 2>/dev/null \
+    | grep -vE "$ifs_step2_re" \
+    | grep -vE "$ifs_step3_re" \
     || true)"
   [ -n "$pc_bad_export_hits" ] || {
     echo "FAIL (AC-003 positive-control): IFS-detector did not flag 'export IFS=|' (keyword-prefixed global mutation)." >&2
@@ -4603,9 +4610,9 @@ EOF
   }
   # BAD: 'cmd; IFS=' MUST be flagged (second-statement global mutation).
   local pc_bad_semi_hits
-  pc_bad_semi_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_semi_ifs" 2>/dev/null \
-    | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
-    | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+  pc_bad_semi_hits="$(grep -nE "$ifs_step1_re" "$pc_bad_semi_ifs" 2>/dev/null \
+    | grep -vE "$ifs_step2_re" \
+    | grep -vE "$ifs_step3_re" \
     || true)"
   [ -n "$pc_bad_semi_hits" ] || {
     echo "FAIL (AC-003 positive-control): IFS-detector did not flag 'cmd; IFS=|' (second-statement global mutation)." >&2
@@ -4616,9 +4623,9 @@ EOF
   # class to not cross statement separators).  The old [^[:space:]]* would cross the ';' and
   # wrongly exclude this as if it were 'IFS=... read'.
   local pc_bad_semi_read_hits
-  pc_bad_semi_read_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_semi_read" 2>/dev/null \
-    | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
-    | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+  pc_bad_semi_read_hits="$(grep -nE "$ifs_step1_re" "$pc_bad_semi_read" 2>/dev/null \
+    | grep -vE "$ifs_step2_re" \
+    | grep -vE "$ifs_step3_re" \
     || true)"
   [ -n "$pc_bad_semi_read_hits" ] || {
     echo "FAIL (AC-003 positive-control / F-P3-001): IFS-detector did NOT flag 'IFS=\\'|\\'; read x'." >&2
@@ -4628,9 +4635,9 @@ EOF
   }
   # GOOD: 'local IFS=' MUST be excluded by the filter (no violation).
   local pc_good_local_hits
-  pc_good_local_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_good_local_ifs" 2>/dev/null \
-    | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
-    | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+  pc_good_local_hits="$(grep -nE "$ifs_step1_re" "$pc_good_local_ifs" 2>/dev/null \
+    | grep -vE "$ifs_step2_re" \
+    | grep -vE "$ifs_step3_re" \
     || true)"
   [ -z "$pc_good_local_hits" ] || {
     echo "FAIL (AC-003 positive-control): IFS-detector falsely flagged 'local IFS=' (must be exempt)." >&2
@@ -4639,9 +4646,9 @@ EOF
   # GOOD: 'IFS=... read' command-prefix MUST be excluded by the filter (no violation).
   # This is the legitimate command-prefix form (e.g., IFS=',' read -ra arr).
   local pc_good_prefix_hits
-  pc_good_prefix_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_good_prefix_ifs" 2>/dev/null \
-    | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
-    | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+  pc_good_prefix_hits="$(grep -nE "$ifs_step1_re" "$pc_good_prefix_ifs" 2>/dev/null \
+    | grep -vE "$ifs_step2_re" \
+    | grep -vE "$ifs_step3_re" \
     || true)"
   [ -z "$pc_good_prefix_hits" ] || {
     echo "FAIL (AC-003 positive-control): IFS-detector falsely flagged 'IFS=... read' prefix (must be exempt)." >&2
@@ -4650,9 +4657,9 @@ EOF
   # BAD (O-P4-002): 'readonly IFS=' MUST be flagged (keyword-prefixed global mutation).
   # This exercises the readonly[[:space:]]+ arm of the optional-keyword group in step-1.
   local pc_bad_readonly_hits
-  pc_bad_readonly_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_readonly_ifs" 2>/dev/null \
-    | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
-    | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+  pc_bad_readonly_hits="$(grep -nE "$ifs_step1_re" "$pc_bad_readonly_ifs" 2>/dev/null \
+    | grep -vE "$ifs_step2_re" \
+    | grep -vE "$ifs_step3_re" \
     || true)"
   [ -n "$pc_bad_readonly_hits" ] || {
     echo "FAIL (AC-003 positive-control / O-P4-002): IFS-detector did not flag 'readonly IFS=' (keyword-prefixed global mutation)." >&2
@@ -4662,9 +4669,9 @@ EOF
   # BAD (O-P4-002): 'declare -g IFS=' MUST be flagged (declare -g global mutation).
   # This exercises the declare[[:space:]]+-g[[:space:]]+ arm in step-1.
   local pc_bad_declare_g_hits
-  pc_bad_declare_g_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_declare_g_ifs" 2>/dev/null \
-    | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
-    | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+  pc_bad_declare_g_hits="$(grep -nE "$ifs_step1_re" "$pc_bad_declare_g_ifs" 2>/dev/null \
+    | grep -vE "$ifs_step2_re" \
+    | grep -vE "$ifs_step3_re" \
     || true)"
   [ -n "$pc_bad_declare_g_hits" ] || {
     echo "FAIL (AC-003 positive-control / O-P4-002): IFS-detector did not flag 'declare -g IFS=' (declare -g global mutation)." >&2
@@ -4674,9 +4681,9 @@ EOF
   # BAD (O-P4-003): 'cmd && IFS=' MUST be flagged (operator-prefixed global mutation).
   # This exercises the new && arm added to step-1 to catch operator-chained mutations.
   local pc_bad_and_hits
-  pc_bad_and_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_and_ifs" 2>/dev/null \
-    | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
-    | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+  pc_bad_and_hits="$(grep -nE "$ifs_step1_re" "$pc_bad_and_ifs" 2>/dev/null \
+    | grep -vE "$ifs_step2_re" \
+    | grep -vE "$ifs_step3_re" \
     || true)"
   [ -n "$pc_bad_and_hits" ] || {
     echo "FAIL (AC-003 positive-control / O-P4-003): IFS-detector did not flag 'cmd && IFS=|' (operator-prefixed global mutation)." >&2
@@ -4686,9 +4693,9 @@ EOF
   # BAD (O-P4-003): 'then IFS=' MUST be flagged (keyword-prefixed global mutation).
   # This exercises the (then|do|else|elif)[[:space:]] arm added to step-1.
   local pc_bad_then_hits
-  pc_bad_then_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_then_ifs" 2>/dev/null \
-    | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
-    | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+  pc_bad_then_hits="$(grep -nE "$ifs_step1_re" "$pc_bad_then_ifs" 2>/dev/null \
+    | grep -vE "$ifs_step2_re" \
+    | grep -vE "$ifs_step3_re" \
     || true)"
   [ -n "$pc_bad_then_hits" ] || {
     echo "FAIL (AC-003 positive-control / O-P4-003): IFS-detector did not flag 'then IFS=|' (keyword-prefixed global mutation)." >&2
@@ -4698,9 +4705,9 @@ EOF
   # BAD (F-P13-001): 'cmd || IFS=' MUST be flagged (operator-prefixed global mutation via ||).
   # The [|][|] arm catches the OR-operator form which was previously UNcovered by a positive control.
   local pc_bad_or_hits
-  pc_bad_or_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_or_ifs" 2>/dev/null \
-    | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
-    | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+  pc_bad_or_hits="$(grep -nE "$ifs_step1_re" "$pc_bad_or_ifs" 2>/dev/null \
+    | grep -vE "$ifs_step2_re" \
+    | grep -vE "$ifs_step3_re" \
     || true)"
   [ -n "$pc_bad_or_hits" ] || {
     echo "FAIL (AC-003 positive-control / F-P13-001): IFS-detector did not flag 'cmd || IFS=|' (OR-operator global mutation)." >&2
@@ -4710,9 +4717,9 @@ EOF
   # BAD (F-P13-001): 'do IFS=' MUST be flagged (keyword-prefixed global mutation).
   # This exercises the 'do' arm of (then|do|else|elif)[[:space:]] — previously UNcovered.
   local pc_bad_do_hits
-  pc_bad_do_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_do_ifs" 2>/dev/null \
-    | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
-    | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+  pc_bad_do_hits="$(grep -nE "$ifs_step1_re" "$pc_bad_do_ifs" 2>/dev/null \
+    | grep -vE "$ifs_step2_re" \
+    | grep -vE "$ifs_step3_re" \
     || true)"
   [ -n "$pc_bad_do_hits" ] || {
     echo "FAIL (AC-003 positive-control / F-P13-001): IFS-detector did not flag 'do IFS=|' (keyword-prefixed global mutation)." >&2
@@ -4722,9 +4729,9 @@ EOF
   # BAD (F-P13-001): 'else IFS=' MUST be flagged (keyword-prefixed global mutation).
   # This exercises the 'else' arm — previously UNcovered.
   local pc_bad_else_hits
-  pc_bad_else_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_else_ifs" 2>/dev/null \
-    | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
-    | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+  pc_bad_else_hits="$(grep -nE "$ifs_step1_re" "$pc_bad_else_ifs" 2>/dev/null \
+    | grep -vE "$ifs_step2_re" \
+    | grep -vE "$ifs_step3_re" \
     || true)"
   [ -n "$pc_bad_else_hits" ] || {
     echo "FAIL (AC-003 positive-control / F-P13-001): IFS-detector did not flag 'else IFS=|' (keyword-prefixed global mutation)." >&2
@@ -4734,9 +4741,9 @@ EOF
   # BAD (F-P13-001): 'elif IFS=' MUST be flagged (keyword-prefixed global mutation).
   # This exercises the 'elif' arm — previously UNcovered.
   local pc_bad_elif_hits
-  pc_bad_elif_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_elif_ifs" 2>/dev/null \
-    | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
-    | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+  pc_bad_elif_hits="$(grep -nE "$ifs_step1_re" "$pc_bad_elif_ifs" 2>/dev/null \
+    | grep -vE "$ifs_step2_re" \
+    | grep -vE "$ifs_step3_re" \
     || true)"
   [ -n "$pc_bad_elif_hits" ] || {
     echo "FAIL (AC-003 positive-control / F-P13-001): IFS-detector did not flag 'elif IFS=|' (keyword-prefixed global mutation)." >&2
@@ -4749,9 +4756,9 @@ EOF
   # step-1 so that '&&' is consumed as a unit first; plain 'cmd &' without a following
   # IFS= cannot satisfy the remainder of the regex and is NOT a false positive.
   local pc_bad_bg_hits
-  pc_bad_bg_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_bg_ifs" 2>/dev/null \
-    | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
-    | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+  pc_bad_bg_hits="$(grep -nE "$ifs_step1_re" "$pc_bad_bg_ifs" 2>/dev/null \
+    | grep -vE "$ifs_step2_re" \
+    | grep -vE "$ifs_step3_re" \
     || true)"
   [ -n "$pc_bad_bg_hits" ] || {
     echo "FAIL (AC-003 positive-control / O-2): IFS-detector did not flag 'cmd & IFS=|' (background+global mutation)." >&2
@@ -4764,9 +4771,9 @@ EOF
   # persists globally.  bash syntax requires at least one space after '{', which distinguishes
   # it from '${IFS...}' parameter expansion (no space after '{').
   local pc_bad_brace_hits
-  pc_bad_brace_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_brace_ifs" 2>/dev/null \
-    | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
-    | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+  pc_bad_brace_hits="$(grep -nE "$ifs_step1_re" "$pc_bad_brace_ifs" 2>/dev/null \
+    | grep -vE "$ifs_step2_re" \
+    | grep -vE "$ifs_step3_re" \
     || true)"
   [ -n "$pc_bad_brace_hits" ] || {
     echo "FAIL (AC-003 positive-control / O-1): IFS-detector did not flag '{ IFS=\$'\\n'; read x; }' (brace-group current-shell mutation)." >&2
@@ -4778,9 +4785,9 @@ EOF
   # The [)][[:space:]]+ arm requires at least one space after ')' to distinguish from
   # function-definition patterns like 'foo() {' where ')' is not followed by IFS=.
   local pc_bad_case_hits
-  pc_bad_case_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_case_ifs" 2>/dev/null \
-    | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
-    | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+  pc_bad_case_hits="$(grep -nE "$ifs_step1_re" "$pc_bad_case_ifs" 2>/dev/null \
+    | grep -vE "$ifs_step2_re" \
+    | grep -vE "$ifs_step3_re" \
     || true)"
   [ -n "$pc_bad_case_hits" ] || {
     echo "FAIL (AC-003 positive-control / O-1): IFS-detector did not flag 'case \$x in foo) IFS=|' (case-pattern body mutation)." >&2
@@ -4791,9 +4798,9 @@ EOF
   # The '{' in a function definition is followed by a space and then a NON-IFS= command,
   # so the \{[[:space:]]+ arm does not produce a false positive.
   local pc_good_func_def_hits
-  pc_good_func_def_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_good_func_def_brace" 2>/dev/null \
-    | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
-    | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+  pc_good_func_def_hits="$(grep -nE "$ifs_step1_re" "$pc_good_func_def_brace" 2>/dev/null \
+    | grep -vE "$ifs_step2_re" \
+    | grep -vE "$ifs_step3_re" \
     || true)"
   [ -z "$pc_good_func_def_hits" ] || {
     echo "FAIL (AC-003 negative-control / O-1): IFS-detector falsely flagged 'foo() { echo hello; }' (function definition brace must be exempt)." >&2
@@ -4804,9 +4811,9 @@ EOF
   # The closing ')' of a command substitution is not followed by IFS= on this line,
   # so the [)][[:space:]]+ arm does not produce a false positive.
   local pc_good_close_paren_hits
-  pc_good_close_paren_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_good_close_paren_no_ifs" 2>/dev/null \
-    | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
-    | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+  pc_good_close_paren_hits="$(grep -nE "$ifs_step1_re" "$pc_good_close_paren_no_ifs" 2>/dev/null \
+    | grep -vE "$ifs_step2_re" \
+    | grep -vE "$ifs_step3_re" \
     || true)"
   [ -z "$pc_good_close_paren_hits" ] || {
     echo "FAIL (AC-003 negative-control / O-1): IFS-detector falsely flagged 'result=\$(cmd); echo \$result' (close-paren not preceding IFS= must be exempt)." >&2
@@ -4836,9 +4843,9 @@ EOF
   for f in "${sh_files[@]}"; do
     local rel="${f#${wave_handoff_skill_dir}/}"
     local hits
-    hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$f" 2>/dev/null \
-      | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
-      | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+    hits="$(grep -nE "$ifs_step1_re" "$f" 2>/dev/null \
+      | grep -vE "$ifs_step2_re" \
+      | grep -vE "$ifs_step3_re" \
       || true)"
     if [ -n "$hits" ]; then
       while IFS= read -r hit; do
@@ -4917,7 +4924,7 @@ EOF
   local pc_bad_py3_if pc_bad_py3_then pc_bad_py3_do pc_bad_py3_else pc_bad_py3_elif
   local pc_bad_py3_time pc_bad_py3_env pc_bad_py3_command pc_bad_py3_xargs
   local pc_bad_py3_xargs_opts pc_bad_py3_brace pc_bad_py3_case_paren pc_bad_py3_subshell
-  local pc_bad_pip3_and pc_good_other_cmdsubst_py
+  local pc_bad_pip3_and pc_good_other_cmdsubst_py pc_bad_py_with_preflight
 
   pc_bad_py3="${BATS_TEST_TMPDIR}/pc_ac004_bad_py3.sh"
   pc_bad_py2="${BATS_TEST_TMPDIR}/pc_ac004_bad_py2.sh"
@@ -4948,6 +4955,7 @@ EOF
   pc_bad_py3_subshell="${BATS_TEST_TMPDIR}/pc_ac004_bad_py3_subshell.sh"
   pc_bad_pip3_and="${BATS_TEST_TMPDIR}/pc_ac004_bad_pip3_and.sh"
   pc_good_other_cmdsubst_py="${BATS_TEST_TMPDIR}/pc_ac004_good_other_cmdsubst.sh"
+  pc_bad_py_with_preflight="${BATS_TEST_TMPDIR}/pc_ac004_bad_py_with_preflight.sh"
 
   printf 'python3 script.py\n' > "$pc_bad_py3"
   printf 'python2 -c "import os; os.system(\"id\")"\n' > "$pc_bad_py2"
@@ -4986,6 +4994,8 @@ EOF
   printf '( python3 script.py )\n' > "$pc_bad_py3_subshell"
   printf 'cmd && pip3 install requests\n' > "$pc_bad_pip3_and"
   printf 'result=$(other_cmd script.py)\n' > "$pc_good_other_cmdsubst_py"
+  # Option A symmetric: python3 WITH 'command -v python3' preflight is STILL a violation (F-P13-002).
+  printf 'command -v python3 >/dev/null 2>&1 || { echo "python3 required" >&2; exit 1; }\npython3 script.py\n' > "$pc_bad_py_with_preflight"
 
   # BAD: bare line-start 'python3 script.py' MUST be detected.
   grep -qE "$python_re" "$pc_bad_py3" || {
@@ -5159,6 +5169,15 @@ EOF
     echo "  The \\\$( arm must require python[0-9.]*/pip[0-9x]* as the immediate next token after '\$(', not any command." >&2
     false
   }
+  # BAD (F-P13-002 / Option A symmetric python preflight): python3 WITH 'command -v python3'
+  # preflight MUST STILL be detected. AC-004 ≡ AC-005 (both Option A): a preflight guard does NOT
+  # make the shell-out acceptable — the fix is REMOVAL of the python invocation, not guarding.
+  grep -qE "$python_re" "$pc_bad_py_with_preflight" || {
+    echo "FAIL (AC-004 positive-control / F-P13-002 Option A): python-detector did not match python3 invocation" >&2
+    echo "  in a file that has a 'command -v python3' preflight guard." >&2
+    echo "  Option A: python3 is forbidden per SKILL.md §149 even with a preflight guard." >&2
+    false
+  }
   # -------------------------------------------
 
   # Scan: detect any python/pip invocation in a command position.
@@ -5169,7 +5188,7 @@ EOF
   for f in "${sh_files[@]}"; do
     local rel="${f#${wave_handoff_skill_dir}/}"
     local hits
-    hits="$(grep -nE '(^[[:space:]]*(python[0-9.]*|pip[0-9x]*)([[:space:]]|$)|[|;&][[:space:]]*(python[0-9.]*|pip[0-9x]*)([[:space:]]|$)|\$[(](python[0-9.]*|pip[0-9x]*)([[:space:]]|$)|`(python[0-9.]*|pip[0-9x]*)([[:space:]]|$)|(xargs|if|then|do|else|elif|time|env|command|sudo)[[:space:]]+(python[0-9.]*|pip[0-9x]*)([[:space:]]|$)|xargs([[:space:]]+-[^[:space:]]+)+[[:space:]]+(python[0-9.]*|pip[0-9x]*)([[:space:]]|$)|\{[[:space:]]*(python[0-9.]*|pip[0-9x]*)([[:space:]]|$)|\)[[:space:]]*(python[0-9.]*|pip[0-9x]*)([[:space:]]|$)|\([[:space:]]*(python[0-9.]*|pip[0-9x]*)([[:space:]]|$))' \
+    hits="$(grep -nE "$python_re" \
         "$f" 2>/dev/null || true)"
     if [ -n "$hits" ]; then
       while IFS= read -r hit; do
@@ -5473,7 +5492,7 @@ EOF
   for f in "${sh_files[@]}"; do
     local rel="${f#${wave_handoff_skill_dir}/}"
     local hits
-    hits="$(grep -nE '(^[[:space:]]*jq([[:space:]]|$)|[|;&][[:space:]]*jq([[:space:]]|$)|\$[(]jq([[:space:]]|$)|`jq([[:space:]]|$)|(xargs|if|then|do|else|elif|time|env|command|sudo)[[:space:]]+jq([[:space:]]|$)|xargs([[:space:]]+-[^[:space:]]+)+[[:space:]]+jq([[:space:]]|$)|\{[[:space:]]*jq([[:space:]]|$)|\)[[:space:]]*jq([[:space:]]|$)|\([[:space:]]*jq([[:space:]]|$))' \
+    hits="$(grep -nE "$jq_re" \
         "$f" 2>/dev/null || true)"
     if [ -n "$hits" ]; then
       while IFS= read -r hit; do

--- a/plugins/vsdd-factory/tests/wave-handoff.bats
+++ b/plugins/vsdd-factory/tests/wave-handoff.bats
@@ -4286,40 +4286,56 @@ EOF
 
   # --- POSITIVE-CONTROL ASSERTIONS (O-1) ---
   # Verify the case-modifier detector matches all bash-4+ forms — including array-element
-  # forms (${arr[0]^^}, ${map[k],,}, ${arr[i]^}) and positional/special parameter forms
-  # (${1^^}, ${@^^}, ${*^^}) — and does not falsely match a plain variable expansion.
+  # forms (${arr[0]^^}, ${map[k],,}, ${arr[i]^}), positional/special parameter forms
+  # (${1^^}, ${@^^}, ${*^^}), and bash-4.4 @-operator case transforms (${var@U}, ${var@L},
+  # ${var@u}) — and does NOT falsely match ${arr[@]}, ${BASH_SOURCE[0]}, or plain expansion.
   # Uses BATS_TEST_TMPDIR synthetic files.
   # Broadened (O-3 / POLICY 13 prospective): optional [...] index between var name and
   # modifier; positional/special parameter names ([0-9]+, @, *, #) in var-name class.
+  # Broadened (O-1 / F-P8): terminal alternation now includes @[ULu] case-transform operators.
   local pc_bad_dbl pc_bad_single pc_bad_arr_elem pc_bad_positional pc_good_plain
+  local pc_bad_at_upper pc_bad_at_lower pc_bad_at_title
+  local pc_good_arr_expand pc_good_bash_source pc_good_pct_expansion
   pc_bad_dbl="${BATS_TEST_TMPDIR}/pc_ac002_bad_dbl.sh"
   pc_bad_single="${BATS_TEST_TMPDIR}/pc_ac002_bad_single.sh"
   pc_bad_arr_elem="${BATS_TEST_TMPDIR}/pc_ac002_bad_arr_elem.sh"
   pc_bad_positional="${BATS_TEST_TMPDIR}/pc_ac002_bad_positional.sh"
   pc_good_plain="${BATS_TEST_TMPDIR}/pc_ac002_good_plain.sh"
+  pc_bad_at_upper="${BATS_TEST_TMPDIR}/pc_ac002_bad_at_upper.sh"
+  pc_bad_at_lower="${BATS_TEST_TMPDIR}/pc_ac002_bad_at_lower.sh"
+  pc_bad_at_title="${BATS_TEST_TMPDIR}/pc_ac002_bad_at_title.sh"
+  pc_good_arr_expand="${BATS_TEST_TMPDIR}/pc_ac002_good_arr_expand.sh"
+  pc_good_bash_source="${BATS_TEST_TMPDIR}/pc_ac002_good_bash_source.sh"
+  pc_good_pct_expansion="${BATS_TEST_TMPDIR}/pc_ac002_good_pct_expansion.sh"
   printf 'echo "${VAR^^}"\n' > "$pc_bad_dbl"
   printf 'echo "${lower,}"\n' > "$pc_bad_single"
   printf 'echo "${arr[0]^^}"\necho "${map[k],,}"\necho "${arr[i]^}"\n' > "$pc_bad_arr_elem"
   printf 'echo "${1^^}"\necho "${@^^}"\n' > "$pc_bad_positional"
   printf 'echo "${VAR}"\n' > "$pc_good_plain"
+  printf 'echo "${v@U}"\n' > "$pc_bad_at_upper"
+  printf 'echo "${v@L}"\n' > "$pc_bad_at_lower"
+  printf 'echo "${v@u}"\n' > "$pc_bad_at_title"
+  printf 'for x in "${arr[@]}"; do echo "$x"; done\n' > "$pc_good_arr_expand"
+  printf 'dir=$(dirname "${BASH_SOURCE[0]}")\n' > "$pc_good_bash_source"
+  printf 'echo "${var%%:*}"\n' > "$pc_good_pct_expansion"
   # Doubled modifier (${VAR^^}) MUST match.
-  grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?)' "$pc_bad_dbl" || {
+  grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?|@[ULu])' "$pc_bad_dbl" || {
     echo "FAIL (AC-002 positive-control): case-modifier-detector did not match '\${VAR^^}'." >&2
     false
   }
   # Single-char modifier (${lower,}) MUST match — bash 4+ only, same as doubled form.
-  grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?)' "$pc_bad_single" || {
+  grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?|@[ULu])' "$pc_bad_single" || {
     echo "FAIL (AC-002 positive-control): case-modifier-detector did not match '\${lower,}'." >&2
     false
   }
   # Array-element modifiers (${arr[0]^^}, ${map[k],,}, ${arr[i]^}) MUST match.
-  grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?)' "$pc_bad_arr_elem" || {
+  grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?|@[ULu])' "$pc_bad_arr_elem" || {
     echo "FAIL (AC-002 positive-control): case-modifier-detector did not match array-element forms (\${arr[0]^^}, \${map[k],,}, \${arr[i]^})." >&2
     false
   }
   # Positional/special param modifiers (${1^^}, ${@^^}) MUST match (O-3 broadening).
   # These are bash 4+ only and cause syntax errors on bash 3.2.
-  grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?)' "$pc_bad_positional" || {
+  grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?|@[ULu])' "$pc_bad_positional" || {
     echo "FAIL (AC-002 positive-control): case-modifier-detector did not match positional/special forms (\${1^^}, \${@^^})." >&2
     echo "  The var-name class must cover [0-9]+ (positional) and [@*#] (special) as alternatives." >&2
     false
@@ -4329,14 +4345,46 @@ EOF
   local pc_bad_hash_modifier
   pc_bad_hash_modifier="${BATS_TEST_TMPDIR}/pc_ac002_bad_hash_modifier.sh"
   printf 'echo "${#^^}"\n' > "$pc_bad_hash_modifier"
-  grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?)' "$pc_bad_hash_modifier" || {
+  grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?|@[ULu])' "$pc_bad_hash_modifier" || {
     echo "FAIL (AC-002 positive-control / O-1): case-modifier-detector did not match '\${#^^}'." >&2
     echo "  bash-portability.md §2 states \${#^^} is covered by the [@*#] class." >&2
     echo "  The # special parameter with a case modifier is bash 4+ only." >&2
     false
   }
+  # O-1 (F-P8): bash-4.4 @-operator case transforms MUST match.
+  # ${var@U} (uppercase), ${var@L} (lowercase), ${var@u} (titlecase) cause "bad substitution"
+  # on bash 3.2 — they are squarely in this story's bash-4+ feature detection scope.
+  grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?|@[ULu])' "$pc_bad_at_upper" || {
+    echo "FAIL (AC-002 positive-control / O-1): case-modifier-detector did not match '\${v@U}' (bash-4.4 uppercase operator)." >&2
+    echo "  Terminal alternation must include @[ULu] to cover bash-4.4 parameter-transformation operators." >&2
+    false
+  }
+  grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?|@[ULu])' "$pc_bad_at_lower" || {
+    echo "FAIL (AC-002 positive-control / O-1): case-modifier-detector did not match '\${v@L}' (bash-4.4 lowercase operator)." >&2
+    false
+  }
+  grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?|@[ULu])' "$pc_bad_at_title" || {
+    echo "FAIL (AC-002 positive-control / O-1): case-modifier-detector did not match '\${v@u}' (bash-4.4 titlecase operator)." >&2
+    false
+  }
+  # Over-match guards: ${arr[@]} (array expand-all), ${BASH_SOURCE[0]}, ${var%%:*} MUST NOT match.
+  # ${arr[@]}: the [@] is an array subscript consumed by the (\[[^]]*\])? group; no modifier follows.
+  ! grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?|@[ULu])' "$pc_good_arr_expand" || {
+    echo "FAIL (AC-002 negative-control / O-1): case-modifier-detector falsely matched '\${arr[@]}' (array expand-all)." >&2
+    echo "  The [@] subscript must be consumed by the optional index group; no modifier follows." >&2
+    false
+  }
+  ! grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?|@[ULu])' "$pc_good_bash_source" || {
+    echo "FAIL (AC-002 negative-control / O-1): case-modifier-detector falsely matched '\${BASH_SOURCE[0]}'." >&2
+    echo "  The [0] subscript must be consumed by the optional index group; no modifier follows." >&2
+    false
+  }
+  ! grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?|@[ULu])' "$pc_good_pct_expansion" || {
+    echo "FAIL (AC-002 negative-control / O-1): case-modifier-detector falsely matched '\${var%%:*}' (suffix-removal operator)." >&2
+    false
+  }
   # Plain expansion (\${VAR}) MUST NOT match.
-  ! grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?)' "$pc_good_plain" || {
+  ! grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?|@[ULu])' "$pc_good_plain" || {
     echo "FAIL (AC-002 positive-control): case-modifier-detector falsely matched plain '\${VAR}'." >&2
     false
   }
@@ -4347,13 +4395,14 @@ EOF
   # Doubled form:     ${var^^} (all-upper),       ${var,,} (all-lower).
   # Array-element forms: ${arr[0]^^}, ${map[k],,}, ${arr[i]^} — optional [...] index allowed.
   # Positional/special forms: ${1^^}, ${@^^}, ${*^^}, ${#^^} — [0-9]+, @, *, # in var-name.
+  # bash-4.4 @-operator case transforms: ${var@U}, ${var@L}, ${var@u} — O-1 extension.
   # Pattern: ${ + (var name | positional | special) + optional [index] + case modifier
   local modifier_files=()
   local violations=()
   local f
   for f in "${sh_files[@]}"; do
     local hits
-    hits="$(grep -nE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?)' "$f" 2>/dev/null || true)"
+    hits="$(grep -nE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?|@[ULu])' "$f" 2>/dev/null || true)"
     if [ -n "$hits" ]; then
       local rel="${f#${wave_handoff_skill_dir}/}"
       modifier_files+=("$f")
@@ -4381,7 +4430,7 @@ EOF
   done
 
   [ "$has_guard" -eq 1 ] || {
-    echo "FAIL (AC-002): bash 4+ case modifiers (\${var^}, \${var^^}, \${var,}, \${var,,}) found in" >&2
+    echo "FAIL (AC-002): bash 4+ case modifiers (\${var^}, \${var^^}, \${var,}, \${var,,}, \${var@U}, \${var@L}, \${var@u}) found in" >&2
     echo "  wave-handoff scripts without an executable bash version guard (BASH_VERSINFO in if/[/(()" >&2
     echo "  found in the scan set." >&2
     echo "  Fix: either remove case modifiers (use 'tr a-z A-Z' or awk for case conversion)" >&2
@@ -4851,10 +4900,23 @@ EOF
   pc_good_py311_preflight="${BATS_TEST_TMPDIR}/pc_ac004_good_py311_preflight.sh"
   printf 'python3.11 -c "import yaml" 2>/dev/null || { echo "pyyaml required" >&2; exit 1; }\n' > "$pc_good_py311_preflight"
   printf 'python3.11 -c "import yaml; print(yaml.safe_load(open(f)))"\n' >> "$pc_good_py311_preflight"
-  # Phase-2 acceptance regex (broadened): python[0-9.]* -c "import yaml" OR command -v python[0-9.]*
-  grep -qE '(python[0-9.]*[[:space:]]+-c[[:space:]]+"import yaml"|command[[:space:]]+-v[[:space:]]+python[0-9.]*)' "$pc_good_py311_preflight" || {
+  # Phase-2 acceptance regex (broadened, O-2): python[0-9.]* -c ["']import yaml["'] OR command -v python[0-9.]*
+  # Accepts both double-quoted and single-quoted forms of the preflight guard.
+  grep -qE "(python[0-9.]*[[:space:]]+-c[[:space:]]+[\"']import yaml[\"']|command[[:space:]]+-v[[:space:]]+python[0-9.]*)" "$pc_good_py311_preflight" || {
     echo "FAIL (AC-004 positive-control / O-P4-001): broadened phase-2 acceptance regex did NOT match 'python3.11 -c \"import yaml\"' preflight." >&2
     echo "  The phase-2 acceptance arm must use python[0-9.]* (not python3) to accept versioned binaries." >&2
+    false
+  }
+  # GOOD (O-2): a script with single-quoted preflight 'python3 -c '\''import yaml'\''' MUST be ACCEPTED.
+  # The phase-2 regex previously hardcoded double-quotes; single-quoted guards are equally valid.
+  local pc_good_singlequote_preflight
+  pc_good_singlequote_preflight="${BATS_TEST_TMPDIR}/pc_ac004_good_singlequote_preflight.sh"
+  printf "python3 -c 'import yaml' 2>/dev/null || { echo 'pyyaml required' >&2; exit 1; }\n" > "$pc_good_singlequote_preflight"
+  printf "python3 -c 'import yaml; print(yaml.safe_load(open(f)))'\n" >> "$pc_good_singlequote_preflight"
+  grep -qE "(python[0-9.]*[[:space:]]+-c[[:space:]]+[\"']import yaml[\"']|command[[:space:]]+-v[[:space:]]+python[0-9.]*)" "$pc_good_singlequote_preflight" || {
+    echo "FAIL (AC-004 positive-control / O-2): phase-2 acceptance regex did NOT match single-quoted preflight 'python3 -c '\"'\"'import yaml'\"'\"''." >&2
+    echo "  O-2: the phase-2 acceptance arm must accept both single and double quotes around 'import yaml'." >&2
+    echo "  Use [\"']import yaml[\"'] (or equivalent) to match both quote forms." >&2
     false
   }
   # -------------------------------------------
@@ -4881,9 +4943,11 @@ EOF
 
   # Phase 2: for each file with a pyyaml/python-yaml invocation, audit for acceptability.
   # Unacceptable form: --break-system-packages (PEP 668 workaround; not a long-term fix).
-  # Acceptable alternatives: python[0-9.]* -c "import yaml" preflight OR awk-based YAML parsing.
+  # Acceptable alternatives: python[0-9.]* -c ["']import yaml["'] preflight OR awk-based YAML parsing.
   # O-P4-001: broadened from python3 to python[0-9.]* so versioned preflights like
   # 'python3.11 -c "import yaml"' and 'command -v python3.11' are recognized as valid guards.
+  # O-2: broadened from double-quote-only to ["']import yaml["'] so single-quoted preflights
+  # like python3 -c 'import yaml' are also recognized (previously caused false FAIL).
   local violations=()
   for f in "${dep_files[@]}"; do
     local rel="${f#${wave_handoff_skill_dir}/}"
@@ -4899,8 +4963,9 @@ EOF
     fi
 
     # Check for proper preflight guard before pyyaml invocation.
-    # Accepts versioned binaries: python3.11 -c "import yaml", command -v python3.11, etc.
-    if ! grep -qE '(python[0-9.]*[[:space:]]+-c[[:space:]]+"import yaml"|command[[:space:]]+-v[[:space:]]+python[0-9.]*)' \
+    # Accepts versioned binaries: python3.11 -c "import yaml", python3 -c 'import yaml', command -v python3.11, etc.
+    # O-2: ["']import yaml["'] accepts both single and double quotes around the import guard.
+    if ! grep -qE "(python[0-9.]*[[:space:]]+-c[[:space:]]+[\"']import yaml[\"']|command[[:space:]]+-v[[:space:]]+python[0-9.]*)" \
         "$f" 2>/dev/null; then
       local hits
       hits="$(grep -nE '(python[0-9.]*[[:space:]].*[Yy][Aa][Mm][Ll]|pip[0-9x]*[[:space:]].*[Pp][Yy][Yy][Aa][Mm][Ll]|import[[:space:]]+yaml)' \
@@ -4943,6 +5008,14 @@ EOF
 #   - Added a separate xargs-with-options arm:
 #     xargs([[:space:]]+-[^[:space:]]+)+[[:space:]]+jq — catches 'xargs -n1 jq', etc.
 #
+# F-P8-001 broadening (LOCAL adversarial pass-8):
+#   Missing execution positions added — jq runs in all three:
+#   - Brace group (current-shell): \{[[:space:]]*jq — '{ jq . f; }'
+#   - Case pattern-action body: \)[[:space:]]*jq — 'case $x in json) jq ...'
+#   - Subshell open: \([[:space:]]*jq — '( jq . f )'
+#   NOTE: unlike IFS (where subshell is EXEMPT because IFS doesn't leak), for jq a
+#   subshell is a HAZARD — jq still executes. So jq covers (, {, AND ).
+#
 # Red Gate expectation: PASS (no jq invocations found; absent = compliant).
 # ---------------------------------------------------------------------------
 
@@ -4964,10 +5037,14 @@ EOF
 
   # --- POSITIVE-CONTROL ASSERTIONS (O-1) ---
   # Verify the jq-detector matches command-substitution, &&/|| chains, xargs (direct and
-  # with options), keyword-prefixed forms (including else/elif — F-P2-002), and common
-  # command wrappers (time, env, command, sudo — O-3), and does NOT match jq in a comment.
+  # with options), keyword-prefixed forms (including else/elif — F-P2-002), common
+  # command wrappers (time, env, command, sudo — O-3), brace-group/case-body/subshell
+  # execution positions (F-P8-001), and does NOT match jq in a comment, $(other_cmd),
+  # foo() { echo; }, or ${jq_var} parameter expansion.
   # Uses BATS_TEST_TMPDIR synthetic files; no real wave-handoff scripts are executed.
   local pc_bad_cmdsubst pc_bad_and pc_bad_xargs pc_bad_else pc_bad_time pc_bad_xargs_opts pc_good_comment
+  local pc_bad_brace pc_bad_case_paren pc_bad_subshell
+  local pc_good_other_cmdsubst pc_good_func_brace pc_good_jq_var
   pc_bad_cmdsubst="${BATS_TEST_TMPDIR}/pc_ac005_bad_cmdsubst.sh"
   pc_bad_and="${BATS_TEST_TMPDIR}/pc_ac005_bad_and.sh"
   pc_bad_xargs="${BATS_TEST_TMPDIR}/pc_ac005_bad_xargs.sh"
@@ -4975,6 +5052,12 @@ EOF
   pc_bad_time="${BATS_TEST_TMPDIR}/pc_ac005_bad_time.sh"
   pc_bad_xargs_opts="${BATS_TEST_TMPDIR}/pc_ac005_bad_xargs_opts.sh"
   pc_good_comment="${BATS_TEST_TMPDIR}/pc_ac005_good_comment.sh"
+  pc_bad_brace="${BATS_TEST_TMPDIR}/pc_ac005_bad_brace.sh"
+  pc_bad_case_paren="${BATS_TEST_TMPDIR}/pc_ac005_bad_case_paren.sh"
+  pc_bad_subshell="${BATS_TEST_TMPDIR}/pc_ac005_bad_subshell.sh"
+  pc_good_other_cmdsubst="${BATS_TEST_TMPDIR}/pc_ac005_good_other_cmdsubst.sh"
+  pc_good_func_brace="${BATS_TEST_TMPDIR}/pc_ac005_good_func_brace.sh"
+  pc_good_jq_var="${BATS_TEST_TMPDIR}/pc_ac005_good_jq_var.sh"
   printf 'result=$(jq -r .name input.json)\n' > "$pc_bad_cmdsubst"
   printf 'cmd && jq ".key" file.json\n' > "$pc_bad_and"
   printf 'find . -name "*.json" | xargs jq ".id"\n' > "$pc_bad_xargs"
@@ -4982,10 +5065,16 @@ EOF
   printf "time jq '.' input.json\n" > "$pc_bad_time"
   printf 'find . -name "*.json" | xargs -n1 jq ".id"\n' > "$pc_bad_xargs_opts"
   printf '# no jq dependency; using awk instead\n' > "$pc_good_comment"
-  # O-3 broadened jq_re: adds time|env|command|sudo to the keyword wrapper group; adds a
-  # separate arm for xargs with intervening options (e.g. xargs -n1 jq).
+  printf '{ jq . f; }\n' > "$pc_bad_brace"
+  printf 'case $x in json) jq -r .x f ;; esac\n' > "$pc_bad_case_paren"
+  printf '( jq . f )\n' > "$pc_bad_subshell"
+  printf 'result=$(other_cmd . f)\n' > "$pc_good_other_cmdsubst"
+  printf 'foo() { echo "hello"; }\n' > "$pc_good_func_brace"
+  printf 'echo "${jq_var}"\n' > "$pc_good_jq_var"
+  # F-P8-001 + O-3 broadened jq_re: adds time|env|command|sudo to the keyword wrapper group;
+  # adds xargs-with-options arm; adds brace-group, case-pattern-body, and subshell arms.
   # Positive-control regex MUST BE BYTE-IDENTICAL to the real-scan-loop regex below.
-  local jq_re='(^[[:space:]]*jq([[:space:]]|$)|[|;&][[:space:]]*jq([[:space:]]|$)|\$[(]jq([[:space:]]|$)|`jq([[:space:]]|$)|(xargs|if|then|do|else|elif|time|env|command|sudo)[[:space:]]+jq([[:space:]]|$)|xargs([[:space:]]+-[^[:space:]]+)+[[:space:]]+jq([[:space:]]|$))'
+  local jq_re='(^[[:space:]]*jq([[:space:]]|$)|[|;&][[:space:]]*jq([[:space:]]|$)|\$[(]jq([[:space:]]|$)|`jq([[:space:]]|$)|(xargs|if|then|do|else|elif|time|env|command|sudo)[[:space:]]+jq([[:space:]]|$)|xargs([[:space:]]+-[^[:space:]]+)+[[:space:]]+jq([[:space:]]|$)|\{[[:space:]]*jq([[:space:]]|$)|\)[[:space:]]*jq([[:space:]]|$)|\([[:space:]]*jq([[:space:]]|$))'
   # BAD: command-substitution $(jq ...) MUST be detected.
   grep -qE "$jq_re" "$pc_bad_cmdsubst" || {
     echo "FAIL (AC-005 positive-control): jq-detector did not match '\$(jq ...)' command-substitution form." >&2
@@ -5018,9 +5107,52 @@ EOF
     echo "  The xargs-with-options arm 'xargs([[:space:]]+-[^[:space:]]+)+[[:space:]]+jq' is required." >&2
     false
   }
+  # BAD (F-P8-001): '{ jq . f; }' brace-group MUST be detected.
+  # Brace groups run in the current shell — jq executes and is a genuine dependency hazard.
+  grep -qE "$jq_re" "$pc_bad_brace" || {
+    echo "FAIL (AC-005 positive-control / F-P8-001): jq-detector did not match '{ jq . f; }' brace-group form." >&2
+    echo "  Brace groups run in the current shell; add arm: \\{[[:space:]]*jq([[:space:]]|\$)" >&2
+    false
+  }
+  # BAD (F-P8-001): 'case $x in json) jq ...' case-pattern-body MUST be detected.
+  # The ) closes the case pattern label; jq is the first command in the case action body.
+  grep -qE "$jq_re" "$pc_bad_case_paren" || {
+    echo "FAIL (AC-005 positive-control / F-P8-001): jq-detector did not match 'case ... ) jq' case-body form." >&2
+    echo "  Case pattern-action bodies run in the current shell; add arm: \\)[[:space:]]*jq([[:space:]]|\$)" >&2
+    false
+  }
+  # BAD (F-P8-001): '( jq . f )' subshell MUST be detected.
+  # Unlike IFS (where subshell is EXEMPT because IFS doesn't leak), jq in a subshell
+  # still EXECUTES — it is a runtime dependency regardless of the subshell boundary.
+  grep -qE "$jq_re" "$pc_bad_subshell" || {
+    echo "FAIL (AC-005 positive-control / F-P8-001): jq-detector did not match '( jq . f )' subshell form." >&2
+    echo "  jq in a subshell still executes (unlike IFS which doesn't leak); add arm: \\([[:space:]]*jq([[:space:]]|\$)" >&2
+    false
+  }
   # GOOD: jq in a comment MUST NOT be detected.
   ! grep -qE "$jq_re" "$pc_good_comment" || {
     echo "FAIL (AC-005 positive-control): jq-detector falsely matched jq inside a comment." >&2
+    false
+  }
+  # GOOD (F-P8-001 negative control): '\$(other_cmd)' MUST NOT be detected.
+  # The \$( arm only fires when 'jq' immediately follows '$(', not other command names.
+  ! grep -qE "$jq_re" "$pc_good_other_cmdsubst" || {
+    echo "FAIL (AC-005 negative-control / F-P8-001): jq-detector falsely matched '\$(other_cmd)'." >&2
+    echo "  The \\\$( arm must require 'jq' as the immediate next token after '\$(', not any command." >&2
+    false
+  }
+  # GOOD (F-P8-001 negative control): 'foo() { echo; }' function definition MUST NOT be detected.
+  # The { arm requires jq as the first token after '{[[:space:]]*'; a function def has 'echo', not 'jq'.
+  ! grep -qE "$jq_re" "$pc_good_func_brace" || {
+    echo "FAIL (AC-005 negative-control / F-P8-001): jq-detector falsely matched 'foo() { echo; }' function definition." >&2
+    echo "  The { arm must only fire when jq is the first command token after '{', not any other command." >&2
+    false
+  }
+  # GOOD (F-P8-001 negative control): '\${jq_var}' parameter expansion MUST NOT be detected.
+  # '\${jq_var}' contains '{' then 'jq_var}'; but jq_var is followed by '}', not space/EOL.
+  ! grep -qE "$jq_re" "$pc_good_jq_var" || {
+    echo "FAIL (AC-005 negative-control / F-P8-001): jq-detector falsely matched '\${jq_var}' parameter expansion." >&2
+    echo "  The { arm requires jq followed by ([[:space:]]|\$); '\${jq_var}' has '_var}' after 'jq', not space/EOL." >&2
     false
   }
   # -------------------------------------------
@@ -5034,13 +5166,18 @@ EOF
   #   (xargs|if|then|do|else|elif|time|env|command|sudo)[[:space:]]+jq(...)
   #                                                        — keyword/wrapper-prefixed invocations
   #   xargs([[:space:]]+-[^[:space:]]+)+[[:space:]]+jq(...)— xargs with intervening options
+  #   \{[[:space:]]*jq([[:space:]]|$)                     — brace-group current-shell execution
+  #   \)[[:space:]]*jq([[:space:]]|$)                     — case-pattern-action body (after ')' label close)
+  #   \([[:space:]]*jq([[:space:]]|$)                     — subshell open (jq still executes)
   #   F-P2-002: else and elif added (genuine command positions for jq invocation).
   #   O-3: time, env, command, sudo added as common command wrappers.
   #        xargs-with-options arm handles 'xargs -n1 jq', 'xargs -n1 -P4 jq', etc.
+  #   F-P8-001: brace-group, case-body, subshell arms added. NOTE: for jq, subshell IS a
+  #             hazard (unlike IFS where subshell is exempt) — jq runs in the subshell.
   local jq_files=()
   local f
   for f in "${sh_files[@]}"; do
-    if grep -qE '(^[[:space:]]*jq([[:space:]]|$)|[|;&][[:space:]]*jq([[:space:]]|$)|\$[(]jq([[:space:]]|$)|`jq([[:space:]]|$)|(xargs|if|then|do|else|elif|time|env|command|sudo)[[:space:]]+jq([[:space:]]|$)|xargs([[:space:]]+-[^[:space:]]+)+[[:space:]]+jq([[:space:]]|$))' \
+    if grep -qE '(^[[:space:]]*jq([[:space:]]|$)|[|;&][[:space:]]*jq([[:space:]]|$)|\$[(]jq([[:space:]]|$)|`jq([[:space:]]|$)|(xargs|if|then|do|else|elif|time|env|command|sudo)[[:space:]]+jq([[:space:]]|$)|xargs([[:space:]]+-[^[:space:]]+)+[[:space:]]+jq([[:space:]]|$)|\{[[:space:]]*jq([[:space:]]|$)|\)[[:space:]]*jq([[:space:]]|$)|\([[:space:]]*jq([[:space:]]|$))' \
         "$f" 2>/dev/null; then
       jq_files+=("$f")
     fi
@@ -5061,7 +5198,7 @@ EOF
     local rel="${f#${wave_handoff_skill_dir}/}"
     if ! grep -qE 'command[[:space:]]+-v[[:space:]]+jq|which[[:space:]]+jq' "$f" 2>/dev/null; then
       local hits
-      hits="$(grep -nE '(^[[:space:]]*jq([[:space:]]|$)|[|;&][[:space:]]*jq([[:space:]]|$)|\$[(]jq([[:space:]]|$)|`jq([[:space:]]|$)|(xargs|if|then|do|else|elif|time|env|command|sudo)[[:space:]]+jq([[:space:]]|$)|xargs([[:space:]]+-[^[:space:]]+)+[[:space:]]+jq([[:space:]]|$))' \
+      hits="$(grep -nE '(^[[:space:]]*jq([[:space:]]|$)|[|;&][[:space:]]*jq([[:space:]]|$)|\$[(]jq([[:space:]]|$)|`jq([[:space:]]|$)|(xargs|if|then|do|else|elif|time|env|command|sudo)[[:space:]]+jq([[:space:]]|$)|xargs([[:space:]]+-[^[:space:]]+)+[[:space:]]+jq([[:space:]]|$)|\{[[:space:]]*jq([[:space:]]|$)|\)[[:space:]]*jq([[:space:]]|$)|\([[:space:]]*jq([[:space:]]|$))' \
               "$f" 2>/dev/null || true)"
       while IFS= read -r hit; do
         violations+=("${rel}: jq invocation without preflight: ${hit}")

--- a/plugins/vsdd-factory/tests/wave-handoff.bats
+++ b/plugins/vsdd-factory/tests/wave-handoff.bats
@@ -5040,16 +5040,18 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# test_portability_no_undeclared_jq_dep
-# AC-005: undeclared jq runtime dependency.
-# jq is not installed by default on all macOS and Linux CI images. Any wave-handoff
-# script that invokes jq as a command MUST have a preflight check confirming jq is
-# available before first use:
-#   command -v jq >/dev/null 2>&1 || { echo "ERROR: jq is required" >&2; exit 1; }
+# test_portability_no_jq_shellout
+# AC-005: forbidden jq shellout (Option A — forbidden-removal, single-phase).
+# SKILL.md §149: "This skill MUST NOT shell out to Python, jq, or any language
+# runtime beyond bash." jq is treated identically to python — ANY jq invocation
+# is a violation regardless of preflight guard placement. The fix is to REMOVE
+# the jq invocation, not add a 'command -v jq' preflight. jq is also a
+# non-guaranteed third-party binary on CI/macOS runners — even a guarded jq
+# callsite violates SKILL.md §149.
 #
-# Detection: lines where 'jq' appears as a standalone command token (preceded by
-# start-of-line, pipe, semicolon, or whitespace, and followed by whitespace or
-# end-of-line). Uses POSIX ERE; no \b word-boundary shorthand.
+# Detection: command-position anchoring (single-phase). Any file with a matching
+# jq invocation fails unconditionally. No Phase 2 preflight-acceptance check.
+# Uses POSIX ERE; no \b word-boundary shorthand.
 #
 # O-3 broadening (POLICY 13 prospective):
 #   - Added time|env|command|sudo to the keyword-wrapper group.
@@ -5065,9 +5067,10 @@ EOF
 #   subshell is a HAZARD — jq still executes. So jq covers (, {, AND ).
 #
 # Red Gate expectation: PASS (no jq invocations found; absent = compliant).
+# Single-phase: any detected jq invocation is unconditionally a violation.
 # ---------------------------------------------------------------------------
 
-@test "test_portability_no_undeclared_jq_dep" {
+@test "test_portability_no_jq_shellout" {
   local wave_handoff_skill_dir
   wave_handoff_skill_dir="$(cd "${BATS_TEST_DIRNAME}/../skills/wave-handoff" && pwd)"
 
@@ -5095,6 +5098,7 @@ EOF
   local pc_good_other_cmdsubst pc_good_func_brace pc_good_jq_var
   local pc_bad_jq_line_start pc_bad_jq_backtick pc_bad_jq_if pc_bad_jq_then pc_bad_jq_do
   local pc_bad_jq_elif pc_bad_jq_env pc_bad_jq_command pc_bad_jq_sudo
+  local pc_bad_jq_with_preflight
   pc_bad_cmdsubst="${BATS_TEST_TMPDIR}/pc_ac005_bad_cmdsubst.sh"
   pc_bad_and="${BATS_TEST_TMPDIR}/pc_ac005_bad_and.sh"
   pc_bad_xargs="${BATS_TEST_TMPDIR}/pc_ac005_bad_xargs.sh"
@@ -5117,6 +5121,7 @@ EOF
   pc_bad_jq_env="${BATS_TEST_TMPDIR}/pc_ac005_bad_jq_env.sh"
   pc_bad_jq_command="${BATS_TEST_TMPDIR}/pc_ac005_bad_jq_command.sh"
   pc_bad_jq_sudo="${BATS_TEST_TMPDIR}/pc_ac005_bad_jq_sudo.sh"
+  pc_bad_jq_with_preflight="${BATS_TEST_TMPDIR}/pc_ac005_bad_jq_with_preflight.sh"
   printf 'result=$(jq -r .name input.json)\n' > "$pc_bad_cmdsubst"
   printf 'cmd && jq ".key" file.json\n' > "$pc_bad_and"
   printf 'find . -name "*.json" | xargs jq ".id"\n' > "$pc_bad_xargs"
@@ -5140,6 +5145,8 @@ EOF
   printf "env jq '.key' file.json\n" > "$pc_bad_jq_env"
   printf "command jq '.key' file.json\n" > "$pc_bad_jq_command"
   printf "sudo jq '.key' file.json\n" > "$pc_bad_jq_sudo"
+  # Option A flip: jq WITH 'command -v jq' preflight is STILL a violation.
+  printf 'command -v jq >/dev/null 2>&1 || { echo "ERROR: jq is required" >&2; exit 1; }\njq -r .name input.json\n' > "$pc_bad_jq_with_preflight"
   # F-P8-001 + O-3 broadened jq_re: adds time|env|command|sudo to the keyword wrapper group;
   # adds xargs-with-options arm; adds brace-group, case-pattern-body, and subshell arms.
   # Positive-control regex MUST BE BYTE-IDENTICAL to the real-scan-loop regex below.
@@ -5280,9 +5287,19 @@ EOF
     echo "  'sudo' must be in the keyword wrapper group (added at O-3)." >&2
     false
   }
+  # BAD (Option A flip): jq WITH 'command -v jq' preflight MUST STILL be detected.
+  # Under Option A, jq is forbidden per SKILL.md §149 regardless of preflight guard placement.
+  # The phase-1 jq_re matches the jq invocation line even when a preflight guard is present.
+  grep -qE "$jq_re" "$pc_bad_jq_with_preflight" || {
+    echo "FAIL (AC-005 positive-control / Option A): jq-detector did not match jq invocation in file with 'command -v jq' preflight." >&2
+    echo "  Option A: jq is forbidden even with a preflight guard — any jq invocation is a violation." >&2
+    false
+  }
   # -------------------------------------------
 
-  # Phase 1: detect jq invocations (jq as a command word, not as part of a variable name).
+  # Scan: detect any jq invocation in a command position.
+  # Any match is a violation — SKILL.md §149 forbids all jq shell-outs; no preflight exemption.
+  # Option A: single-phase detection; phase-2 preflight-acceptance removed.
   # Patterns that indicate jq is used as a command (POSIX ERE, no PCRE shorthand):
   #   ^[[:space:]]*jq([[:space:]]|$)                      — start of line
   #   [|;&][[:space:]]*jq([[:space:]]|$)                   — after |, ;, &  (covers |, ||, &&)
@@ -5299,48 +5316,31 @@ EOF
   #        xargs-with-options arm handles 'xargs -n1 jq', 'xargs -n1 -P4 jq', etc.
   #   F-P8-001: brace-group, case-body, subshell arms added. NOTE: for jq, subshell IS a
   #             hazard (unlike IFS where subshell is exempt) — jq runs in the subshell.
-  local jq_files=()
+  local violations=()
   local f
   for f in "${sh_files[@]}"; do
-    if grep -qE '(^[[:space:]]*jq([[:space:]]|$)|[|;&][[:space:]]*jq([[:space:]]|$)|\$[(]jq([[:space:]]|$)|`jq([[:space:]]|$)|(xargs|if|then|do|else|elif|time|env|command|sudo)[[:space:]]+jq([[:space:]]|$)|xargs([[:space:]]+-[^[:space:]]+)+[[:space:]]+jq([[:space:]]|$)|\{[[:space:]]*jq([[:space:]]|$)|\)[[:space:]]*jq([[:space:]]|$)|\([[:space:]]*jq([[:space:]]|$))' \
-        "$f" 2>/dev/null; then
-      jq_files+=("$f")
-    fi
-  done
-
-  # No jq invocations — compliant.
-  if [ "${#jq_files[@]}" -eq 0 ]; then
-    echo "AC-005: scanned=${#sh_files[@]} files"
-    return 0
-  fi
-
-  # Phase 2: for each file with jq invocations, verify a preflight guard exists.
-  # Acceptable preflight forms:
-  #   command -v jq    — POSIX-portable availability check
-  #   which jq         — non-POSIX but common fallback
-  local violations=()
-  for f in "${jq_files[@]}"; do
     local rel="${f#${wave_handoff_skill_dir}/}"
-    if ! grep -qE 'command[[:space:]]+-v[[:space:]]+jq|which[[:space:]]+jq' "$f" 2>/dev/null; then
-      local hits
-      hits="$(grep -nE '(^[[:space:]]*jq([[:space:]]|$)|[|;&][[:space:]]*jq([[:space:]]|$)|\$[(]jq([[:space:]]|$)|`jq([[:space:]]|$)|(xargs|if|then|do|else|elif|time|env|command|sudo)[[:space:]]+jq([[:space:]]|$)|xargs([[:space:]]+-[^[:space:]]+)+[[:space:]]+jq([[:space:]]|$)|\{[[:space:]]*jq([[:space:]]|$)|\)[[:space:]]*jq([[:space:]]|$)|\([[:space:]]*jq([[:space:]]|$))' \
-              "$f" 2>/dev/null || true)"
+    local hits
+    hits="$(grep -nE '(^[[:space:]]*jq([[:space:]]|$)|[|;&][[:space:]]*jq([[:space:]]|$)|\$[(]jq([[:space:]]|$)|`jq([[:space:]]|$)|(xargs|if|then|do|else|elif|time|env|command|sudo)[[:space:]]+jq([[:space:]]|$)|xargs([[:space:]]+-[^[:space:]]+)+[[:space:]]+jq([[:space:]]|$)|\{[[:space:]]*jq([[:space:]]|$)|\)[[:space:]]*jq([[:space:]]|$)|\([[:space:]]*jq([[:space:]]|$))' \
+        "$f" 2>/dev/null || true)"
+    if [ -n "$hits" ]; then
       while IFS= read -r hit; do
-        violations+=("${rel}: jq invocation without preflight: ${hit}")
+        violations+=("${rel}: jq shell-out: ${hit}")
       done <<< "$hits"
     fi
   done
 
   if [ "${#violations[@]}" -gt 0 ]; then
-    echo "FAIL (AC-005): bare jq invocation without preflight guard found in wave-handoff scripts." >&2
-    echo "  Fix: add preflight before first jq use:" >&2
-    echo "    command -v jq >/dev/null 2>&1 || { echo 'ERROR: jq is required; install with brew install jq' >&2; exit 1; }" >&2
+    echo "FAIL (AC-005): forbidden jq shellout found in wave-handoff scripts." >&2
+    echo "  SKILL.md §149: 'This skill MUST NOT shell out to Python, jq, or any language runtime beyond bash.'" >&2
+    echo "  Fix: remove jq invocations entirely — replace with awk/grep/bash builtins." >&2
+    echo "  A 'command -v jq' preflight guard does NOT make jq usage compliant." >&2
     echo "  Violations:" >&2
     local v
     for v in "${violations[@]}"; do echo "  ${v}" >&2; done
     false
   fi
-  echo "AC-005: scanned=${#sh_files[@]} files"
+  echo "AC-005: scanned=${#sh_files[@]} files, jq_violations=0"
 }
 
 # ---------------------------------------------------------------------------

--- a/plugins/vsdd-factory/tests/wave-handoff.bats
+++ b/plugins/vsdd-factory/tests/wave-handoff.bats
@@ -4959,6 +4959,7 @@ EOF
   local pc_bad_py3_time pc_bad_py3_env pc_bad_py3_command pc_bad_py3_xargs
   local pc_bad_py3_xargs_opts pc_bad_py3_brace pc_bad_py3_case_paren pc_bad_py3_subshell
   local pc_bad_pip3_and pc_good_other_cmdsubst_py pc_bad_py_with_preflight
+  local pc_good_py_func_brace pc_good_py_var_expansion
 
   pc_bad_py3="${BATS_TEST_TMPDIR}/pc_ac004_bad_py3.sh"
   pc_bad_py2="${BATS_TEST_TMPDIR}/pc_ac004_bad_py2.sh"
@@ -4990,6 +4991,8 @@ EOF
   pc_bad_pip3_and="${BATS_TEST_TMPDIR}/pc_ac004_bad_pip3_and.sh"
   pc_good_other_cmdsubst_py="${BATS_TEST_TMPDIR}/pc_ac004_good_other_cmdsubst.sh"
   pc_bad_py_with_preflight="${BATS_TEST_TMPDIR}/pc_ac004_bad_py_with_preflight.sh"
+  pc_good_py_func_brace="${BATS_TEST_TMPDIR}/pc_ac004_good_py_func_brace.sh"
+  pc_good_py_var_expansion="${BATS_TEST_TMPDIR}/pc_ac004_good_py_var_expansion.sh"
 
   printf 'python3 script.py\n' > "$pc_bad_py3"
   printf 'python2 -c "import os; os.system(\"id\")"\n' > "$pc_bad_py2"
@@ -5030,6 +5033,12 @@ EOF
   printf 'result=$(other_cmd script.py)\n' > "$pc_good_other_cmdsubst_py"
   # Option A symmetric: python3 WITH 'command -v python3' preflight is STILL a violation (F-P13-002).
   printf 'command -v python3 >/dev/null 2>&1 || { echo "python3 required" >&2; exit 1; }\npython3 script.py\n' > "$pc_bad_py_with_preflight"
+  # GOOD (D-741 O-3 symmetry with jq's pc_good_func_brace): function-brace-arm form —
+  # NOT a python invocation ('echo' is the first token after '{', not python/pip).
+  printf 'foo() { echo; }\n' > "$pc_good_py_func_brace"
+  # GOOD (D-741 O-3 symmetry with jq's pc_good_jq_var): '${python3_x}' parameter expansion —
+  # NOT a command invocation; python3 is followed by '_x}', not space/EOL.
+  printf 'echo "${python3_x}"\n' > "$pc_good_py_var_expansion"
 
   # BAD: bare line-start 'python3 script.py' MUST be detected.
   grep -qE "$python_re" "$pc_bad_py3" || {
@@ -5091,6 +5100,20 @@ EOF
   ! grep -qE "$python_re" "$pc_good_echo_py" || {
     echo "FAIL (AC-004 negative-control): python-detector falsely matched 'echo \"install python3 first\"'." >&2
     echo "  python3 as an argument to echo is not a python shell-out." >&2
+    false
+  }
+  # GOOD (D-741 O-3 symmetry with jq's pc_good_func_brace): 'foo() { echo; }' function definition MUST NOT be detected.
+  # The { arm requires python[0-9.]*/pip[0-9x]* as the first token after '{[[:space:]]*'; here it's 'echo'.
+  ! grep -qE "$python_re" "$pc_good_py_func_brace" || {
+    echo "FAIL (AC-004 negative-control / D-741 O-3): python-detector falsely matched 'foo() { echo; }' function definition." >&2
+    echo "  The { arm must only fire when python/pip is the first command token after '{', not any other command." >&2
+    false
+  }
+  # GOOD (D-741 O-3 symmetry with jq's pc_good_jq_var): '${python3_x}' parameter expansion MUST NOT be detected.
+  # '${python3_x}' contains '{' then 'python3_x}'; python3 is followed by '_x}', not space/EOL — a var-expansion, not invocation.
+  ! grep -qE "$python_re" "$pc_good_py_var_expansion" || {
+    echo "FAIL (AC-004 negative-control / D-741 O-3): python-detector falsely matched '\${python3_x}' parameter expansion." >&2
+    echo "  The { arm requires python[0-9.]* followed by ([[:space:]]|\$); '\${python3_x}' has '_x}' after 'python3', not space/EOL." >&2
     false
   }
   # F-P12-001 positive controls: per-arm coverage for arms 2, 4, 5-remaining, 6, 7, 8, 9.

--- a/plugins/vsdd-factory/tests/wave-handoff.bats
+++ b/plugins/vsdd-factory/tests/wave-handoff.bats
@@ -4005,6 +4005,897 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
+# S-18.12 PORTABILITY-LINT EXTENSION (AC-001 through AC-005)
+# Static portability guards extending the PCRE guard above.
+# Anchored to lesson L-S18-macos-ci-leg-caught-runtime-portability — the four
+# macOS CI failures in S-18.01 that PCRE-only lint missed:
+#   1. bash 3.2 incompatible local -A (ea7328ac)
+#   2. global IFS mutation (2b40dfd5)
+#   3. undeclared PyYAML runtime dep (aaa8da8a / 3fe11ea1)
+#   4. (no jq in S-18.01, but jq is also not declared — added prospectively)
+#
+# Architecture compliance (S-18.12 ACR):
+#   - Static analysis ONLY — grep the script sources; NEVER execute them.
+#   - Non-vacuity (EC-005): each test asserts >= 1 .sh file was scanned.
+#   - Scope: plugins/vsdd-factory/skills/wave-handoff/ production scripts ONLY.
+#   - POSIX ERE (grep -E); no PCRE shorthand classes (\s, \d, \w, \b, etc.).
+#   - Additive: these tests do NOT modify the PCRE guard above.
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# test_portability_no_unguarded_local_A_associative_array
+# AC-001: bash 3.2 compatibility — local -A / declare -A require bash 4+.
+# macOS ships bash 3.2 at /bin/bash; Homebrew bash 5 is not on PATH by default.
+#
+# Invariant: if any file in the wave-handoff skill uses local -A or declare -A,
+# a bash version guard (BASH_VERSINFO check) MUST exist somewhere in the scan
+# set. The S-18.01 fix (ea7328ac) added the guard to wave-handoff.sh — the main
+# entrypoint that sources all lib scripts, providing early-exit protection before
+# any lib function using bash 4+ syntax is ever called.
+#
+# Red Gate expectation: PASS (guard confirmed present post-S-18.01 merge).
+# ---------------------------------------------------------------------------
+
+@test "test_portability_no_unguarded_local_A_associative_array" {
+  local wave_handoff_skill_dir
+  wave_handoff_skill_dir="$(cd "${BATS_TEST_DIRNAME}/../skills/wave-handoff" && pwd)"
+
+  # Collect all .sh files under wave-handoff (main + lib/)
+  local sh_files=()
+  while IFS= read -r f; do
+    sh_files+=("$f")
+  done < <(find "$wave_handoff_skill_dir" -name "*.sh" -type f | sort)
+
+  # EC-005 non-vacuity: the scan must cover at least one .sh file.
+  # An empty scan set means the skill directory has drifted (scripts renamed or
+  # moved) and this guard is stale — that is also a FAIL, not a false-pass.
+  [ "${#sh_files[@]}" -gt 0 ] || {
+    echo "FAIL (AC-001 EC-005): no .sh files found under ${wave_handoff_skill_dir}." >&2
+    echo "  The portability-lint scope has drifted — update the guard to the new location." >&2
+    false
+  }
+
+  # --- POSITIVE-CONTROL ASSERTIONS (O-1) ---
+  # Verify the array-detector and guard-detector regexes discriminate correctly.
+  # Uses synthetic temp files in BATS_TEST_TMPDIR; no real wave-handoff scripts are executed.
+  # Broadened detector: covers -A, -Ax (combined flags), -gA (prefix flags), and -A at EOL.
+  # Distinguishes -A (associative, bash 4+) from -a (indexed, bash 3 safe).
+  local pc_bad_arr pc_bad_Ax pc_bad_gA pc_good_arr pc_bad_guard pc_good_guard
+  pc_bad_arr="${BATS_TEST_TMPDIR}/pc_ac001_bad_arr.sh"
+  pc_bad_Ax="${BATS_TEST_TMPDIR}/pc_ac001_bad_Ax.sh"
+  pc_bad_gA="${BATS_TEST_TMPDIR}/pc_ac001_bad_gA.sh"
+  pc_good_arr="${BATS_TEST_TMPDIR}/pc_ac001_good_arr.sh"
+  pc_bad_guard="${BATS_TEST_TMPDIR}/pc_ac001_bad_guard.sh"
+  pc_good_guard="${BATS_TEST_TMPDIR}/pc_ac001_good_guard.sh"
+  printf 'declare -A my_map\n' > "$pc_bad_arr"
+  printf 'declare -Ax my_map\n' > "$pc_bad_Ax"
+  printf 'declare -gA my_map\n' > "$pc_bad_gA"
+  printf 'declare -a my_arr\n' > "$pc_good_arr"
+  printf '# removed the BASH_VERSINFO guard\n' > "$pc_bad_guard"
+  printf 'if [ "${BASH_VERSINFO[0]:-0}" -lt 4 ]; then\n  exit 1\nfi\n' > "$pc_good_guard"
+  # Array-detector: BAD sample (declare -A) MUST match.
+  grep -qE '(local|declare)[[:space:]]+-[a-zA-Z]*A[a-zA-Z]*([[:space:]]|$)' "$pc_bad_arr" || {
+    echo "FAIL (AC-001 positive-control): array-detector did not match 'declare -A my_map'." >&2
+    false
+  }
+  # Array-detector: BAD sample (declare -Ax, combined flag) MUST match.
+  grep -qE '(local|declare)[[:space:]]+-[a-zA-Z]*A[a-zA-Z]*([[:space:]]|$)' "$pc_bad_Ax" || {
+    echo "FAIL (AC-001 positive-control): array-detector did not match 'declare -Ax my_map' (combined-flag form)." >&2
+    false
+  }
+  # Array-detector: BAD sample (declare -gA, flag prefix) MUST match.
+  grep -qE '(local|declare)[[:space:]]+-[a-zA-Z]*A[a-zA-Z]*([[:space:]]|$)' "$pc_bad_gA" || {
+    echo "FAIL (AC-001 positive-control): array-detector did not match 'declare -gA my_map' (flag-prefix form)." >&2
+    false
+  }
+  # Array-detector: BAD sample (declare -A at end-of-line, no var name — EOL -A form).
+  # The ([[:space:]]|$) suffix's $ branch fires when nothing follows the -A flag on the line.
+  # This exercises the continuation/split-line usage pattern (O-P4-002).
+  local pc_bad_eol_A
+  pc_bad_eol_A="${BATS_TEST_TMPDIR}/pc_ac001_bad_eol_A.sh"
+  printf 'declare -A\n' > "$pc_bad_eol_A"
+  grep -qE '(local|declare)[[:space:]]+-[a-zA-Z]*A[a-zA-Z]*([[:space:]]|$)' "$pc_bad_eol_A" || {
+    echo "FAIL (AC-001 positive-control): array-detector did not match 'declare -A' at end-of-line (EOL -A form)." >&2
+    echo "  The ([[:space:]]|$) suffix's \$ branch must fire when no var name follows the -A flag." >&2
+    false
+  }
+  # Same EOL branch: 'local -A' at end-of-line MUST also match (O-P4-002).
+  local pc_bad_eol_local_A
+  pc_bad_eol_local_A="${BATS_TEST_TMPDIR}/pc_ac001_bad_eol_local_A.sh"
+  printf 'local -A\n' > "$pc_bad_eol_local_A"
+  grep -qE '(local|declare)[[:space:]]+-[a-zA-Z]*A[a-zA-Z]*([[:space:]]|$)' "$pc_bad_eol_local_A" || {
+    echo "FAIL (AC-001 positive-control): array-detector did not match 'local -A' at end-of-line (EOL -A form)." >&2
+    false
+  }
+  # Array-detector: GOOD sample (declare -a, POSIX indexed array) MUST NOT match.
+  ! grep -qE '(local|declare)[[:space:]]+-[a-zA-Z]*A[a-zA-Z]*([[:space:]]|$)' "$pc_good_arr" || {
+    echo "FAIL (AC-001 positive-control): array-detector falsely matched 'declare -a' (POSIX indexed array; bash-3-safe)." >&2
+    false
+  }
+  # Guard-detector: executable conditional MUST match ([ precedes BASH_VERSINFO on the line).
+  grep -qE '([[].*BASH_VERSINFO|[(][(].*BASH_VERSINFO)' "$pc_good_guard" || {
+    echo "FAIL (AC-001 positive-control): guard-detector did not match 'if [ ... BASH_VERSINFO' form." >&2
+    false
+  }
+  # Guard-detector: BASH_VERSINFO in a comment MUST NOT match (prevents paper-fix false-pass).
+  ! grep -qE '([[].*BASH_VERSINFO|[(][(].*BASH_VERSINFO)' "$pc_bad_guard" || {
+    echo "FAIL (AC-001 positive-control): guard-detector falsely matched BASH_VERSINFO in a comment." >&2
+    false
+  }
+  # -------------------------------------------
+
+  # Check whether any file uses local -A or declare -A (bash 4+ associative arrays).
+  # Broadened: also catches combined flags (-Ax), prefix flags (-gA), and -A at end-of-line.
+  # Does NOT catch -a (indexed arrays, bash-3-safe): [a-zA-Z]*A[a-zA-Z]* requires capital A.
+  local has_arrays=0
+  local f
+  for f in "${sh_files[@]}"; do
+    if grep -qE '(local|declare)[[:space:]]+-[a-zA-Z]*A[a-zA-Z]*([[:space:]]|$)' "$f" 2>/dev/null; then
+      has_arrays=1
+      break
+    fi
+  done
+
+  # If no associative arrays are used anywhere, the scan set is compliant.
+  [ "$has_arrays" -eq 1 ] || return 0
+
+  # Associative arrays are used; verify the bash version guard exists in the scan set.
+  # Acceptable guard forms: BASH_VERSINFO inside an executable conditional.
+  # "[ ${BASH_VERSINFO[0]:-0} -lt 4 ]" — [ precedes BASH_VERSINFO on the same line.
+  # "(( BASH_VERSINFO[0] < 4 ))" — (( precedes BASH_VERSINFO on the same line.
+  # A bare comment like "# removed the BASH_VERSINFO guard" does NOT satisfy the oracle.
+  local has_guard=0
+  for f in "${sh_files[@]}"; do
+    if grep -qE '([[].*BASH_VERSINFO|[(][(].*BASH_VERSINFO)' "$f" 2>/dev/null; then
+      has_guard=1
+      break
+    fi
+  done
+
+  [ "$has_guard" -eq 1 ] || {
+    echo "FAIL (AC-001): associative arrays (local -A / declare -A) found in wave-handoff" >&2
+    echo "  scripts but no executable bash version guard (BASH_VERSINFO inside if/[/(()" >&2
+    echo "  found in the scan set. A bare comment mentioning BASH_VERSINFO is insufficient." >&2
+    echo "  The S-18.01 fix (ea7328ac) added the guard to wave-handoff.sh. It has been lost." >&2
+    echo "  Fix: restore in wave-handoff.sh (before sourcing lib scripts):" >&2
+    echo "    if [ \"\${BASH_VERSINFO[0]:-0}\" -lt 4 ]; then" >&2
+    echo "      echo 'ERROR: wave-handoff requires bash >= 4.0 (associative arrays)' >&2" >&2
+    echo "      echo '  On macOS: brew install bash' >&2" >&2
+    echo "      exit 1" >&2
+    echo "    fi" >&2
+    false
+  }
+}
+
+# ---------------------------------------------------------------------------
+# test_portability_no_unguarded_bash4_case_modifiers
+# AC-002: bash 3.2 compatibility — ${var^^} and ${var,,} case modifiers require bash 4+.
+# These operators cause a syntax error on bash 3.2 (/bin/bash on macOS).
+#
+# O-3 broadening (POLICY 13 prospective): detector now covers positional/special
+# parameter names (${1^^}, ${@^^}, ${*^^}, ${#^^}) as well as named vars.
+# The original var-name class [a-zA-Z_][a-zA-Z0-9_]* missed these forms.
+#
+# Invariant: if any wave-handoff script uses ${var^^} or ${var,,} (in any form —
+# named, positional, or special param), a bash version guard (BASH_VERSINFO check)
+# MUST also exist in the scan set.
+#
+# Red Gate expectation: PASS (no case modifiers present; absent = compliant).
+# ---------------------------------------------------------------------------
+
+@test "test_portability_no_unguarded_bash4_case_modifiers" {
+  local wave_handoff_skill_dir
+  wave_handoff_skill_dir="$(cd "${BATS_TEST_DIRNAME}/../skills/wave-handoff" && pwd)"
+
+  local sh_files=()
+  while IFS= read -r f; do
+    sh_files+=("$f")
+  done < <(find "$wave_handoff_skill_dir" -name "*.sh" -type f | sort)
+
+  # EC-005 non-vacuity
+  [ "${#sh_files[@]}" -gt 0 ] || {
+    echo "FAIL (AC-002 EC-005): no .sh files found under ${wave_handoff_skill_dir}." >&2
+    echo "  The portability-lint scope has drifted — update the guard to the new location." >&2
+    false
+  }
+
+  # --- POSITIVE-CONTROL ASSERTIONS (O-1) ---
+  # Verify the case-modifier detector matches all bash-4+ forms — including array-element
+  # forms (${arr[0]^^}, ${map[k],,}, ${arr[i]^}) and positional/special parameter forms
+  # (${1^^}, ${@^^}, ${*^^}) — and does not falsely match a plain variable expansion.
+  # Uses BATS_TEST_TMPDIR synthetic files.
+  # Broadened (O-3 / POLICY 13 prospective): optional [...] index between var name and
+  # modifier; positional/special parameter names ([0-9]+, @, *, #) in var-name class.
+  local pc_bad_dbl pc_bad_single pc_bad_arr_elem pc_bad_positional pc_good_plain
+  pc_bad_dbl="${BATS_TEST_TMPDIR}/pc_ac002_bad_dbl.sh"
+  pc_bad_single="${BATS_TEST_TMPDIR}/pc_ac002_bad_single.sh"
+  pc_bad_arr_elem="${BATS_TEST_TMPDIR}/pc_ac002_bad_arr_elem.sh"
+  pc_bad_positional="${BATS_TEST_TMPDIR}/pc_ac002_bad_positional.sh"
+  pc_good_plain="${BATS_TEST_TMPDIR}/pc_ac002_good_plain.sh"
+  printf 'echo "${VAR^^}"\n' > "$pc_bad_dbl"
+  printf 'echo "${lower,}"\n' > "$pc_bad_single"
+  printf 'echo "${arr[0]^^}"\necho "${map[k],,}"\necho "${arr[i]^}"\n' > "$pc_bad_arr_elem"
+  printf 'echo "${1^^}"\necho "${@^^}"\n' > "$pc_bad_positional"
+  printf 'echo "${VAR}"\n' > "$pc_good_plain"
+  # Doubled modifier (${VAR^^}) MUST match.
+  grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?)' "$pc_bad_dbl" || {
+    echo "FAIL (AC-002 positive-control): case-modifier-detector did not match '\${VAR^^}'." >&2
+    false
+  }
+  # Single-char modifier (${lower,}) MUST match — bash 4+ only, same as doubled form.
+  grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?)' "$pc_bad_single" || {
+    echo "FAIL (AC-002 positive-control): case-modifier-detector did not match '\${lower,}'." >&2
+    false
+  }
+  # Array-element modifiers (${arr[0]^^}, ${map[k],,}, ${arr[i]^}) MUST match.
+  grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?)' "$pc_bad_arr_elem" || {
+    echo "FAIL (AC-002 positive-control): case-modifier-detector did not match array-element forms (\${arr[0]^^}, \${map[k],,}, \${arr[i]^})." >&2
+    false
+  }
+  # Positional/special param modifiers (${1^^}, ${@^^}) MUST match (O-3 broadening).
+  # These are bash 4+ only and cause syntax errors on bash 3.2.
+  grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?)' "$pc_bad_positional" || {
+    echo "FAIL (AC-002 positive-control): case-modifier-detector did not match positional/special forms (\${1^^}, \${@^^})." >&2
+    echo "  The var-name class must cover [0-9]+ (positional) and [@*#] (special) as alternatives." >&2
+    false
+  }
+  # Plain expansion (\${VAR}) MUST NOT match.
+  ! grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?)' "$pc_good_plain" || {
+    echo "FAIL (AC-002 positive-control): case-modifier-detector falsely matched plain '\${VAR}'." >&2
+    false
+  }
+  # -------------------------------------------
+
+  # Collect all uses of bash 4+ case modifiers — bash 4+ only, syntax error on bash 3.2.
+  # Single-char form: ${var^} (first-char upper), ${var,} (first-char lower).
+  # Doubled form:     ${var^^} (all-upper),       ${var,,} (all-lower).
+  # Array-element forms: ${arr[0]^^}, ${map[k],,}, ${arr[i]^} — optional [...] index allowed.
+  # Positional/special forms: ${1^^}, ${@^^}, ${*^^}, ${#^^} — [0-9]+, @, *, # in var-name.
+  # Pattern: ${ + (var name | positional | special) + optional [index] + case modifier
+  local modifier_files=()
+  local violations=()
+  local f
+  for f in "${sh_files[@]}"; do
+    local hits
+    hits="$(grep -nE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?)' "$f" 2>/dev/null || true)"
+    if [ -n "$hits" ]; then
+      local rel="${f#${wave_handoff_skill_dir}/}"
+      modifier_files+=("$f")
+      while IFS= read -r hit; do
+        violations+=("${rel}: ${hit}")
+      done <<< "$hits"
+    fi
+  done
+
+  # No case modifiers found — compliant.
+  [ "${#modifier_files[@]}" -gt 0 ] || return 0
+
+  # Case modifiers are used; verify an executable bash version guard exists in the scan set.
+  # Acceptable forms: BASH_VERSINFO inside an if-conditional ([ or (( precedes it on the line).
+  # A bare comment mentioning BASH_VERSINFO is insufficient.
+  local has_guard=0
+  for f in "${sh_files[@]}"; do
+    if grep -qE '([[].*BASH_VERSINFO|[(][(].*BASH_VERSINFO)' "$f" 2>/dev/null; then
+      has_guard=1
+      break
+    fi
+  done
+
+  [ "$has_guard" -eq 1 ] || {
+    echo "FAIL (AC-002): bash 4+ case modifiers (\${var^}, \${var^^}, \${var,}, \${var,,}) found in" >&2
+    echo "  wave-handoff scripts without an executable bash version guard (BASH_VERSINFO in if/[/(()" >&2
+    echo "  found in the scan set." >&2
+    echo "  Fix: either remove case modifiers (use 'tr a-z A-Z' or awk for case conversion)" >&2
+    echo "  or add a bash 4+ version check to wave-handoff.sh before sourcing lib scripts." >&2
+    echo "  Violations:" >&2
+    local v
+    for v in "${violations[@]}"; do echo "  ${v}" >&2; done
+    false
+  }
+}
+
+# ---------------------------------------------------------------------------
+# test_portability_no_global_ifs_mutation
+# AC-003: IFS must not be mutated at global script scope or as a non-local function
+# assignment. Global IFS mutation persists across all subsequent reads and causes
+# silent misclassification (SOUL.md §4 silent-failure category).
+# The S-18.01 fix (2b40dfd5) replaced IFS='|' with awk -F'|' in parse-sprint-state.sh.
+#
+# Allowed forms (not flagged by this test):
+#   local IFS=...            — local declaration (scoped to function body)
+#   while IFS= read -r ...   — command-prefix before read (scoped to that read)
+#   IFS=','  read -ra arr    — command-prefix before read (scoped to that read)
+#   (IFS=...; command)       — subshell-scoped (same-line subshell open)
+#
+# Flagged forms (violations):
+#   IFS='|'                  — standalone global assignment (not a command prefix)
+#   IFS=$'\n'                — standalone global assignment
+#   export IFS='|'           — export-prefixed global mutation
+#   readonly IFS=$'\n'       — readonly-prefixed global mutation (O-P4-002)
+#   declare -g IFS='|'       — declare -g global mutation (O-P4-002)
+#   cmd && IFS='|'           — operator-prefixed global mutation (O-P4-003)
+#   cmd & IFS='|'            — background+global mutation: background cmd then assign IFS (O-2)
+#   cmd || IFS='|'           — operator-prefixed global mutation (O-P4-003)
+#   then IFS='|'             — keyword-prefixed global mutation (O-P4-003)
+#   do IFS='|'               — keyword-prefixed global mutation (O-P4-003)
+#   else IFS='|'             — keyword-prefixed global mutation (O-P4-003)
+#   elif IFS='|'             — keyword-prefixed global mutation (O-P4-003)
+#
+# Detection: three-step filter — step-1 anchors on line-start/separator/operator/keyword
+# before IFS=; step-2 excludes local-scoped and subshell-open forms; step-3 excludes
+# command-prefix-to-read forms.
+#
+# Red Gate expectation: PASS (global IFS mutation removed in S-18.01 merge 2b40dfd5).
+# ---------------------------------------------------------------------------
+
+@test "test_portability_no_global_ifs_mutation" {
+  local wave_handoff_skill_dir
+  wave_handoff_skill_dir="$(cd "${BATS_TEST_DIRNAME}/../skills/wave-handoff" && pwd)"
+
+  local sh_files=()
+  while IFS= read -r f; do
+    sh_files+=("$f")
+  done < <(find "$wave_handoff_skill_dir" -name "*.sh" -type f | sort)
+
+  # EC-005 non-vacuity
+  [ "${#sh_files[@]}" -gt 0 ] || {
+    echo "FAIL (AC-003 EC-005): no .sh files found under ${wave_handoff_skill_dir}." >&2
+    echo "  The portability-lint scope has drifted — update the guard to the new location." >&2
+    false
+  }
+
+  # --- POSITIVE-CONTROL ASSERTIONS (O-1) ---
+  # Verify the three-step IFS-mutation detector flags bare global IFS= (including export,
+  # readonly, declare -g, and after-semicolon forms) and correctly exempts local IFS= and
+  # IFS=... read command-prefix forms.
+  # Uses BATS_TEST_TMPDIR synthetic files; no real wave-handoff scripts are executed.
+  #
+  # F-P3-001 fix: step-3 exclusion tightened to not cross statement separators.
+  # OLD (greedy — false-negative): 'IFS=[^[:space:]]*[[:space:]]+read([[:space:]]|$)'
+  #   [^[:space:]]* crosses ; so 'IFS='|'; read x' was wrongly excluded.
+  # NEW (safe — stops at ;, &, |): 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)'
+  #
+  # Step-1 pattern (extended): (^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]])[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=
+  #   ^                   — bare global assignment at start of line
+  #   ;                   — second statement on same line (cmd; IFS=)
+  #   &&                  — operator-prefixed: cmd && IFS='|' (O-P4-003)
+  #   &                   — background+global: cmd & IFS='|' (O-2); && listed before & so &&
+  #                          is consumed as a unit first; plain 'cmd &' without IFS= cannot match
+  #   ||                  — operator-prefixed: cmd || IFS='|' (O-P4-003)
+  #   then|do|else|elif   — keyword-prefixed: then IFS='|', else IFS='|', etc. (O-P4-003)
+  #   export/readonly/declare -g prefixes — keyword-prefixed global mutations
+  # Step-2 (exclude): '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' — local scoped / subshell-open
+  # Step-3 (exclude): 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' — command-prefix for read
+  #   [^[:space:];&|]* — matches only non-separator chars; stops at ; & | before crossing them
+  local pc_bad_ifs pc_bad_export_ifs pc_bad_semi_ifs pc_bad_semi_read pc_good_local_ifs pc_good_prefix_ifs
+  local pc_bad_readonly_ifs pc_bad_declare_g_ifs pc_bad_and_ifs pc_bad_then_ifs pc_bad_bg_ifs
+  pc_bad_ifs="${BATS_TEST_TMPDIR}/pc_ac003_bad_ifs.sh"
+  pc_bad_export_ifs="${BATS_TEST_TMPDIR}/pc_ac003_bad_export.sh"
+  pc_bad_semi_ifs="${BATS_TEST_TMPDIR}/pc_ac003_bad_semi.sh"
+  pc_bad_semi_read="${BATS_TEST_TMPDIR}/pc_ac003_bad_semi_read.sh"
+  pc_good_local_ifs="${BATS_TEST_TMPDIR}/pc_ac003_good_local.sh"
+  pc_good_prefix_ifs="${BATS_TEST_TMPDIR}/pc_ac003_good_prefix.sh"
+  pc_bad_readonly_ifs="${BATS_TEST_TMPDIR}/pc_ac003_bad_readonly.sh"
+  pc_bad_declare_g_ifs="${BATS_TEST_TMPDIR}/pc_ac003_bad_declare_g.sh"
+  pc_bad_and_ifs="${BATS_TEST_TMPDIR}/pc_ac003_bad_and.sh"
+  pc_bad_then_ifs="${BATS_TEST_TMPDIR}/pc_ac003_bad_then.sh"
+  pc_bad_bg_ifs="${BATS_TEST_TMPDIR}/pc_ac003_bad_bg.sh"
+  printf "IFS='|'\n" > "$pc_bad_ifs"
+  printf "export IFS='|'\n" > "$pc_bad_export_ifs"
+  printf "cmd; IFS='|'\n" > "$pc_bad_semi_ifs"
+  printf "IFS='|'; read x\n" > "$pc_bad_semi_read"
+  printf "local IFS=':'\n" > "$pc_good_local_ifs"
+  printf "IFS=',' read -ra arr\n" > "$pc_good_prefix_ifs"
+  printf "readonly IFS='|'\n" > "$pc_bad_readonly_ifs"
+  printf "declare -g IFS='|'\n" > "$pc_bad_declare_g_ifs"
+  printf "cmd && IFS='|'\n" > "$pc_bad_and_ifs"
+  printf "then IFS='|'\n" > "$pc_bad_then_ifs"
+  printf "cmd & IFS='|'\n" > "$pc_bad_bg_ifs"
+  # BAD: bare global IFS= MUST pass through the three-step filter (produces a violation).
+  local pc_bad_ifs_hits
+  pc_bad_ifs_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]])[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_ifs" 2>/dev/null \
+    | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
+    | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+    || true)"
+  [ -n "$pc_bad_ifs_hits" ] || {
+    echo "FAIL (AC-003 positive-control): IFS-detector did not flag bare global 'IFS=|' assignment." >&2
+    false
+  }
+  # BAD: 'export IFS=' MUST be flagged (keyword-prefixed global mutation).
+  local pc_bad_export_hits
+  pc_bad_export_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]])[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_export_ifs" 2>/dev/null \
+    | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
+    | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+    || true)"
+  [ -n "$pc_bad_export_hits" ] || {
+    echo "FAIL (AC-003 positive-control): IFS-detector did not flag 'export IFS=|' (keyword-prefixed global mutation)." >&2
+    false
+  }
+  # BAD: 'cmd; IFS=' MUST be flagged (second-statement global mutation).
+  local pc_bad_semi_hits
+  pc_bad_semi_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]])[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_semi_ifs" 2>/dev/null \
+    | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
+    | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+    || true)"
+  [ -n "$pc_bad_semi_hits" ] || {
+    echo "FAIL (AC-003 positive-control): IFS-detector did not flag 'cmd; IFS=|' (second-statement global mutation)." >&2
+    false
+  }
+  # BAD (F-P3-001): 'IFS='|'; read x' MUST be flagged — semicolon separates a global IFS=
+  # assignment from 'read'; it is NOT a command-prefix (step-3 exemption requires the value
+  # class to not cross statement separators).  The old [^[:space:]]* would cross the ';' and
+  # wrongly exclude this as if it were 'IFS=... read'.
+  local pc_bad_semi_read_hits
+  pc_bad_semi_read_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]])[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_semi_read" 2>/dev/null \
+    | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
+    | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+    || true)"
+  [ -n "$pc_bad_semi_read_hits" ] || {
+    echo "FAIL (AC-003 positive-control / F-P3-001): IFS-detector did NOT flag 'IFS=\\'|\\'; read x'." >&2
+    echo "  This is a global IFS mutation; the semicolon separates IFS= from read (not a command-prefix)." >&2
+    echo "  The step-3 exclusion value class [^[:space:];&|]* must stop at the semicolon." >&2
+    false
+  }
+  # GOOD: 'local IFS=' MUST be excluded by the filter (no violation).
+  local pc_good_local_hits
+  pc_good_local_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]])[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_good_local_ifs" 2>/dev/null \
+    | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
+    | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+    || true)"
+  [ -z "$pc_good_local_hits" ] || {
+    echo "FAIL (AC-003 positive-control): IFS-detector falsely flagged 'local IFS=' (must be exempt)." >&2
+    false
+  }
+  # GOOD: 'IFS=... read' command-prefix MUST be excluded by the filter (no violation).
+  # This is the legitimate command-prefix form (e.g., IFS=',' read -ra arr).
+  local pc_good_prefix_hits
+  pc_good_prefix_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]])[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_good_prefix_ifs" 2>/dev/null \
+    | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
+    | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+    || true)"
+  [ -z "$pc_good_prefix_hits" ] || {
+    echo "FAIL (AC-003 positive-control): IFS-detector falsely flagged 'IFS=... read' prefix (must be exempt)." >&2
+    false
+  }
+  # BAD (O-P4-002): 'readonly IFS=' MUST be flagged (keyword-prefixed global mutation).
+  # This exercises the readonly[[:space:]]+ arm of the optional-keyword group in step-1.
+  local pc_bad_readonly_hits
+  pc_bad_readonly_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]])[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_readonly_ifs" 2>/dev/null \
+    | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
+    | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+    || true)"
+  [ -n "$pc_bad_readonly_hits" ] || {
+    echo "FAIL (AC-003 positive-control / O-P4-002): IFS-detector did not flag 'readonly IFS=' (keyword-prefixed global mutation)." >&2
+    echo "  The readonly[[:space:]]+ arm of step-1's optional-keyword group must fire." >&2
+    false
+  }
+  # BAD (O-P4-002): 'declare -g IFS=' MUST be flagged (declare -g global mutation).
+  # This exercises the declare[[:space:]]+-g[[:space:]]+ arm in step-1.
+  local pc_bad_declare_g_hits
+  pc_bad_declare_g_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]])[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_declare_g_ifs" 2>/dev/null \
+    | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
+    | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+    || true)"
+  [ -n "$pc_bad_declare_g_hits" ] || {
+    echo "FAIL (AC-003 positive-control / O-P4-002): IFS-detector did not flag 'declare -g IFS=' (declare -g global mutation)." >&2
+    echo "  The declare[[:space:]]+-g[[:space:]]+ arm of step-1's optional-keyword group must fire." >&2
+    false
+  }
+  # BAD (O-P4-003): 'cmd && IFS=' MUST be flagged (operator-prefixed global mutation).
+  # This exercises the new && arm added to step-1 to catch operator-chained mutations.
+  local pc_bad_and_hits
+  pc_bad_and_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]])[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_and_ifs" 2>/dev/null \
+    | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
+    | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+    || true)"
+  [ -n "$pc_bad_and_hits" ] || {
+    echo "FAIL (AC-003 positive-control / O-P4-003): IFS-detector did not flag 'cmd && IFS=|' (operator-prefixed global mutation)." >&2
+    echo "  The && arm must be in step-1's outer alternation group." >&2
+    false
+  }
+  # BAD (O-P4-003): 'then IFS=' MUST be flagged (keyword-prefixed global mutation).
+  # This exercises the (then|do|else|elif)[[:space:]] arm added to step-1.
+  local pc_bad_then_hits
+  pc_bad_then_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]])[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_then_ifs" 2>/dev/null \
+    | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
+    | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+    || true)"
+  [ -n "$pc_bad_then_hits" ] || {
+    echo "FAIL (AC-003 positive-control / O-P4-003): IFS-detector did not flag 'then IFS=|' (keyword-prefixed global mutation)." >&2
+    echo "  The (then|do|else|elif)[[:space:]] arm must be in step-1's outer alternation group." >&2
+    false
+  }
+  # BAD (O-2): 'cmd & IFS=' MUST be flagged (background+global mutation).
+  # Backgrounding a command and then assigning IFS globally on the same line mutates the
+  # shell's IFS just as a standalone assignment does.  The & arm is listed after && in
+  # step-1 so that '&&' is consumed as a unit first; plain 'cmd &' without a following
+  # IFS= cannot satisfy the remainder of the regex and is NOT a false positive.
+  local pc_bad_bg_hits
+  pc_bad_bg_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]])[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_bg_ifs" 2>/dev/null \
+    | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
+    | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+    || true)"
+  [ -n "$pc_bad_bg_hits" ] || {
+    echo "FAIL (AC-003 positive-control / O-2): IFS-detector did not flag 'cmd & IFS=|' (background+global mutation)." >&2
+    echo "  The & arm must be in step-1's outer alternation group (listed after && so && is" >&2
+    echo "  consumed as a unit first; AC-005's jq detector already includes & per [|;&])." >&2
+    false
+  }
+  # -------------------------------------------
+
+  # Detect global IFS= mutations at script or function scope.
+  # Step 1 (extended): lines where IFS= appears at line-start, after a semicolon,
+  #         after an operator (&&, &, ||), or after a shell keyword (then/do/else/elif),
+  #         optionally preceded by export/readonly/declare -g keywords.
+  #         — (^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]])[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=
+  #         Catches: bare IFS=, export/readonly/declare -g IFS=, cmd; IFS=,
+  #         cmd && IFS=, cmd & IFS=, cmd || IFS=, then/do/else/elif IFS= (O-P4-003/O-2)
+  # Step 2: exclude "local IFS=" — locally scoped within a function body.
+  # Step 3: exclude "(IFS=" — subshell-scoped (subshell open on same line as IFS=).
+  # Step 4: exclude "IFS=<value> read" — command-prefix for the read builtin.
+  #         A command-prefix assignment is always on the same line as the command
+  #         and the command name appears after the assignment value.
+  #         F-P3-001: value class is [^[:space:];&|]* (not [^[:space:]]*) to avoid crossing
+  #         statement separators — 'IFS='|'; read x' is a global mutation, not a prefix.
+  local violations=()
+  local f
+  for f in "${sh_files[@]}"; do
+    local rel="${f#${wave_handoff_skill_dir}/}"
+    local hits
+    hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]])[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$f" 2>/dev/null \
+      | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
+      | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+      || true)"
+    if [ -n "$hits" ]; then
+      while IFS= read -r hit; do
+        violations+=("${rel}: ${hit}")
+      done <<< "$hits"
+    fi
+  done
+
+  if [ "${#violations[@]}" -gt 0 ]; then
+    echo "FAIL (AC-003): bare global IFS= assignment found in wave-handoff scripts." >&2
+    echo "  Global IFS mutation persists across all subsequent reads and is not portable." >&2
+    echo "  The S-18.01 fix (2b40dfd5) was to replace IFS-based splitting with awk -F'...'." >&2
+    echo "  Fix options:" >&2
+    echo "    (a) Use 'local IFS=...' inside a function (scoped to that function body)." >&2
+    echo "    (b) Use 'IFS=... read' as a command prefix (scoped to that single read)." >&2
+    echo "    (c) Replace IFS-split loops with awk -F'...' or cut -d'...' -f<n>." >&2
+    echo "  Violations:" >&2
+    local v
+    for v in "${violations[@]}"; do echo "  ${v}" >&2; done
+    false
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# test_portability_no_undeclared_pyyaml_dep
+# AC-004: undeclared Python/PyYAML runtime dependency.
+# S-18.01 hit "externally managed environment" PEP 668 error on macOS GitHub Actions
+# when pip tried to install pyyaml (aaa8da8a). The --break-system-packages workaround
+# (3fe11ea1) is NOT accepted as a long-term resolution in wave-handoff scripts.
+#
+# O-3 broadening (POLICY 13 prospective): python arm uses python[0-9.]* (was python[23]?)
+# to catch versioned binaries like python3.11 and python3.12 which are common on modern
+# macOS and Linux CI images and were missed by the [23]? class.
+#
+# EC-002: python3 -c "import json; ..." is fine — json is a stdlib module, no pip
+# install is needed. Only external packages (pyyaml, yaml) are flagged.
+#
+# Scan: if any wave-handoff script invokes python (any version) with yaml/pyyaml or
+# pip-installs pyyaml, it MUST have a preflight check. Absence = compliant.
+#
+# Red Gate expectation: PASS (pyyaml dep removed / never added post-S-18.01 merge).
+# ---------------------------------------------------------------------------
+
+@test "test_portability_no_undeclared_pyyaml_dep" {
+  local wave_handoff_skill_dir
+  wave_handoff_skill_dir="$(cd "${BATS_TEST_DIRNAME}/../skills/wave-handoff" && pwd)"
+
+  local sh_files=()
+  while IFS= read -r f; do
+    sh_files+=("$f")
+  done < <(find "$wave_handoff_skill_dir" -name "*.sh" -type f | sort)
+
+  # EC-005 non-vacuity
+  [ "${#sh_files[@]}" -gt 0 ] || {
+    echo "FAIL (AC-004 EC-005): no .sh files found under ${wave_handoff_skill_dir}." >&2
+    echo "  The portability-lint scope has drifted — update the guard to the new location." >&2
+    false
+  }
+
+  # --- POSITIVE-CONTROL ASSERTIONS (O-1) ---
+  # Verify the pyyaml/pip detector matches pip2/pip3/pipx and python/python2/python3+yaml
+  # forms, and does NOT match python3 stdlib-only usage (EC-002 exemption).
+  # Uses BATS_TEST_TMPDIR synthetic files; no real wave-handoff scripts are executed.
+  # F-P2-001 fix: pyyaml token is case-insensitive ([Pp][Yy][Yy][Aa][Mm][Ll]) to catch
+  # canonical PyPI capitalization "PyYAML" which evaded the lowercase-only detector.
+  # O-3 fix: python arm broadened from python[23]? to python[0-9.]* to catch versioned
+  # binaries like python3.11 and python3.12 (POLICY 13 prospective).
+  local pc_bad_pip3 pc_bad_pipx pc_bad_py2yaml pc_bad_pyyaml_canonical pc_bad_py311 pc_good_stdlib pc_bad_bsp
+  pc_bad_pip3="${BATS_TEST_TMPDIR}/pc_ac004_bad_pip3.sh"
+  pc_bad_pipx="${BATS_TEST_TMPDIR}/pc_ac004_bad_pipx.sh"
+  pc_bad_py2yaml="${BATS_TEST_TMPDIR}/pc_ac004_bad_py2yaml.sh"
+  pc_bad_pyyaml_canonical="${BATS_TEST_TMPDIR}/pc_ac004_bad_pyyaml_canonical.sh"
+  pc_bad_py311="${BATS_TEST_TMPDIR}/pc_ac004_bad_py311.sh"
+  pc_good_stdlib="${BATS_TEST_TMPDIR}/pc_ac004_good_stdlib.sh"
+  pc_bad_bsp="${BATS_TEST_TMPDIR}/pc_ac004_bad_bsp.sh"
+  printf 'pip3 install pyyaml\n' > "$pc_bad_pip3"
+  printf 'pipx install pyyaml\n' > "$pc_bad_pipx"
+  printf 'python2 -c "import yaml; yaml.safe_load(f)"\n' > "$pc_bad_py2yaml"
+  printf 'pip install PyYAML\n' > "$pc_bad_pyyaml_canonical"
+  printf 'python3.11 -c "import yaml; print(yaml.safe_load(open(f)))"\n' > "$pc_bad_py311"
+  printf 'python3 -c "import json; print(json.load(open(f)))"\n' > "$pc_good_stdlib"
+  printf 'pip install pyyaml --break-system-packages\n' > "$pc_bad_bsp"
+  local dep_re='(python[0-9.]*[[:space:]].*[Yy][Aa][Mm][Ll]|pip[0-9x]*[[:space:]].*[Pp][Yy][Yy][Aa][Mm][Ll]|import[[:space:]]+yaml)'
+  # BAD: pip3 MUST be detected.
+  grep -qE "$dep_re" "$pc_bad_pip3" || {
+    echo "FAIL (AC-004 positive-control): pyyaml-detector did not match 'pip3 install pyyaml'." >&2
+    false
+  }
+  # BAD: pipx MUST be detected.
+  grep -qE "$dep_re" "$pc_bad_pipx" || {
+    echo "FAIL (AC-004 positive-control): pyyaml-detector did not match 'pipx install pyyaml'." >&2
+    false
+  }
+  # BAD: python2+yaml MUST be detected.
+  grep -qE "$dep_re" "$pc_bad_py2yaml" || {
+    echo "FAIL (AC-004 positive-control): pyyaml-detector did not match 'python2 ... yaml'." >&2
+    false
+  }
+  # BAD: 'pip install PyYAML' (canonical PyPI capitalization) MUST be detected (F-P2-001).
+  grep -qE "$dep_re" "$pc_bad_pyyaml_canonical" || {
+    echo "FAIL (AC-004 positive-control): pyyaml-detector did not match 'pip install PyYAML' (canonical capitalization)." >&2
+    echo "  F-P2-001: the pip arm must use [Pp][Yy][Yy][Aa][Mm][Ll] to catch mixed-case PyPI name." >&2
+    false
+  }
+  # BAD (O-3): 'python3.11 ... yaml' MUST be detected — versioned python binaries were missed
+  # by python[23]? which does not match the decimal point in '3.11'.
+  grep -qE "$dep_re" "$pc_bad_py311" || {
+    echo "FAIL (AC-004 positive-control / O-3): pyyaml-detector did not match 'python3.11 -c \"import yaml\"'." >&2
+    echo "  The python arm must use python[0-9.]* (not python[23]?) to cover versioned binaries." >&2
+    false
+  }
+  # GOOD (EC-002): python3 stdlib-only usage MUST NOT be detected.
+  ! grep -qE "$dep_re" "$pc_good_stdlib" || {
+    echo "FAIL (AC-004 positive-control): pyyaml-detector falsely matched python3 stdlib-only usage." >&2
+    false
+  }
+  # BAD (--break-system-packages): bsp-detector MUST match.
+  grep -qE '\-\-break-system-packages' "$pc_bad_bsp" || {
+    echo "FAIL (AC-004 positive-control): bsp-detector did not match '--break-system-packages'." >&2
+    false
+  }
+  # GOOD (O-P4-001): a script with 'python3.11 -c "import yaml"' as its preflight MUST be ACCEPTED.
+  # Phase-1 would catch this file (has python3.11 ... yaml); phase-2 must recognize the versioned
+  # preflight as acceptable — this tests the broadened python[0-9.]* acceptance arm.
+  local pc_good_py311_preflight
+  pc_good_py311_preflight="${BATS_TEST_TMPDIR}/pc_ac004_good_py311_preflight.sh"
+  printf 'python3.11 -c "import yaml" 2>/dev/null || { echo "pyyaml required" >&2; exit 1; }\n' > "$pc_good_py311_preflight"
+  printf 'python3.11 -c "import yaml; print(yaml.safe_load(open(f)))"\n' >> "$pc_good_py311_preflight"
+  # Phase-2 acceptance regex (broadened): python[0-9.]* -c "import yaml" OR command -v python[0-9.]*
+  grep -qE '(python[0-9.]*[[:space:]]+-c[[:space:]]+"import yaml"|command[[:space:]]+-v[[:space:]]+python[0-9.]*)' "$pc_good_py311_preflight" || {
+    echo "FAIL (AC-004 positive-control / O-P4-001): broadened phase-2 acceptance regex did NOT match 'python3.11 -c \"import yaml\"' preflight." >&2
+    echo "  The phase-2 acceptance arm must use python[0-9.]* (not python3) to accept versioned binaries." >&2
+    false
+  }
+  # -------------------------------------------
+
+  # Phase 1: detect any python/python2/python3/python3.11+yaml or pip/pip2/pip3/pipx+pyyaml invocations.
+  # EC-002 exception: python3 using only stdlib modules (json, os, sys, re, etc.) is fine.
+  # We flag: import yaml / pyyaml (case-insensitive) / pip[0-9x]* install PyYAML / python[0-9.]* ... yaml.
+  # O-3: python arm uses python[0-9.]* to catch versioned binaries like python3.11/python3.12.
+  # F-P2-001: pyyaml token uses [Pp][Yy][Yy][Aa][Mm][Ll] to catch canonical "PyYAML" capitalization.
+  local dep_files=()
+  local f
+  for f in "${sh_files[@]}"; do
+    if grep -qE '(python[0-9.]*[[:space:]].*[Yy][Aa][Mm][Ll]|pip[0-9x]*[[:space:]].*[Pp][Yy][Yy][Aa][Mm][Ll]|import[[:space:]]+yaml)' \
+        "$f" 2>/dev/null; then
+      dep_files+=("$f")
+    fi
+  done
+
+  # No python/pyyaml invocations — compliant (EC-002: stdlib-only python3 is fine).
+  [ "${#dep_files[@]}" -gt 0 ] || return 0
+
+  # Phase 2: for each file with a pyyaml/python-yaml invocation, audit for acceptability.
+  # Unacceptable form: --break-system-packages (PEP 668 workaround; not a long-term fix).
+  # Acceptable alternatives: python[0-9.]* -c "import yaml" preflight OR awk-based YAML parsing.
+  # O-P4-001: broadened from python3 to python[0-9.]* so versioned preflights like
+  # 'python3.11 -c "import yaml"' and 'command -v python3.11' are recognized as valid guards.
+  local violations=()
+  for f in "${dep_files[@]}"; do
+    local rel="${f#${wave_handoff_skill_dir}/}"
+
+    # Flag --break-system-packages explicitly (canonical unacceptable workaround per AC-004)
+    local bsp_hits
+    bsp_hits="$(grep -nE '\-\-break-system-packages' "$f" 2>/dev/null || true)"
+    if [ -n "$bsp_hits" ]; then
+      while IFS= read -r hit; do
+        violations+=("${rel}: --break-system-packages (PEP 668 workaround; not a long-term fix): ${hit}")
+      done <<< "$bsp_hits"
+      continue
+    fi
+
+    # Check for proper preflight guard before pyyaml invocation.
+    # Accepts versioned binaries: python3.11 -c "import yaml", command -v python3.11, etc.
+    if ! grep -qE '(python[0-9.]*[[:space:]]+-c[[:space:]]+"import yaml"|command[[:space:]]+-v[[:space:]]+python[0-9.]*)' \
+        "$f" 2>/dev/null; then
+      local hits
+      hits="$(grep -nE '(python[0-9.]*[[:space:]].*[Yy][Aa][Mm][Ll]|pip[0-9x]*[[:space:]].*[Pp][Yy][Yy][Aa][Mm][Ll]|import[[:space:]]+yaml)' \
+              "$f" 2>/dev/null || true)"
+      while IFS= read -r hit; do
+        violations+=("${rel}: pyyaml/yaml usage without preflight: ${hit}")
+      done <<< "$hits"
+    fi
+  done
+
+  if [ "${#violations[@]}" -gt 0 ]; then
+    echo "FAIL (AC-004): python3/pyyaml invocation without preflight guard found." >&2
+    echo "  Fix options (choose one):" >&2
+    echo "    (a) Add preflight: python3 -c \"import yaml\" 2>/dev/null || { echo 'yaml required' >&2; exit 1; }" >&2
+    echo "    (b) Replace with POSIX portable alternative: awk or sed-based YAML key extraction." >&2
+    echo "  NOTE: --break-system-packages is explicitly NOT accepted (PEP 668 is a macOS-runner" >&2
+    echo "  policy; the correct fix is to not depend on externally managed pip packages in CI)." >&2
+    echo "  Violations:" >&2
+    local v
+    for v in "${violations[@]}"; do echo "  ${v}" >&2; done
+    false
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# test_portability_no_undeclared_jq_dep
+# AC-005: undeclared jq runtime dependency.
+# jq is not installed by default on all macOS and Linux CI images. Any wave-handoff
+# script that invokes jq as a command MUST have a preflight check confirming jq is
+# available before first use:
+#   command -v jq >/dev/null 2>&1 || { echo "ERROR: jq is required" >&2; exit 1; }
+#
+# Detection: lines where 'jq' appears as a standalone command token (preceded by
+# start-of-line, pipe, semicolon, or whitespace, and followed by whitespace or
+# end-of-line). Uses POSIX ERE; no \b word-boundary shorthand.
+#
+# O-3 broadening (POLICY 13 prospective):
+#   - Added time|env|command|sudo to the keyword-wrapper group.
+#   - Added a separate xargs-with-options arm:
+#     xargs([[:space:]]+-[^[:space:]]+)+[[:space:]]+jq — catches 'xargs -n1 jq', etc.
+#
+# Red Gate expectation: PASS (no jq invocations found; absent = compliant).
+# ---------------------------------------------------------------------------
+
+@test "test_portability_no_undeclared_jq_dep" {
+  local wave_handoff_skill_dir
+  wave_handoff_skill_dir="$(cd "${BATS_TEST_DIRNAME}/../skills/wave-handoff" && pwd)"
+
+  local sh_files=()
+  while IFS= read -r f; do
+    sh_files+=("$f")
+  done < <(find "$wave_handoff_skill_dir" -name "*.sh" -type f | sort)
+
+  # EC-005 non-vacuity
+  [ "${#sh_files[@]}" -gt 0 ] || {
+    echo "FAIL (AC-005 EC-005): no .sh files found under ${wave_handoff_skill_dir}." >&2
+    echo "  The portability-lint scope has drifted — update the guard to the new location." >&2
+    false
+  }
+
+  # --- POSITIVE-CONTROL ASSERTIONS (O-1) ---
+  # Verify the jq-detector matches command-substitution, &&/|| chains, xargs (direct and
+  # with options), keyword-prefixed forms (including else/elif — F-P2-002), and common
+  # command wrappers (time, env, command, sudo — O-3), and does NOT match jq in a comment.
+  # Uses BATS_TEST_TMPDIR synthetic files; no real wave-handoff scripts are executed.
+  local pc_bad_cmdsubst pc_bad_and pc_bad_xargs pc_bad_else pc_bad_time pc_bad_xargs_opts pc_good_comment
+  pc_bad_cmdsubst="${BATS_TEST_TMPDIR}/pc_ac005_bad_cmdsubst.sh"
+  pc_bad_and="${BATS_TEST_TMPDIR}/pc_ac005_bad_and.sh"
+  pc_bad_xargs="${BATS_TEST_TMPDIR}/pc_ac005_bad_xargs.sh"
+  pc_bad_else="${BATS_TEST_TMPDIR}/pc_ac005_bad_else.sh"
+  pc_bad_time="${BATS_TEST_TMPDIR}/pc_ac005_bad_time.sh"
+  pc_bad_xargs_opts="${BATS_TEST_TMPDIR}/pc_ac005_bad_xargs_opts.sh"
+  pc_good_comment="${BATS_TEST_TMPDIR}/pc_ac005_good_comment.sh"
+  printf 'result=$(jq -r .name input.json)\n' > "$pc_bad_cmdsubst"
+  printf 'cmd && jq ".key" file.json\n' > "$pc_bad_and"
+  printf 'find . -name "*.json" | xargs jq ".id"\n' > "$pc_bad_xargs"
+  printf 'else jq -r .status file.json\n' > "$pc_bad_else"
+  printf "time jq '.' input.json\n" > "$pc_bad_time"
+  printf 'find . -name "*.json" | xargs -n1 jq ".id"\n' > "$pc_bad_xargs_opts"
+  printf '# no jq dependency; using awk instead\n' > "$pc_good_comment"
+  # O-3 broadened jq_re: adds time|env|command|sudo to the keyword wrapper group; adds a
+  # separate arm for xargs with intervening options (e.g. xargs -n1 jq).
+  # Positive-control regex MUST BE BYTE-IDENTICAL to the real-scan-loop regex below.
+  local jq_re='(^[[:space:]]*jq([[:space:]]|$)|[|;&][[:space:]]*jq([[:space:]]|$)|\$[(]jq([[:space:]]|$)|`jq([[:space:]]|$)|(xargs|if|then|do|else|elif|time|env|command|sudo)[[:space:]]+jq([[:space:]]|$)|xargs([[:space:]]+-[^[:space:]]+)+[[:space:]]+jq([[:space:]]|$))'
+  # BAD: command-substitution $(jq ...) MUST be detected.
+  grep -qE "$jq_re" "$pc_bad_cmdsubst" || {
+    echo "FAIL (AC-005 positive-control): jq-detector did not match '\$(jq ...)' command-substitution form." >&2
+    false
+  }
+  # BAD: && jq MUST be detected (& in [|;&] catches both && and ||).
+  grep -qE "$jq_re" "$pc_bad_and" || {
+    echo "FAIL (AC-005 positive-control): jq-detector did not match 'cmd && jq' form." >&2
+    false
+  }
+  # BAD: xargs jq (direct, no intervening options) MUST be detected.
+  grep -qE "$jq_re" "$pc_bad_xargs" || {
+    echo "FAIL (AC-005 positive-control): jq-detector did not match 'xargs jq' form." >&2
+    false
+  }
+  # BAD: 'else jq' MUST be detected (F-P2-002 — else/elif are genuine command positions).
+  grep -qE "$jq_re" "$pc_bad_else" || {
+    echo "FAIL (AC-005 positive-control): jq-detector did not match 'else jq' form (F-P2-002)." >&2
+    false
+  }
+  # BAD (O-3): 'time jq' MUST be detected — time is a common command wrapper.
+  grep -qE "$jq_re" "$pc_bad_time" || {
+    echo "FAIL (AC-005 positive-control / O-3): jq-detector did not match 'time jq' form." >&2
+    echo "  time|env|command|sudo must be in the wrapper keyword group." >&2
+    false
+  }
+  # BAD (O-3): 'xargs -n1 jq' MUST be detected — xargs with intervening options precedes jq.
+  grep -qE "$jq_re" "$pc_bad_xargs_opts" || {
+    echo "FAIL (AC-005 positive-control / O-3): jq-detector did not match 'xargs -n1 jq' form." >&2
+    echo "  The xargs-with-options arm 'xargs([[:space:]]+-[^[:space:]]+)+[[:space:]]+jq' is required." >&2
+    false
+  }
+  # GOOD: jq in a comment MUST NOT be detected.
+  ! grep -qE "$jq_re" "$pc_good_comment" || {
+    echo "FAIL (AC-005 positive-control): jq-detector falsely matched jq inside a comment." >&2
+    false
+  }
+  # -------------------------------------------
+
+  # Phase 1: detect jq invocations (jq as a command word, not as part of a variable name).
+  # Patterns that indicate jq is used as a command (POSIX ERE, no PCRE shorthand):
+  #   ^[[:space:]]*jq([[:space:]]|$)                      — start of line
+  #   [|;&][[:space:]]*jq([[:space:]]|$)                   — after |, ;, &  (covers |, ||, &&)
+  #   \$[(]jq([[:space:]]|$)                               — command substitution $(jq ...)
+  #   `jq([[:space:]]|$)                                   — backtick command substitution
+  #   (xargs|if|then|do|else|elif|time|env|command|sudo)[[:space:]]+jq(...)
+  #                                                        — keyword/wrapper-prefixed invocations
+  #   xargs([[:space:]]+-[^[:space:]]+)+[[:space:]]+jq(...)— xargs with intervening options
+  #   F-P2-002: else and elif added (genuine command positions for jq invocation).
+  #   O-3: time, env, command, sudo added as common command wrappers.
+  #        xargs-with-options arm handles 'xargs -n1 jq', 'xargs -n1 -P4 jq', etc.
+  local jq_files=()
+  local f
+  for f in "${sh_files[@]}"; do
+    if grep -qE '(^[[:space:]]*jq([[:space:]]|$)|[|;&][[:space:]]*jq([[:space:]]|$)|\$[(]jq([[:space:]]|$)|`jq([[:space:]]|$)|(xargs|if|then|do|else|elif|time|env|command|sudo)[[:space:]]+jq([[:space:]]|$)|xargs([[:space:]]+-[^[:space:]]+)+[[:space:]]+jq([[:space:]]|$))' \
+        "$f" 2>/dev/null; then
+      jq_files+=("$f")
+    fi
+  done
+
+  # No jq invocations — compliant.
+  [ "${#jq_files[@]}" -gt 0 ] || return 0
+
+  # Phase 2: for each file with jq invocations, verify a preflight guard exists.
+  # Acceptable preflight forms:
+  #   command -v jq    — POSIX-portable availability check
+  #   which jq         — non-POSIX but common fallback
+  local violations=()
+  for f in "${jq_files[@]}"; do
+    local rel="${f#${wave_handoff_skill_dir}/}"
+    if ! grep -qE 'command[[:space:]]+-v[[:space:]]+jq|which[[:space:]]+jq' "$f" 2>/dev/null; then
+      local hits
+      hits="$(grep -nE '(^[[:space:]]*jq([[:space:]]|$)|[|;&][[:space:]]*jq([[:space:]]|$)|\$[(]jq([[:space:]]|$)|`jq([[:space:]]|$)|(xargs|if|then|do|else|elif|time|env|command|sudo)[[:space:]]+jq([[:space:]]|$)|xargs([[:space:]]+-[^[:space:]]+)+[[:space:]]+jq([[:space:]]|$))' \
+              "$f" 2>/dev/null || true)"
+      while IFS= read -r hit; do
+        violations+=("${rel}: jq invocation without preflight: ${hit}")
+      done <<< "$hits"
+    fi
+  done
+
+  if [ "${#violations[@]}" -gt 0 ]; then
+    echo "FAIL (AC-005): bare jq invocation without preflight guard found in wave-handoff scripts." >&2
+    echo "  Fix: add preflight before first jq use:" >&2
+    echo "    command -v jq >/dev/null 2>&1 || { echo 'ERROR: jq is required; install with brew install jq' >&2; exit 1; }" >&2
+    echo "  Violations:" >&2
+    local v
+    for v in "${violations[@]}"; do echo "  ${v}" >&2; done
+    false
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # test_BC_5_41_001_F_P11_001_bsd_classify_stories_has_next_wave
 # F-P11-001 behavioral regression
 # When sprint-state.yaml contains a story with status: pending (has-next-wave),

--- a/plugins/vsdd-factory/tests/wave-handoff.bats
+++ b/plugins/vsdd-factory/tests/wave-handoff.bats
@@ -4420,10 +4420,12 @@ EOF
 #   do IFS='|'               — keyword-prefixed global mutation (O-P4-003)
 #   else IFS='|'             — keyword-prefixed global mutation (O-P4-003)
 #   elif IFS='|'             — keyword-prefixed global mutation (O-P4-003)
+#   { IFS=$'\n'; read x; }  — brace-group current-shell mutation (O-1)
+#   case $x in p) IFS='|'   — case-pattern body current-shell mutation (O-1)
 #
-# Detection: three-step filter — step-1 anchors on line-start/separator/operator/keyword
-# before IFS=; step-2 excludes local-scoped and subshell-open forms; step-3 excludes
-# command-prefix-to-read forms.
+# Detection: three-step filter — step-1 anchors on line-start/separator/operator/keyword/
+# brace-group-open/case-pattern-close before IFS=; step-2 excludes local-scoped and
+# subshell-open forms; step-3 excludes command-prefix-to-read forms.
 #
 # Red Gate expectation: PASS (global IFS mutation removed in S-18.01 merge 2b40dfd5).
 # ---------------------------------------------------------------------------
@@ -4455,7 +4457,7 @@ EOF
   #   [^[:space:]]* crosses ; so 'IFS='|'; read x' was wrongly excluded.
   # NEW (safe — stops at ;, &, |): 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)'
   #
-  # Step-1 pattern (extended): (^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]])[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=
+  # Step-1 pattern (extended): (^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=
   #   ^                   — bare global assignment at start of line
   #   ;                   — second statement on same line (cmd; IFS=)
   #   &&                  — operator-prefixed: cmd && IFS='|' (O-P4-003)
@@ -4463,12 +4465,19 @@ EOF
   #                          is consumed as a unit first; plain 'cmd &' without IFS= cannot match
   #   ||                  — operator-prefixed: cmd || IFS='|' (O-P4-003)
   #   then|do|else|elif   — keyword-prefixed: then IFS='|', else IFS='|', etc. (O-P4-003)
+  #   \{[[:space:]]+      — brace-group current-shell: { IFS=$'\n'; ... } (O-1)
+  #                          requires at least one space after { (bash syntax requires it);
+  #                          distinguishes from ${IFS...} param expansion (no space after {)
+  #   [)][[:space:]]+     — case-pattern body: case $x in p) IFS='|' ;; (O-1)
+  #                          requires at least one space after ); benign forms like foo() {
+  #                          are not followed by IFS= and do not match
   #   export/readonly/declare -g prefixes — keyword-prefixed global mutations
   # Step-2 (exclude): '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' — local scoped / subshell-open
   # Step-3 (exclude): 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' — command-prefix for read
   #   [^[:space:];&|]* — matches only non-separator chars; stops at ; & | before crossing them
   local pc_bad_ifs pc_bad_export_ifs pc_bad_semi_ifs pc_bad_semi_read pc_good_local_ifs pc_good_prefix_ifs
   local pc_bad_readonly_ifs pc_bad_declare_g_ifs pc_bad_and_ifs pc_bad_then_ifs pc_bad_bg_ifs
+  local pc_bad_brace_ifs pc_bad_case_ifs pc_good_func_def_brace pc_good_close_paren_no_ifs
   pc_bad_ifs="${BATS_TEST_TMPDIR}/pc_ac003_bad_ifs.sh"
   pc_bad_export_ifs="${BATS_TEST_TMPDIR}/pc_ac003_bad_export.sh"
   pc_bad_semi_ifs="${BATS_TEST_TMPDIR}/pc_ac003_bad_semi.sh"
@@ -4480,6 +4489,10 @@ EOF
   pc_bad_and_ifs="${BATS_TEST_TMPDIR}/pc_ac003_bad_and.sh"
   pc_bad_then_ifs="${BATS_TEST_TMPDIR}/pc_ac003_bad_then.sh"
   pc_bad_bg_ifs="${BATS_TEST_TMPDIR}/pc_ac003_bad_bg.sh"
+  pc_bad_brace_ifs="${BATS_TEST_TMPDIR}/pc_ac003_bad_brace.sh"
+  pc_bad_case_ifs="${BATS_TEST_TMPDIR}/pc_ac003_bad_case.sh"
+  pc_good_func_def_brace="${BATS_TEST_TMPDIR}/pc_ac003_good_func_def.sh"
+  pc_good_close_paren_no_ifs="${BATS_TEST_TMPDIR}/pc_ac003_good_close_paren.sh"
   printf "IFS='|'\n" > "$pc_bad_ifs"
   printf "export IFS='|'\n" > "$pc_bad_export_ifs"
   printf "cmd; IFS='|'\n" > "$pc_bad_semi_ifs"
@@ -4491,9 +4504,17 @@ EOF
   printf "cmd && IFS='|'\n" > "$pc_bad_and_ifs"
   printf "then IFS='|'\n" > "$pc_bad_then_ifs"
   printf "cmd & IFS='|'\n" > "$pc_bad_bg_ifs"
+  # Brace-group: current-shell mutation (bash requires space after { so { IFS=... is unambiguous)
+  printf '{ IFS=$'"'"'\\n'"'"'; read x; }\n' > "$pc_bad_brace_ifs"
+  # Case-pattern body: ') IFS=|' in a case action body (current-shell)
+  printf "case \$x in foo) IFS='|' ;; esac\n" > "$pc_bad_case_ifs"
+  # GOOD: function definition brace: 'foo() {' — the { is not followed by IFS= (must NOT match)
+  printf "foo() { echo hello; }\n" > "$pc_good_func_def_brace"
+  # GOOD: closing paren without IFS=: 'result=$(cmd); echo $result' — ) not followed by IFS=
+  printf 'result=$(cmd); echo "$result"\n' > "$pc_good_close_paren_no_ifs"
   # BAD: bare global IFS= MUST pass through the three-step filter (produces a violation).
   local pc_bad_ifs_hits
-  pc_bad_ifs_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]])[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_ifs" 2>/dev/null \
+  pc_bad_ifs_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_ifs" 2>/dev/null \
     | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
     | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
     || true)"
@@ -4503,7 +4524,7 @@ EOF
   }
   # BAD: 'export IFS=' MUST be flagged (keyword-prefixed global mutation).
   local pc_bad_export_hits
-  pc_bad_export_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]])[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_export_ifs" 2>/dev/null \
+  pc_bad_export_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_export_ifs" 2>/dev/null \
     | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
     | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
     || true)"
@@ -4513,7 +4534,7 @@ EOF
   }
   # BAD: 'cmd; IFS=' MUST be flagged (second-statement global mutation).
   local pc_bad_semi_hits
-  pc_bad_semi_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]])[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_semi_ifs" 2>/dev/null \
+  pc_bad_semi_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_semi_ifs" 2>/dev/null \
     | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
     | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
     || true)"
@@ -4526,7 +4547,7 @@ EOF
   # class to not cross statement separators).  The old [^[:space:]]* would cross the ';' and
   # wrongly exclude this as if it were 'IFS=... read'.
   local pc_bad_semi_read_hits
-  pc_bad_semi_read_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]])[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_semi_read" 2>/dev/null \
+  pc_bad_semi_read_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_semi_read" 2>/dev/null \
     | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
     | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
     || true)"
@@ -4538,7 +4559,7 @@ EOF
   }
   # GOOD: 'local IFS=' MUST be excluded by the filter (no violation).
   local pc_good_local_hits
-  pc_good_local_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]])[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_good_local_ifs" 2>/dev/null \
+  pc_good_local_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_good_local_ifs" 2>/dev/null \
     | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
     | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
     || true)"
@@ -4549,7 +4570,7 @@ EOF
   # GOOD: 'IFS=... read' command-prefix MUST be excluded by the filter (no violation).
   # This is the legitimate command-prefix form (e.g., IFS=',' read -ra arr).
   local pc_good_prefix_hits
-  pc_good_prefix_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]])[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_good_prefix_ifs" 2>/dev/null \
+  pc_good_prefix_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_good_prefix_ifs" 2>/dev/null \
     | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
     | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
     || true)"
@@ -4560,7 +4581,7 @@ EOF
   # BAD (O-P4-002): 'readonly IFS=' MUST be flagged (keyword-prefixed global mutation).
   # This exercises the readonly[[:space:]]+ arm of the optional-keyword group in step-1.
   local pc_bad_readonly_hits
-  pc_bad_readonly_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]])[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_readonly_ifs" 2>/dev/null \
+  pc_bad_readonly_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_readonly_ifs" 2>/dev/null \
     | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
     | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
     || true)"
@@ -4572,7 +4593,7 @@ EOF
   # BAD (O-P4-002): 'declare -g IFS=' MUST be flagged (declare -g global mutation).
   # This exercises the declare[[:space:]]+-g[[:space:]]+ arm in step-1.
   local pc_bad_declare_g_hits
-  pc_bad_declare_g_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]])[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_declare_g_ifs" 2>/dev/null \
+  pc_bad_declare_g_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_declare_g_ifs" 2>/dev/null \
     | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
     | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
     || true)"
@@ -4584,7 +4605,7 @@ EOF
   # BAD (O-P4-003): 'cmd && IFS=' MUST be flagged (operator-prefixed global mutation).
   # This exercises the new && arm added to step-1 to catch operator-chained mutations.
   local pc_bad_and_hits
-  pc_bad_and_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]])[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_and_ifs" 2>/dev/null \
+  pc_bad_and_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_and_ifs" 2>/dev/null \
     | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
     | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
     || true)"
@@ -4596,7 +4617,7 @@ EOF
   # BAD (O-P4-003): 'then IFS=' MUST be flagged (keyword-prefixed global mutation).
   # This exercises the (then|do|else|elif)[[:space:]] arm added to step-1.
   local pc_bad_then_hits
-  pc_bad_then_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]])[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_then_ifs" 2>/dev/null \
+  pc_bad_then_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_then_ifs" 2>/dev/null \
     | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
     | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
     || true)"
@@ -4611,7 +4632,7 @@ EOF
   # step-1 so that '&&' is consumed as a unit first; plain 'cmd &' without a following
   # IFS= cannot satisfy the remainder of the regex and is NOT a false positive.
   local pc_bad_bg_hits
-  pc_bad_bg_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]])[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_bg_ifs" 2>/dev/null \
+  pc_bad_bg_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_bg_ifs" 2>/dev/null \
     | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
     | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
     || true)"
@@ -4621,15 +4642,71 @@ EOF
     echo "  consumed as a unit first; AC-005's jq detector already includes & per [|;&])." >&2
     false
   }
+  # BAD (O-1): '{ IFS=$'\n'; read x; }' MUST be flagged (brace-group current-shell mutation).
+  # A brace group runs in the current shell (unlike a subshell), so IFS mutation inside it
+  # persists globally.  bash syntax requires at least one space after '{', which distinguishes
+  # it from '${IFS...}' parameter expansion (no space after '{').
+  local pc_bad_brace_hits
+  pc_bad_brace_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_brace_ifs" 2>/dev/null \
+    | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
+    | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+    || true)"
+  [ -n "$pc_bad_brace_hits" ] || {
+    echo "FAIL (AC-003 positive-control / O-1): IFS-detector did not flag '{ IFS=\$'\\n'; read x; }' (brace-group current-shell mutation)." >&2
+    echo "  The \\{[[:space:]]+ arm of step-1 must fire for brace-group-leading IFS= assignments." >&2
+    false
+  }
+  # BAD (O-1): 'case $x in foo) IFS='|' ;; esac' MUST be flagged (case-pattern body mutation).
+  # Case-pattern action bodies run in the current shell, so 'p) IFS=...' is a global mutation.
+  # The [)][[:space:]]+ arm requires at least one space after ')' to distinguish from
+  # function-definition patterns like 'foo() {' where ')' is not followed by IFS=.
+  local pc_bad_case_hits
+  pc_bad_case_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_case_ifs" 2>/dev/null \
+    | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
+    | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+    || true)"
+  [ -n "$pc_bad_case_hits" ] || {
+    echo "FAIL (AC-003 positive-control / O-1): IFS-detector did not flag 'case \$x in foo) IFS=|' (case-pattern body mutation)." >&2
+    echo "  The [)][[:space:]]+ arm of step-1 must fire for case-action-body IFS= assignments." >&2
+    false
+  }
+  # GOOD (O-1 negative control): 'foo() { echo hello; }' MUST NOT be flagged.
+  # The '{' in a function definition is followed by a space and then a NON-IFS= command,
+  # so the \{[[:space:]]+ arm does not produce a false positive.
+  local pc_good_func_def_hits
+  pc_good_func_def_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_good_func_def_brace" 2>/dev/null \
+    | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
+    | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+    || true)"
+  [ -z "$pc_good_func_def_hits" ] || {
+    echo "FAIL (AC-003 negative-control / O-1): IFS-detector falsely flagged 'foo() { echo hello; }' (function definition brace must be exempt)." >&2
+    echo "  The \\{[[:space:]]+ arm fires only when { is immediately followed (with optional space) by IFS=." >&2
+    false
+  }
+  # GOOD (O-1 negative control): 'result=$(cmd); echo $result' MUST NOT be flagged.
+  # The closing ')' of a command substitution is not followed by IFS= on this line,
+  # so the [)][[:space:]]+ arm does not produce a false positive.
+  local pc_good_close_paren_hits
+  pc_good_close_paren_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_good_close_paren_no_ifs" 2>/dev/null \
+    | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
+    | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+    || true)"
+  [ -z "$pc_good_close_paren_hits" ] || {
+    echo "FAIL (AC-003 negative-control / O-1): IFS-detector falsely flagged 'result=\$(cmd); echo \$result' (close-paren not preceding IFS= must be exempt)." >&2
+    echo "  The [)][[:space:]]+ arm fires only when ) is followed (with optional space) by IFS=." >&2
+    false
+  }
   # -------------------------------------------
 
   # Detect global IFS= mutations at script or function scope.
   # Step 1 (extended): lines where IFS= appears at line-start, after a semicolon,
-  #         after an operator (&&, &, ||), or after a shell keyword (then/do/else/elif),
+  #         after an operator (&&, &, ||), after a shell keyword (then/do/else/elif),
+  #         after a brace-group open ({ ), or after a case-pattern close () ),
   #         optionally preceded by export/readonly/declare -g keywords.
-  #         — (^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]])[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=
+  #         — (^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=
   #         Catches: bare IFS=, export/readonly/declare -g IFS=, cmd; IFS=,
-  #         cmd && IFS=, cmd & IFS=, cmd || IFS=, then/do/else/elif IFS= (O-P4-003/O-2)
+  #         cmd && IFS=, cmd & IFS=, cmd || IFS=, then/do/else/elif IFS= (O-P4-003/O-2),
+  #         { IFS=... (brace-group current-shell), p) IFS=... (case-pattern body) (O-1)
   # Step 2: exclude "local IFS=" — locally scoped within a function body.
   # Step 3: exclude "(IFS=" — subshell-scoped (subshell open on same line as IFS=).
   # Step 4: exclude "IFS=<value> read" — command-prefix for the read builtin.
@@ -4642,7 +4719,7 @@ EOF
   for f in "${sh_files[@]}"; do
     local rel="${f#${wave_handoff_skill_dir}/}"
     local hits
-    hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]])[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$f" 2>/dev/null \
+    hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$f" 2>/dev/null \
       | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
       | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
       || true)"

--- a/plugins/vsdd-factory/tests/wave-handoff.bats
+++ b/plugins/vsdd-factory/tests/wave-handoff.bats
@@ -4367,6 +4367,17 @@ EOF
     echo "FAIL (AC-002 positive-control / O-1): case-modifier-detector did not match '\${v@u}' (bash-4.4 titlecase operator)." >&2
     false
   }
+  # O-3 addition: ${*^^} MUST match — isolates the * branch of the [@*#] class independently.
+  # bash-portability.md §2 states the [@*#] class covers *; this control verifies it explicitly.
+  # (${@^^} is already in pc_bad_positional; ${#^^} is in pc_bad_hash_modifier; ${*^^} was uncovered.)
+  local pc_bad_star_modifier
+  pc_bad_star_modifier="${BATS_TEST_TMPDIR}/pc_ac002_bad_star_modifier.sh"
+  printf 'echo "${*^^}"\n' > "$pc_bad_star_modifier"
+  grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?|@[ULu])' "$pc_bad_star_modifier" || {
+    echo "FAIL (AC-002 positive-control / O-3): case-modifier-detector did not match '\${*^^}' (star special param)." >&2
+    echo "  The [@*#] class must cover * as an independent branch; \${*^^} is bash 4+ only." >&2
+    false
+  }
   # Over-match guards: ${arr[@]} (array expand-all), ${BASH_SOURCE[0]}, ${var%%:*} MUST NOT match.
   # ${arr[@]}: the [@] is an array subscript consumed by the (\[[^]]*\])? group; no modifier follows.
   ! grep -qE '\$\{([a-zA-Z_][a-zA-Z0-9_]*|[0-9]+|[@*#])(\[[^]]*\])?(\^\^?|,,?|@[ULu])' "$pc_good_arr_expand" || {
@@ -4526,6 +4537,7 @@ EOF
   #   [^[:space:];&|]* — matches only non-separator chars; stops at ; & | before crossing them
   local pc_bad_ifs pc_bad_export_ifs pc_bad_semi_ifs pc_bad_semi_read pc_good_local_ifs pc_good_prefix_ifs
   local pc_bad_readonly_ifs pc_bad_declare_g_ifs pc_bad_and_ifs pc_bad_then_ifs pc_bad_bg_ifs
+  local pc_bad_or_ifs pc_bad_do_ifs pc_bad_else_ifs pc_bad_elif_ifs
   local pc_bad_brace_ifs pc_bad_case_ifs pc_good_func_def_brace pc_good_close_paren_no_ifs
   pc_bad_ifs="${BATS_TEST_TMPDIR}/pc_ac003_bad_ifs.sh"
   pc_bad_export_ifs="${BATS_TEST_TMPDIR}/pc_ac003_bad_export.sh"
@@ -4537,6 +4549,10 @@ EOF
   pc_bad_declare_g_ifs="${BATS_TEST_TMPDIR}/pc_ac003_bad_declare_g.sh"
   pc_bad_and_ifs="${BATS_TEST_TMPDIR}/pc_ac003_bad_and.sh"
   pc_bad_then_ifs="${BATS_TEST_TMPDIR}/pc_ac003_bad_then.sh"
+  pc_bad_or_ifs="${BATS_TEST_TMPDIR}/pc_ac003_bad_or.sh"
+  pc_bad_do_ifs="${BATS_TEST_TMPDIR}/pc_ac003_bad_do.sh"
+  pc_bad_else_ifs="${BATS_TEST_TMPDIR}/pc_ac003_bad_else.sh"
+  pc_bad_elif_ifs="${BATS_TEST_TMPDIR}/pc_ac003_bad_elif.sh"
   pc_bad_bg_ifs="${BATS_TEST_TMPDIR}/pc_ac003_bad_bg.sh"
   pc_bad_brace_ifs="${BATS_TEST_TMPDIR}/pc_ac003_bad_brace.sh"
   pc_bad_case_ifs="${BATS_TEST_TMPDIR}/pc_ac003_bad_case.sh"
@@ -4552,6 +4568,10 @@ EOF
   printf "declare -g IFS='|'\n" > "$pc_bad_declare_g_ifs"
   printf "cmd && IFS='|'\n" > "$pc_bad_and_ifs"
   printf "then IFS='|'\n" > "$pc_bad_then_ifs"
+  printf "cmd || IFS='|'\n" > "$pc_bad_or_ifs"
+  printf "do IFS='|'\n" > "$pc_bad_do_ifs"
+  printf "else IFS='|'\n" > "$pc_bad_else_ifs"
+  printf "elif IFS='|'\n" > "$pc_bad_elif_ifs"
   printf "cmd & IFS='|'\n" > "$pc_bad_bg_ifs"
   # Brace-group: current-shell mutation (bash requires space after { so { IFS=... is unambiguous)
   printf '{ IFS=$'"'"'\\n'"'"'; read x; }\n' > "$pc_bad_brace_ifs"
@@ -4675,6 +4695,54 @@ EOF
     echo "  The (then|do|else|elif)[[:space:]] arm must be in step-1's outer alternation group." >&2
     false
   }
+  # BAD (F-P13-001): 'cmd || IFS=' MUST be flagged (operator-prefixed global mutation via ||).
+  # The [|][|] arm catches the OR-operator form which was previously UNcovered by a positive control.
+  local pc_bad_or_hits
+  pc_bad_or_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_or_ifs" 2>/dev/null \
+    | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
+    | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+    || true)"
+  [ -n "$pc_bad_or_hits" ] || {
+    echo "FAIL (AC-003 positive-control / F-P13-001): IFS-detector did not flag 'cmd || IFS=|' (OR-operator global mutation)." >&2
+    echo "  The [|][|] arm must be in step-1's outer alternation group." >&2
+    false
+  }
+  # BAD (F-P13-001): 'do IFS=' MUST be flagged (keyword-prefixed global mutation).
+  # This exercises the 'do' arm of (then|do|else|elif)[[:space:]] — previously UNcovered.
+  local pc_bad_do_hits
+  pc_bad_do_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_do_ifs" 2>/dev/null \
+    | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
+    | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+    || true)"
+  [ -n "$pc_bad_do_hits" ] || {
+    echo "FAIL (AC-003 positive-control / F-P13-001): IFS-detector did not flag 'do IFS=|' (keyword-prefixed global mutation)." >&2
+    echo "  The 'do' branch of (then|do|else|elif)[[:space:]] must fire." >&2
+    false
+  }
+  # BAD (F-P13-001): 'else IFS=' MUST be flagged (keyword-prefixed global mutation).
+  # This exercises the 'else' arm — previously UNcovered.
+  local pc_bad_else_hits
+  pc_bad_else_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_else_ifs" 2>/dev/null \
+    | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
+    | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+    || true)"
+  [ -n "$pc_bad_else_hits" ] || {
+    echo "FAIL (AC-003 positive-control / F-P13-001): IFS-detector did not flag 'else IFS=|' (keyword-prefixed global mutation)." >&2
+    echo "  The 'else' branch of (then|do|else|elif)[[:space:]] must fire." >&2
+    false
+  }
+  # BAD (F-P13-001): 'elif IFS=' MUST be flagged (keyword-prefixed global mutation).
+  # This exercises the 'elif' arm — previously UNcovered.
+  local pc_bad_elif_hits
+  pc_bad_elif_hits="$(grep -nE '(^|;|&&|&|[|][|]|(then|do|else|elif)[[:space:]]|\{[[:space:]]+|[)][[:space:]]+)[[:space:]]*(export[[:space:]]+|readonly[[:space:]]+|declare[[:space:]]+-g[[:space:]]+)?IFS=' "$pc_bad_elif_ifs" 2>/dev/null \
+    | grep -vE '^[0-9]+:[[:space:]]*(local[[:space:]]|[(])' \
+    | grep -vE 'IFS=[^[:space:];&|]*[[:space:]]+read([[:space:]]|$)' \
+    || true)"
+  [ -n "$pc_bad_elif_hits" ] || {
+    echo "FAIL (AC-003 positive-control / F-P13-001): IFS-detector did not flag 'elif IFS=|' (keyword-prefixed global mutation)." >&2
+    echo "  The 'elif' branch of (then|do|else|elif)[[:space:]] must fire." >&2
+    false
+  }
   # BAD (O-2): 'cmd & IFS=' MUST be flagged (background+global mutation).
   # Backgrounding a command and then assigning IFS globally on the same line mutates the
   # shell's IFS just as a standalone assignment does.  The & arm is listed after && in
@@ -4796,26 +4864,28 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# test_portability_no_undeclared_pyyaml_dep
-# AC-004: undeclared Python/PyYAML runtime dependency.
-# S-18.01 hit "externally managed environment" PEP 668 error on macOS GitHub Actions
-# when pip tried to install pyyaml (aaa8da8a). The --break-system-packages workaround
-# (3fe11ea1) is NOT accepted as a long-term resolution in wave-handoff scripts.
+# test_portability_no_python_shellout
+# AC-004: Python or pip shell-out prohibition (F-P11-001 Option A redesign).
+# SKILL.md §149: "This skill MUST NOT shell out to Python, jq, or any language
+# runtime beyond bash." Python is treated identically to jq — ANY python/pip
+# invocation in a command position is a violation.
 #
-# O-3 broadening (POLICY 13 prospective): python arm uses python[0-9.]* (was python[23]?)
-# to catch versioned binaries like python3.11 and python3.12 which are common on modern
-# macOS and Linux CI images and were missed by the [23]? class.
+# F-P11-001 Option A: no preflight-acceptance and no stdlib exemption.
+#   - The former phase-2 preflight-acceptance (python3 -c "import yaml" guard) is REMOVED.
+#   - The former EC-002 stdlib exemption (python3 -c "import json" was PASS) is REMOVED.
+#   - python3 -c 'import json' is now a VIOLATION, same as python3 -c 'import yaml'.
+#   - The fix is REMOVAL of the python/pip invocation, not the addition of a guard.
 #
-# EC-002: python3 -c "import json; ..." is fine — json is a stdlib module, no pip
-# install is needed. Only external packages (pyyaml, yaml) are flagged.
+# Detection: command-position anchoring analogous to jq_re (AC-005). Detects
+# python[0-9.]* and pip[0-9x]* as command tokens in all execution positions:
+# line-start, after ;/&&/&/||, $(...), backtick, brace-group, case-pattern body,
+# subshell, and keyword/wrapper positions (xargs/if/then/do/else/elif/time/env/
+# command/sudo).
 #
-# Scan: if any wave-handoff script invokes python (any version) with yaml/pyyaml or
-# pip-installs pyyaml, it MUST have a preflight check. Absence = compliant.
-#
-# Red Gate expectation: PASS (pyyaml dep removed / never added post-S-18.01 merge).
+# Red Gate expectation: PASS (no python/pip invocations present; absent = compliant).
 # ---------------------------------------------------------------------------
 
-@test "test_portability_no_undeclared_pyyaml_dep" {
+@test "test_portability_no_python_shellout" {
   local wave_handoff_skill_dir
   wave_handoff_skill_dir="$(cd "${BATS_TEST_DIRNAME}/../skills/wave-handoff" && pwd)"
 
@@ -4831,158 +4901,136 @@ EOF
     false
   }
 
-  # --- POSITIVE-CONTROL ASSERTIONS (O-1) ---
-  # Verify the pyyaml/pip detector matches pip2/pip3/pipx and python/python2/python3+yaml
-  # forms, and does NOT match python3 stdlib-only usage (EC-002 exemption).
+  # --- POSITIVE-CONTROL ASSERTIONS ---
+  # Verify the python-shellout detector matches python/pip in all command positions,
+  # including stdlib python3 -c 'import json' (formerly exempt under EC-002, now a
+  # violation under F-P11-001 Option A), and does NOT match benign substrings like
+  # variable names starting with "python", comments, or "python" as an echo argument.
+  # python_re MUST BE BYTE-IDENTICAL to the real-scan-loop regex below.
   # Uses BATS_TEST_TMPDIR synthetic files; no real wave-handoff scripts are executed.
-  # F-P2-001 fix: pyyaml token is case-insensitive ([Pp][Yy][Yy][Aa][Mm][Ll]) to catch
-  # canonical PyPI capitalization "PyYAML" which evaded the lowercase-only detector.
-  # O-3 fix: python arm broadened from python[23]? to python[0-9.]* to catch versioned
-  # binaries like python3.11 and python3.12 (POLICY 13 prospective).
-  local pc_bad_pip3 pc_bad_pipx pc_bad_py2yaml pc_bad_pyyaml_canonical pc_bad_py311 pc_good_stdlib pc_bad_bsp
+  local python_re='(^[[:space:]]*(python[0-9.]*|pip[0-9x]*)([[:space:]]|$)|[|;&][[:space:]]*(python[0-9.]*|pip[0-9x]*)([[:space:]]|$)|\$[(](python[0-9.]*|pip[0-9x]*)([[:space:]]|$)|`(python[0-9.]*|pip[0-9x]*)([[:space:]]|$)|(xargs|if|then|do|else|elif|time|env|command|sudo)[[:space:]]+(python[0-9.]*|pip[0-9x]*)([[:space:]]|$)|xargs([[:space:]]+-[^[:space:]]+)+[[:space:]]+(python[0-9.]*|pip[0-9x]*)([[:space:]]|$)|\{[[:space:]]*(python[0-9.]*|pip[0-9x]*)([[:space:]]|$)|\)[[:space:]]*(python[0-9.]*|pip[0-9x]*)([[:space:]]|$)|\([[:space:]]*(python[0-9.]*|pip[0-9x]*)([[:space:]]|$))'
+
+  local pc_bad_py3 pc_bad_py2 pc_bad_pip3 pc_bad_pipx pc_bad_py311 pc_bad_stdlib
+  local pc_bad_py3_cmdsubst pc_bad_sudo_py3
+  local pc_good_py_var pc_good_comment pc_good_echo_py
+
+  pc_bad_py3="${BATS_TEST_TMPDIR}/pc_ac004_bad_py3.sh"
+  pc_bad_py2="${BATS_TEST_TMPDIR}/pc_ac004_bad_py2.sh"
   pc_bad_pip3="${BATS_TEST_TMPDIR}/pc_ac004_bad_pip3.sh"
   pc_bad_pipx="${BATS_TEST_TMPDIR}/pc_ac004_bad_pipx.sh"
-  pc_bad_py2yaml="${BATS_TEST_TMPDIR}/pc_ac004_bad_py2yaml.sh"
-  pc_bad_pyyaml_canonical="${BATS_TEST_TMPDIR}/pc_ac004_bad_pyyaml_canonical.sh"
   pc_bad_py311="${BATS_TEST_TMPDIR}/pc_ac004_bad_py311.sh"
-  pc_good_stdlib="${BATS_TEST_TMPDIR}/pc_ac004_good_stdlib.sh"
-  pc_bad_bsp="${BATS_TEST_TMPDIR}/pc_ac004_bad_bsp.sh"
-  printf 'pip3 install pyyaml\n' > "$pc_bad_pip3"
-  printf 'pipx install pyyaml\n' > "$pc_bad_pipx"
-  printf 'python2 -c "import yaml; yaml.safe_load(f)"\n' > "$pc_bad_py2yaml"
-  printf 'pip install PyYAML\n' > "$pc_bad_pyyaml_canonical"
+  pc_bad_stdlib="${BATS_TEST_TMPDIR}/pc_ac004_bad_stdlib.sh"
+  pc_bad_py3_cmdsubst="${BATS_TEST_TMPDIR}/pc_ac004_bad_py3_cmdsubst.sh"
+  pc_bad_sudo_py3="${BATS_TEST_TMPDIR}/pc_ac004_bad_sudo_py3.sh"
+  pc_good_py_var="${BATS_TEST_TMPDIR}/pc_ac004_good_py_var.sh"
+  pc_good_comment="${BATS_TEST_TMPDIR}/pc_ac004_good_comment.sh"
+  pc_good_echo_py="${BATS_TEST_TMPDIR}/pc_ac004_good_echo_py.sh"
+
+  printf 'python3 script.py\n' > "$pc_bad_py3"
+  printf 'python2 -c "import os; os.system(\"id\")"\n' > "$pc_bad_py2"
+  printf 'pip3 install requests\n' > "$pc_bad_pip3"
+  printf 'pipx run cowsay hello\n' > "$pc_bad_pipx"
   printf 'python3.11 -c "import yaml; print(yaml.safe_load(open(f)))"\n' > "$pc_bad_py311"
-  printf 'python3 -c "import json; print(json.load(open(f)))"\n' > "$pc_good_stdlib"
-  printf 'pip install pyyaml --break-system-packages\n' > "$pc_bad_bsp"
-  local dep_re='(python[0-9.]*[[:space:]].*[Yy][Aa][Mm][Ll]|pip[0-9x]*[[:space:]].*[Pp][Yy][Yy][Aa][Mm][Ll]|import[[:space:]]+yaml)'
-  # BAD: pip3 MUST be detected.
-  grep -qE "$dep_re" "$pc_bad_pip3" || {
-    echo "FAIL (AC-004 positive-control): pyyaml-detector did not match 'pip3 install pyyaml'." >&2
+  # F-P11-001 Option A: stdlib python invocation is NOW a violation (EC-002 exemption removed).
+  # This fixture was formerly a GOOD/negative control; it is now a BAD/positive control.
+  printf "python3 -c 'import json; print(json.load(open(f)))'\n" > "$pc_bad_stdlib"
+  printf 'result=$(python3 compute.py)\n' > "$pc_bad_py3_cmdsubst"
+  printf 'sudo python3 /usr/local/bin/setup.py\n' > "$pc_bad_sudo_py3"
+  # GOOD: variable name starting with 'python' — NOT a command invocation.
+  # python_bin=python3.11 has 'python_bin' at line-start; 'python[0-9.]*([[:space:]]|$)'
+  # does not match because '_bin' immediately follows 'python', not space/EOL.
+  printf 'python_bin=python3.11\n' > "$pc_good_py_var"
+  # GOOD: comment mentioning python3 — NOT a command invocation.
+  printf '# python3 is not used in this script\n' > "$pc_good_comment"
+  # GOOD: python3 as argument to echo — NOT a command invocation.
+  printf 'echo "install python3 first"\n' > "$pc_good_echo_py"
+
+  # BAD: bare line-start 'python3 script.py' MUST be detected.
+  grep -qE "$python_re" "$pc_bad_py3" || {
+    echo "FAIL (AC-004 positive-control): python-detector did not match bare 'python3 script.py' (line-start)." >&2
     false
   }
-  # BAD: pipx MUST be detected.
-  grep -qE "$dep_re" "$pc_bad_pipx" || {
-    echo "FAIL (AC-004 positive-control): pyyaml-detector did not match 'pipx install pyyaml'." >&2
+  # BAD: 'python2 ...' MUST be detected.
+  grep -qE "$python_re" "$pc_bad_py2" || {
+    echo "FAIL (AC-004 positive-control): python-detector did not match 'python2 ...' (line-start)." >&2
     false
   }
-  # BAD: python2+yaml MUST be detected.
-  grep -qE "$dep_re" "$pc_bad_py2yaml" || {
-    echo "FAIL (AC-004 positive-control): pyyaml-detector did not match 'python2 ... yaml'." >&2
+  # BAD: 'pip3 install ...' MUST be detected.
+  grep -qE "$python_re" "$pc_bad_pip3" || {
+    echo "FAIL (AC-004 positive-control): python-detector did not match 'pip3 install ...' (line-start)." >&2
     false
   }
-  # BAD: 'pip install PyYAML' (canonical PyPI capitalization) MUST be detected (F-P2-001).
-  grep -qE "$dep_re" "$pc_bad_pyyaml_canonical" || {
-    echo "FAIL (AC-004 positive-control): pyyaml-detector did not match 'pip install PyYAML' (canonical capitalization)." >&2
-    echo "  F-P2-001: the pip arm must use [Pp][Yy][Yy][Aa][Mm][Ll] to catch mixed-case PyPI name." >&2
+  # BAD: 'pipx run ...' MUST be detected.
+  grep -qE "$python_re" "$pc_bad_pipx" || {
+    echo "FAIL (AC-004 positive-control): python-detector did not match 'pipx run ...' (line-start)." >&2
     false
   }
-  # BAD (O-3): 'python3.11 ... yaml' MUST be detected — versioned python binaries were missed
-  # by python[23]? which does not match the decimal point in '3.11'.
-  grep -qE "$dep_re" "$pc_bad_py311" || {
-    echo "FAIL (AC-004 positive-control / O-3): pyyaml-detector did not match 'python3.11 -c \"import yaml\"'." >&2
-    echo "  The python arm must use python[0-9.]* (not python[23]?) to cover versioned binaries." >&2
+  # BAD: 'python3.11 -c ...' (versioned binary) MUST be detected.
+  grep -qE "$python_re" "$pc_bad_py311" || {
+    echo "FAIL (AC-004 positive-control): python-detector did not match 'python3.11 -c ...' (versioned binary)." >&2
+    echo "  python[0-9.]* must match version-suffixed binaries." >&2
     false
   }
-  # GOOD (EC-002): python3 stdlib-only usage MUST NOT be detected.
-  ! grep -qE "$dep_re" "$pc_good_stdlib" || {
-    echo "FAIL (AC-004 positive-control): pyyaml-detector falsely matched python3 stdlib-only usage." >&2
+  # BAD (F-P11-001 Option A stdlib flip): python3 -c 'import json' MUST now be detected.
+  # Previously this was a PASS (EC-002 stdlib exemption); under F-P11-001 Option A any
+  # python shell-out is a violation — stdlib usage is no longer exempt.
+  grep -qE "$python_re" "$pc_bad_stdlib" || {
+    echo "FAIL (AC-004 positive-control / F-P11-001): python-detector did not match 'python3 -c ...import json...' (stdlib)." >&2
+    echo "  F-P11-001 Option A removes EC-002: any python shell-out is a violation, stdlib included." >&2
     false
   }
-  # BAD (--break-system-packages): bsp-detector MUST match.
-  grep -qE '\-\-break-system-packages' "$pc_bad_bsp" || {
-    echo "FAIL (AC-004 positive-control): bsp-detector did not match '--break-system-packages'." >&2
+  # BAD: '\$(python3 ...)' command-substitution MUST be detected.
+  grep -qE "$python_re" "$pc_bad_py3_cmdsubst" || {
+    echo "FAIL (AC-004 positive-control): python-detector did not match '\$(python3 ...)' command-substitution." >&2
     false
   }
-  # GOOD (O-P4-001): a script with 'python3.11 -c "import yaml"' as its preflight MUST be ACCEPTED.
-  # Phase-1 would catch this file (has python3.11 ... yaml); phase-2 must recognize the versioned
-  # preflight as acceptable — this tests the broadened python[0-9.]* acceptance arm.
-  local pc_good_py311_preflight
-  pc_good_py311_preflight="${BATS_TEST_TMPDIR}/pc_ac004_good_py311_preflight.sh"
-  printf 'python3.11 -c "import yaml" 2>/dev/null || { echo "pyyaml required" >&2; exit 1; }\n' > "$pc_good_py311_preflight"
-  printf 'python3.11 -c "import yaml; print(yaml.safe_load(open(f)))"\n' >> "$pc_good_py311_preflight"
-  # Phase-2 acceptance regex (broadened, O-2): python[0-9.]* -c ["']import yaml["'] OR command -v python[0-9.]*
-  # Accepts both double-quoted and single-quoted forms of the preflight guard.
-  grep -qE "(python[0-9.]*[[:space:]]+-c[[:space:]]+[\"']import yaml[\"']|command[[:space:]]+-v[[:space:]]+python[0-9.]*)" "$pc_good_py311_preflight" || {
-    echo "FAIL (AC-004 positive-control / O-P4-001): broadened phase-2 acceptance regex did NOT match 'python3.11 -c \"import yaml\"' preflight." >&2
-    echo "  The phase-2 acceptance arm must use python[0-9.]* (not python3) to accept versioned binaries." >&2
+  # BAD: 'sudo python3 ...' MUST be detected (keyword wrapper arm).
+  grep -qE "$python_re" "$pc_bad_sudo_py3" || {
+    echo "FAIL (AC-004 positive-control): python-detector did not match 'sudo python3 ...' (keyword wrapper)." >&2
+    echo "  sudo must be in the wrapper keyword group for the python detector." >&2
     false
   }
-  # GOOD (O-2): a script with single-quoted preflight 'python3 -c '\''import yaml'\''' MUST be ACCEPTED.
-  # The phase-2 regex previously hardcoded double-quotes; single-quoted guards are equally valid.
-  local pc_good_singlequote_preflight
-  pc_good_singlequote_preflight="${BATS_TEST_TMPDIR}/pc_ac004_good_singlequote_preflight.sh"
-  printf "python3 -c 'import yaml' 2>/dev/null || { echo 'pyyaml required' >&2; exit 1; }\n" > "$pc_good_singlequote_preflight"
-  printf "python3 -c 'import yaml; print(yaml.safe_load(open(f)))'\n" >> "$pc_good_singlequote_preflight"
-  grep -qE "(python[0-9.]*[[:space:]]+-c[[:space:]]+[\"']import yaml[\"']|command[[:space:]]+-v[[:space:]]+python[0-9.]*)" "$pc_good_singlequote_preflight" || {
-    echo "FAIL (AC-004 positive-control / O-2): phase-2 acceptance regex did NOT match single-quoted preflight 'python3 -c '\"'\"'import yaml'\"'\"''." >&2
-    echo "  O-2: the phase-2 acceptance arm must accept both single and double quotes around 'import yaml'." >&2
-    echo "  Use [\"']import yaml[\"'] (or equivalent) to match both quote forms." >&2
+  # GOOD: 'python_bin=python3.11' variable assignment MUST NOT be detected.
+  ! grep -qE "$python_re" "$pc_good_py_var" || {
+    echo "FAIL (AC-004 negative-control): python-detector falsely matched 'python_bin=python3.11' (variable assignment)." >&2
+    echo "  The detector anchors on command position; 'python_bin' starts with 'python' but has '_bin' next, not space/EOL." >&2
+    false
+  }
+  # GOOD: '# python3 is not used' comment MUST NOT be detected.
+  ! grep -qE "$python_re" "$pc_good_comment" || {
+    echo "FAIL (AC-004 negative-control): python-detector falsely matched python3 inside a comment." >&2
+    false
+  }
+  # GOOD: 'echo "install python3 first"' MUST NOT be detected (python3 is an argument, not a command).
+  ! grep -qE "$python_re" "$pc_good_echo_py" || {
+    echo "FAIL (AC-004 negative-control): python-detector falsely matched 'echo \"install python3 first\"'." >&2
+    echo "  python3 as an argument to echo is not a python shell-out." >&2
     false
   }
   # -------------------------------------------
 
-  # Phase 1: detect any python/python2/python3/python3.11+yaml or pip/pip2/pip3/pipx+pyyaml invocations.
-  # EC-002 exception: python3 using only stdlib modules (json, os, sys, re, etc.) is fine.
-  # We flag: import yaml / pyyaml (case-insensitive) / pip[0-9x]* install PyYAML / python[0-9.]* ... yaml.
-  # O-3: python arm uses python[0-9.]* to catch versioned binaries like python3.11/python3.12.
-  # F-P2-001: pyyaml token uses [Pp][Yy][Yy][Aa][Mm][Ll] to catch canonical "PyYAML" capitalization.
-  local dep_files=()
+  # Scan: detect any python/pip invocation in a command position.
+  # Any match is a violation — SKILL.md §149 forbids all python shell-outs; no exemptions.
+  # F-P11-001 Option A: single-phase detection; phase-2 preflight-acceptance removed.
+  local violations=()
   local f
   for f in "${sh_files[@]}"; do
-    if grep -qE '(python[0-9.]*[[:space:]].*[Yy][Aa][Mm][Ll]|pip[0-9x]*[[:space:]].*[Pp][Yy][Yy][Aa][Mm][Ll]|import[[:space:]]+yaml)' \
-        "$f" 2>/dev/null; then
-      dep_files+=("$f")
-    fi
-  done
-
-  # No python/pyyaml invocations — compliant (EC-002: stdlib-only python3 is fine).
-  if [ "${#dep_files[@]}" -eq 0 ]; then
-    echo "AC-004: scanned=${#sh_files[@]} files"
-    return 0
-  fi
-
-  # Phase 2: for each file with a pyyaml/python-yaml invocation, audit for acceptability.
-  # Unacceptable form: --break-system-packages (PEP 668 workaround; not a long-term fix).
-  # Acceptable alternatives: python[0-9.]* -c ["']import yaml["'] preflight OR awk-based YAML parsing.
-  # O-P4-001: broadened from python3 to python[0-9.]* so versioned preflights like
-  # 'python3.11 -c "import yaml"' and 'command -v python3.11' are recognized as valid guards.
-  # O-2: broadened from double-quote-only to ["']import yaml["'] so single-quoted preflights
-  # like python3 -c 'import yaml' are also recognized (previously caused false FAIL).
-  local violations=()
-  for f in "${dep_files[@]}"; do
     local rel="${f#${wave_handoff_skill_dir}/}"
-
-    # Flag --break-system-packages explicitly (canonical unacceptable workaround per AC-004)
-    local bsp_hits
-    bsp_hits="$(grep -nE '\-\-break-system-packages' "$f" 2>/dev/null || true)"
-    if [ -n "$bsp_hits" ]; then
+    local hits
+    hits="$(grep -nE '(^[[:space:]]*(python[0-9.]*|pip[0-9x]*)([[:space:]]|$)|[|;&][[:space:]]*(python[0-9.]*|pip[0-9x]*)([[:space:]]|$)|\$[(](python[0-9.]*|pip[0-9x]*)([[:space:]]|$)|`(python[0-9.]*|pip[0-9x]*)([[:space:]]|$)|(xargs|if|then|do|else|elif|time|env|command|sudo)[[:space:]]+(python[0-9.]*|pip[0-9x]*)([[:space:]]|$)|xargs([[:space:]]+-[^[:space:]]+)+[[:space:]]+(python[0-9.]*|pip[0-9x]*)([[:space:]]|$)|\{[[:space:]]*(python[0-9.]*|pip[0-9x]*)([[:space:]]|$)|\)[[:space:]]*(python[0-9.]*|pip[0-9x]*)([[:space:]]|$)|\([[:space:]]*(python[0-9.]*|pip[0-9x]*)([[:space:]]|$))' \
+        "$f" 2>/dev/null || true)"
+    if [ -n "$hits" ]; then
       while IFS= read -r hit; do
-        violations+=("${rel}: --break-system-packages (PEP 668 workaround; not a long-term fix): ${hit}")
-      done <<< "$bsp_hits"
-      continue
-    fi
-
-    # Check for proper preflight guard before pyyaml invocation.
-    # Accepts versioned binaries: python3.11 -c "import yaml", python3 -c 'import yaml', command -v python3.11, etc.
-    # O-2: ["']import yaml["'] accepts both single and double quotes around the import guard.
-    if ! grep -qE "(python[0-9.]*[[:space:]]+-c[[:space:]]+[\"']import yaml[\"']|command[[:space:]]+-v[[:space:]]+python[0-9.]*)" \
-        "$f" 2>/dev/null; then
-      local hits
-      hits="$(grep -nE '(python[0-9.]*[[:space:]].*[Yy][Aa][Mm][Ll]|pip[0-9x]*[[:space:]].*[Pp][Yy][Yy][Aa][Mm][Ll]|import[[:space:]]+yaml)' \
-              "$f" 2>/dev/null || true)"
-      while IFS= read -r hit; do
-        violations+=("${rel}: pyyaml/yaml usage without preflight: ${hit}")
+        violations+=("${rel}: python/pip shell-out: ${hit}")
       done <<< "$hits"
     fi
   done
 
   if [ "${#violations[@]}" -gt 0 ]; then
-    echo "FAIL (AC-004): python3/pyyaml invocation without preflight guard found." >&2
-    echo "  Fix options (choose one):" >&2
-    echo "    (a) Add preflight: python3 -c \"import yaml\" 2>/dev/null || { echo 'yaml required' >&2; exit 1; }" >&2
-    echo "    (b) Replace with POSIX portable alternative: awk or sed-based YAML key extraction." >&2
-    echo "  NOTE: --break-system-packages is explicitly NOT accepted (PEP 668 is a macOS-runner" >&2
-    echo "  policy; the correct fix is to not depend on externally managed pip packages in CI)." >&2
+    echo "FAIL (AC-004): python or pip invocation found in wave-handoff scripts." >&2
+    echo "  SKILL.md §149: 'This skill MUST NOT shell out to Python, jq, or any language runtime beyond bash.'" >&2
+    echo "  Fix: remove python/pip invocations; replace with POSIX portable alternatives (awk, grep, sed)." >&2
+    echo "  NOTE: stdlib python (python3 -c 'import json') is also a violation (F-P11-001 Option A)." >&2
     echo "  Violations:" >&2
     local v
     for v in "${violations[@]}"; do echo "  ${v}" >&2; done
@@ -5045,6 +5093,8 @@ EOF
   local pc_bad_cmdsubst pc_bad_and pc_bad_xargs pc_bad_else pc_bad_time pc_bad_xargs_opts pc_good_comment
   local pc_bad_brace pc_bad_case_paren pc_bad_subshell
   local pc_good_other_cmdsubst pc_good_func_brace pc_good_jq_var
+  local pc_bad_jq_line_start pc_bad_jq_backtick pc_bad_jq_if pc_bad_jq_then pc_bad_jq_do
+  local pc_bad_jq_elif pc_bad_jq_env pc_bad_jq_command pc_bad_jq_sudo
   pc_bad_cmdsubst="${BATS_TEST_TMPDIR}/pc_ac005_bad_cmdsubst.sh"
   pc_bad_and="${BATS_TEST_TMPDIR}/pc_ac005_bad_and.sh"
   pc_bad_xargs="${BATS_TEST_TMPDIR}/pc_ac005_bad_xargs.sh"
@@ -5058,6 +5108,15 @@ EOF
   pc_good_other_cmdsubst="${BATS_TEST_TMPDIR}/pc_ac005_good_other_cmdsubst.sh"
   pc_good_func_brace="${BATS_TEST_TMPDIR}/pc_ac005_good_func_brace.sh"
   pc_good_jq_var="${BATS_TEST_TMPDIR}/pc_ac005_good_jq_var.sh"
+  pc_bad_jq_line_start="${BATS_TEST_TMPDIR}/pc_ac005_bad_jq_line_start.sh"
+  pc_bad_jq_backtick="${BATS_TEST_TMPDIR}/pc_ac005_bad_jq_backtick.sh"
+  pc_bad_jq_if="${BATS_TEST_TMPDIR}/pc_ac005_bad_jq_if.sh"
+  pc_bad_jq_then="${BATS_TEST_TMPDIR}/pc_ac005_bad_jq_then.sh"
+  pc_bad_jq_do="${BATS_TEST_TMPDIR}/pc_ac005_bad_jq_do.sh"
+  pc_bad_jq_elif="${BATS_TEST_TMPDIR}/pc_ac005_bad_jq_elif.sh"
+  pc_bad_jq_env="${BATS_TEST_TMPDIR}/pc_ac005_bad_jq_env.sh"
+  pc_bad_jq_command="${BATS_TEST_TMPDIR}/pc_ac005_bad_jq_command.sh"
+  pc_bad_jq_sudo="${BATS_TEST_TMPDIR}/pc_ac005_bad_jq_sudo.sh"
   printf 'result=$(jq -r .name input.json)\n' > "$pc_bad_cmdsubst"
   printf 'cmd && jq ".key" file.json\n' > "$pc_bad_and"
   printf 'find . -name "*.json" | xargs jq ".id"\n' > "$pc_bad_xargs"
@@ -5071,6 +5130,16 @@ EOF
   printf 'result=$(other_cmd . f)\n' > "$pc_good_other_cmdsubst"
   printf 'foo() { echo "hello"; }\n' > "$pc_good_func_brace"
   printf 'echo "${jq_var}"\n' > "$pc_good_jq_var"
+  # F-P13-001 additions: fixtures for arms that lacked positive controls.
+  printf 'jq -r .x f.json\n' > "$pc_bad_jq_line_start"
+  printf '`jq . f`\n' > "$pc_bad_jq_backtick"
+  printf "if jq '.key' file.json\n" > "$pc_bad_jq_if"
+  printf "then jq '.key' file.json\n" > "$pc_bad_jq_then"
+  printf "do jq '.key' file.json\n" > "$pc_bad_jq_do"
+  printf "elif jq '.key' file.json\n" > "$pc_bad_jq_elif"
+  printf "env jq '.key' file.json\n" > "$pc_bad_jq_env"
+  printf "command jq '.key' file.json\n" > "$pc_bad_jq_command"
+  printf "sudo jq '.key' file.json\n" > "$pc_bad_jq_sudo"
   # F-P8-001 + O-3 broadened jq_re: adds time|env|command|sudo to the keyword wrapper group;
   # adds xargs-with-options arm; adds brace-group, case-pattern-body, and subshell arms.
   # Positive-control regex MUST BE BYTE-IDENTICAL to the real-scan-loop regex below.
@@ -5153,6 +5222,62 @@ EOF
   ! grep -qE "$jq_re" "$pc_good_jq_var" || {
     echo "FAIL (AC-005 negative-control / F-P8-001): jq-detector falsely matched '\${jq_var}' parameter expansion." >&2
     echo "  The { arm requires jq followed by ([[:space:]]|\$); '\${jq_var}' has '_var}' after 'jq', not space/EOL." >&2
+    false
+  }
+  # F-P13-001 positive controls: arms that lacked coverage.
+  # BAD (F-P13-001): bare line-start 'jq -r .x f.json' MUST be detected (^[[:space:]]*jq arm).
+  # This is the most common jq invocation form and was the only arm without a positive control.
+  grep -qE "$jq_re" "$pc_bad_jq_line_start" || {
+    echo "FAIL (AC-005 positive-control / F-P13-001): jq-detector did not match bare line-start 'jq -r .x f.json'." >&2
+    echo "  The ^[[:space:]]*jq([[:space:]]|\$) arm must match jq at the start of a line." >&2
+    false
+  }
+  # BAD (F-P13-001): backtick form '\`jq . f\`' MUST be detected.
+  grep -qE "$jq_re" "$pc_bad_jq_backtick" || {
+    echo "FAIL (AC-005 positive-control / F-P13-001): jq-detector did not match backtick '\`jq . f\`' form." >&2
+    echo "  The \`jq([[:space:]]|\$) arm must match jq inside backtick command substitution." >&2
+    false
+  }
+  # BAD (F-P13-001): 'if jq ...' MUST be detected (if arm in keyword group).
+  grep -qE "$jq_re" "$pc_bad_jq_if" || {
+    echo "FAIL (AC-005 positive-control / F-P13-001): jq-detector did not match 'if jq' form." >&2
+    echo "  'if' must be in the keyword wrapper group (xargs|if|then|do|else|elif|time|env|command|sudo)." >&2
+    false
+  }
+  # BAD (F-P13-001): 'then jq ...' MUST be detected (then arm in keyword group).
+  grep -qE "$jq_re" "$pc_bad_jq_then" || {
+    echo "FAIL (AC-005 positive-control / F-P13-001): jq-detector did not match 'then jq' form." >&2
+    echo "  'then' must be in the keyword wrapper group." >&2
+    false
+  }
+  # BAD (F-P13-001): 'do jq ...' MUST be detected (do arm in keyword group).
+  grep -qE "$jq_re" "$pc_bad_jq_do" || {
+    echo "FAIL (AC-005 positive-control / F-P13-001): jq-detector did not match 'do jq' form." >&2
+    echo "  'do' must be in the keyword wrapper group." >&2
+    false
+  }
+  # BAD (F-P13-001): 'elif jq ...' MUST be detected (elif arm in keyword group).
+  grep -qE "$jq_re" "$pc_bad_jq_elif" || {
+    echo "FAIL (AC-005 positive-control / F-P13-001): jq-detector did not match 'elif jq' form." >&2
+    echo "  'elif' must be in the keyword wrapper group." >&2
+    false
+  }
+  # BAD (F-P13-001): 'env jq ...' MUST be detected (env arm in keyword group — O-3 addition).
+  grep -qE "$jq_re" "$pc_bad_jq_env" || {
+    echo "FAIL (AC-005 positive-control / F-P13-001): jq-detector did not match 'env jq' form." >&2
+    echo "  'env' must be in the keyword wrapper group (added at O-3)." >&2
+    false
+  }
+  # BAD (F-P13-001): 'command jq ...' MUST be detected (command arm in keyword group — O-3 addition).
+  grep -qE "$jq_re" "$pc_bad_jq_command" || {
+    echo "FAIL (AC-005 positive-control / F-P13-001): jq-detector did not match 'command jq' form." >&2
+    echo "  'command' must be in the keyword wrapper group (added at O-3)." >&2
+    false
+  }
+  # BAD (F-P13-001): 'sudo jq ...' MUST be detected (sudo arm in keyword group — O-3 addition).
+  grep -qE "$jq_re" "$pc_bad_jq_sudo" || {
+    echo "FAIL (AC-005 positive-control / F-P13-001): jq-detector did not match 'sudo jq' form." >&2
+    echo "  'sudo' must be in the keyword wrapper group (added at O-3)." >&2
     false
   }
   # -------------------------------------------


### PR DESCRIPTION
## Summary

S-18.12 (v1.12, E-18 wave-9) extends the `wave-handoff.bats` portability-lint guard from a single PCRE-class check (AC-007, preserved) to five additional static-lint detectors that catch the class of bash-3.2-vs-4-syntax and forbidden-shell-out defects that forced 4 emergency fixes during S-18.01's PR review (lesson `L-S18-macos-ci-leg-caught-runtime-portability`).

New detectors (each with its own positive/negative-control fixture pair against synthetic `BATS_TEST_TMPDIR` files, in addition to scanning the real wave-handoff skill scripts):

- **AC-001** — unguarded bash 4+ associative arrays (`declare -A` / `local -A` and prefixed forms) without a preceding `BASH_VERSINFO` guard
- **AC-002** — bash 4+ case-modifier parameter expansion (`${var^^}`, `${var,,}`, `${var@U}`, etc.)
- **AC-003** — global `IFS` mutation (bare / `export` / `readonly` / `declare -g`) that leaks into the parent shell
- **AC-004** — forbidden `python`/`pip` shell-outs (forbidden-removal model — no preflight-acceptance path, per F-P11-001 Option A)
- **AC-005** — forbidden `jq` shell-outs (same forbidden-removal model as AC-004, closing the earlier python/jq asymmetry)

AC-006 (guard scoped to wave-handoff scripts only) and AC-007 (pre-existing PCRE-class guard) are covered structurally / by regression — no dedicated new test required per the story's Test Plan.

**Intentional no-behavioral-contract gate-enforcement story.** `behavioral_contracts: []` is deliberate — this is a pure test/lint-gate extension with no production runtime behavior change, following the S-18.09 precedent (human-directed 2026-06-29). The deliverable is a static bats lint guard, not a feature with a BC to trace.

## Drift items closed (pre-PR polish burst, v1.11 → v1.12)

| Drift ID | Description | Commit |
|----------|-------------|--------|
| D-741 O-3 | `python_re` negative-control symmetry (`${python3_x}` param expansion, brace-arm) | `d039dd50` |
| D-740 O-3 | Comment-strip parity for AC-001..005 violation detectors (commented-out violations must not false-positive) | `3d7d1c4d` |
| D-740 O-6 | Anti-volatile-pin remediation — replaced `SKILL.md §149` line-number citation with a stable section-name citation (`'Forbidden Dependencies' section in bash-portability.md`), per TD-VSDD-091 | `9cbd9439` |

## Test evidence

`plugins/vsdd-factory/tests/wave-handoff.bats` — **68/68 green** (the file this branch touches), including all 6 portability detector tests (`test_BC_5_41_001_F_P11_001_bsd_portability_no_pcre_classes_in_grep_sed` regression + the 5 new `test_portability_no_*` AC-001..005 tests) with their embedded positive/negative-control assertions.

Full local pre-push gate (mirrors `.github/workflows/ci.yml`):

- `cargo fmt --check --all` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean, 0 warnings
- `cargo test --workspace --all-targets` — 179 test binaries, all green, 0 failed
- `plugins/vsdd-factory/tests/run-all.sh` (full bats suite) — all green except one pre-existing, unrelated suite:
  - `pass-real-state-md-snapshot` — validates the live production STATE.md snapshot; CI skips this suite via `VSDD_SKIP_PRODUCTION_STATE_MD_TEST=1` (TD-VSDD-101). Not caused by this branch — no STATE.md changes here.
  - `resolver-integration` (F-P3-008 timing-flake class, documented flaky) ran clean on this pass — no action needed.

## Evidence

Per-AC demo evidence with full positive/negative-control mapping: [`docs/demo-evidence/S-18.12/evidence-report.md`](https://github.com/drbothen/vsdd-factory/blob/feature/S-18.12/docs/demo-evidence/S-18.12/evidence-report.md)

## Test plan

- [x] `cargo fmt --check --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --all-targets`
- [x] `plugins/vsdd-factory/tests/wave-handoff.bats` 68/68 green
- [x] CI green on all required legs (see PR checks)
