### PR TITLE
fix(release): registry-vs-staged WASM assertion (recovers PR #431 amendment missed by squash)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,16 +182,39 @@ jobs:
           # hello-hook example lives under examples/
           cp target/wasm32-wasip1/release/examples/hello-hook.wasm artifact/ 2>/dev/null || true
 
-      - name: Verify all 16 native WASM plugins are staged
+      - name: Verify registry-declared WASM plugins are staged
         shell: bash
         run: |
-          count=$(ls artifact/*.wasm 2>/dev/null | wc -l)
-          if [ "$count" -lt 16 ]; then
-            echo "::error::Only $count wasm files staged in artifact/; expected >= 16."
-            ls artifact/*.wasm 2>/dev/null || true
+          # Parse all hook plugin WASMs declared in hooks-registry.toml.
+          mapfile -t declared < <(
+            grep -E '^\s*plugin\s*=\s*"hook-plugins/' \
+              plugins/vsdd-factory/hooks-registry.toml \
+              | grep -oE 'hook-plugins/[^"]+' \
+              | sed 's|hook-plugins/||' \
+              | sort -u
+          )
+          # Guard: a parse yielding fewer than 30 entries is almost certainly
+          # a regex failure — an empty parse would vacuously pass every check.
+          if [ "${#declared[@]}" -lt 30 ]; then
+            echo "::error::hooks-registry.toml parse yielded ${#declared[@]} entries (expected >= 30). Possible parse failure."
             exit 1
           fi
-          echo "Staged $count wasm files."
+          echo "Parsed ${#declared[@]} plugins from hooks-registry.toml."
+          # Assert every declared plugin exists in the staged artifact dir.
+          # Note: vsdd-context-resolvers.wasm (hyphen, git-tracked from S-12.07)
+          # is NOT produced by cargo build — it lives only in hook-plugins/ on
+          # main, not in the build artifact. Only hooks-registry entries are
+          # checked here; resolvers-registry is checked in the commit-binaries job.
+          missing=()
+          for name in "${declared[@]}"; do
+            [ -f "artifact/$name" ] || missing+=("$name")
+          done
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::error::${#missing[@]} registry-declared WASM(s) absent from artifact/:"
+            printf '  missing: %s\n' "${missing[@]}"
+            exit 1
+          fi
+          echo "Registry-vs-staged: all ${#declared[@]} hooks-registry plugins present in artifact/. OK"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -281,16 +304,45 @@ jobs:
             echo "staged $name"
           done
 
-      - name: Verify all 16 native WASM plugins are staged
+      - name: Verify registry-declared WASM plugins are staged
         shell: bash
         run: |
-          count=$(ls plugins/vsdd-factory/hook-plugins/*.wasm 2>/dev/null | wc -l)
-          if [ "$count" -lt 16 ]; then
-            echo "::error::Only $count wasm files staged; expected >= 16."
-            ls plugins/vsdd-factory/hook-plugins/*.wasm 2>/dev/null || true
+          # Parse hook plugins from hooks-registry.toml.
+          mapfile -t hooks_plugins < <(
+            grep -E '^\s*plugin\s*=\s*"hook-plugins/' \
+              plugins/vsdd-factory/hooks-registry.toml \
+              | grep -oE 'hook-plugins/[^"]+' \
+              | sed 's|hook-plugins/||' \
+              | sort -u
+          )
+          # Parse resolver WASMs from resolvers-registry.toml.
+          mapfile -t resolver_plugins < <(
+            grep -E '^\s*plugin\s*=\s*"hook-plugins/' \
+              plugins/vsdd-factory/resolvers-registry.toml 2>/dev/null \
+              | grep -oE 'hook-plugins/[^"]+' \
+              | sed 's|hook-plugins/||' \
+              | sort -u
+          )
+          # Guard: a parse yielding fewer than 30 entries is almost certainly
+          # a regex failure — an empty parse would vacuously pass every check.
+          if [ "${#hooks_plugins[@]}" -lt 30 ]; then
+            echo "::error::hooks-registry.toml parse yielded ${#hooks_plugins[@]} entries (expected >= 30). Possible parse failure."
             exit 1
           fi
-          echo "Staged $count wasm files."
+          echo "Parsed ${#hooks_plugins[@]} hooks + ${#resolver_plugins[@]} resolvers = $((${#hooks_plugins[@]} + ${#resolver_plugins[@]})) total declared WASMs."
+          # Assert every declared plugin/resolver WASM exists in the staged hook-plugins/ dir.
+          # This includes vsdd-context-resolvers.wasm (hyphen, from resolvers-registry.toml),
+          # which is git-tracked from S-12.07 and present in the main checkout before staging.
+          missing=()
+          for name in "${hooks_plugins[@]}" "${resolver_plugins[@]}"; do
+            [ -f "plugins/vsdd-factory/hook-plugins/$name" ] || missing+=("$name")
+          done
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::error::${#missing[@]} registry-declared WASM(s) absent from hook-plugins/:"
+            printf '  missing: %s\n' "${missing[@]}"
+            exit 1
+          fi
+          echo "Registry-vs-staged: all $((${#hooks_plugins[@]} + ${#resolver_plugins[@]})) declared WASMs present in hook-plugins/. OK"
 
       - name: Regenerate hooks.json.<platform> variants
         run: scripts/generate-hooks-json.sh


### PR DESCRIPTION
## Provenance — merge-race recovery

PR #431 was merged at ~17:57Z. The adversary LOW-1 amendment commit `fc9d4b25` was pushed to `maintenance/rc22-pre-release-cleanup` at ~18:20Z — after the merge. Because #431 was squash-merged, only the original two commits (`c44b2a31` + `3a6e830d`) landed on `develop`. The `fc9d4b25` changes were not included.

Post-merge smoke on `develop` (`34aa9e8f`) confirmed the gap: `release.yml` still contains the old `count >= 16` floor checks in both the `build-binaries` and `commit-binaries` verification steps.

This PR delivers `fc9d4b25` as a clean cherry-pick onto `develop` (`f805308a`). The diff is byte-equivalent to the original commit (+64/-12, single file `.github/workflows/release.yml`).

## What this change does — closes adversary LOW-1

Replaces the slack `count >= 16` WASM floor in **both** `release.yml` verification steps with a declarative registry-vs-staged set assertion.

**`build-binaries` job:** Parses all hook plugin WASMs declared in `hooks-registry.toml` (33 entries), guards that the parse yields ≥ 30 entries (prevents vacuous-pass on regex failure or empty parse), then asserts every declared plugin is present in `artifact/` by name. Any missing entry fails loudly with the full missing set listed. `vsdd-context-resolvers.wasm` (hyphen form, git-tracked from S-12.07, not produced by cargo) is correctly excluded from this job's assertion.

**`commit-binaries` job:** Same structure, additionally parses `resolvers-registry.toml` (1 entry: `vsdd-context-resolvers.wasm`), applies the same ≥ 30 guard on hooks, then asserts all 34 (33 hooks + 1 resolver) are present in `hook-plugins/` after staging. The hyphen-form resolver is present in the main checkout at this stage.

**Why the set assertion is strictly stronger than the count floor:** The floor passed vacuously on any count ≥ 16 regardless of which files were present. The set check verifies every declared WASM by name — a regression that swapped one file for another (or left one missing while adding an unrelated file) would be caught.

## Prior review — delta APPROVE at fc9d4b25

This content was reviewed by `vsdd-factory:pr-reviewer` as a scoped delta review of `fc9d4b25`. Verdict: **APPROVE**, LOW-1 confirmed closed. Reviewer directly parsed `hooks-registry.toml` (73 raw lines → 33 unique names after `sort -u`), confirmed `resolvers-registry.toml` → 1 entry, verified the 33-vs-34 split is architecturally correct, and confirmed shell correctness (`mapfile -t`, `grep -oE`, `sed`, `sort -u`) on bash 5 / ubuntu-latest. No blockers.

## 4-scenario simulation evidence (re-validated against real registry files)

| Scenario | Outcome |
|----------|---------|
| Full set present | PASS |
| One plugin removed from staged dir | FAIL — names the missing file |
| Empty staged dir | FAIL — guard fires |
| Registry parse yields 0 entries (simulated truncation) | FAIL — `< 30` guard fires before set check |

`actionlint` clean on the modified sections.

## Test plan

- [ ] CI: `cargo fmt --check --all && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace --all-targets` passes
- [ ] Verify `release.yml` `build-binaries` verification step uses registry-vs-staged assertion (lines ~185), no `count >= 16` floor
- [ ] Verify `release.yml` `commit-binaries` verification step uses registry-vs-staged assertion (lines ~307), no `count >= 16` floor
- [ ] Verify parse guard (`< 30`) is present in both steps