### PR TITLE
fix(release): bash-3.2 compat for registry-vs-staged assertion (mapfile → while-read)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,7 +186,10 @@ jobs:
         shell: bash
         run: |
           # Parse all hook plugin WASMs declared in hooks-registry.toml.
-          mapfile -t declared < <(
+          # bash-3.2 portable (no mapfile): process substitution works in 3.2;
+          # mapfile requires bash 4.0+ and fails on macOS default /bin/bash.
+          declared=()
+          while IFS= read -r __line; do [ -n "$__line" ] && declared+=("$__line"); done < <(
             grep -E '^\s*plugin\s*=\s*"hook-plugins/' \
               plugins/vsdd-factory/hooks-registry.toml \
               | grep -oE 'hook-plugins/[^"]+' \
@@ -308,7 +311,10 @@ jobs:
         shell: bash
         run: |
           # Parse hook plugins from hooks-registry.toml.
-          mapfile -t hooks_plugins < <(
+          # bash-3.2 portable (no mapfile): process substitution works in 3.2;
+          # mapfile requires bash 4.0+ and fails on macOS default /bin/bash.
+          hooks_plugins=()
+          while IFS= read -r __line; do [ -n "$__line" ] && hooks_plugins+=("$__line"); done < <(
             grep -E '^\s*plugin\s*=\s*"hook-plugins/' \
               plugins/vsdd-factory/hooks-registry.toml \
               | grep -oE 'hook-plugins/[^"]+' \
@@ -316,7 +322,8 @@ jobs:
               | sort -u
           )
           # Parse resolver WASMs from resolvers-registry.toml.
-          mapfile -t resolver_plugins < <(
+          resolver_plugins=()
+          while IFS= read -r __line; do [ -n "$__line" ] && resolver_plugins+=("$__line"); done < <(
             grep -E '^\s*plugin\s*=\s*"hook-plugins/' \
               plugins/vsdd-factory/resolvers-registry.toml 2>/dev/null \
               | grep -oE 'hook-plugins/[^"]+' \


### PR DESCRIPTION
## Summary

Release pipeline run [28659218883](https://github.com/drbothen/vsdd-factory/actions/runs/28659218883) failed at `build-dispatcher` (darwin-arm64) in step "Verify registry-declared WASM plugins are staged" with `mapfile: command not found`, exit 127.

**Root cause:** `mapfile` (a.k.a. `readarray`) is a bash 4.0+ builtin. macOS GitHub runners ship with Apple `/bin/bash` 3.2. All 5 platforms in the `build-binaries` matrix use `shell: bash`, which resolves to the system bash — `/bin/bash 3.2` on darwin-arm64 and darwin-x64. The two verification steps introduced in PR #438 (registry-vs-staged assertion) used `mapfile -t` in both jobs.

This is the exact S-18.12 portability-lint bug class applied to our own CI.

**Fix:** Replaces all 3 `mapfile` calls with the bash-3.2 portable while-read form:
```bash
arr=()
while IFS= read -r __line; do [ -n "$__line" ] && arr+=("$__line"); done < <(...)
```
Process substitution `< <(...)` works correctly in bash 3.2. The pipelines inside `< <(...)` are unchanged. TD-VSDD-060 sibling-sweep confirmed no other bash-4+ constructs (`readarray`, `${var,,}`, `${var^^}`, associative arrays) in the two affected steps.

**Recovery procedure per RELEASING.md:** Fix on a follow-up PR targeting main. After merge, delete and re-create tag `v1.0.0-rc.22` at main's new tip per RELEASING.md §"commit-binaries fails" recovery.

## Validation evidence

Extracted both modified steps and ran under `/bin/bash 3.2.57(1)-release (arm64-apple-darwin25)`:

**build-binaries step:**
- S1 full PASS: `all 33 hooks-registry plugins present in artifact/. OK`
- S2 one-missing FAIL: `1 registry-declared WASM(s) absent: validate-phantom-nonexistent.wasm`

**commit-binaries step:**
- S3 full PASS: `all 34 declared WASMs present in hook-plugins/. OK` (33 hooks + 1 resolver)

**bash 5.3.9 regression check:** both steps parse 33 hooks + 1 resolver correctly — no regression.

**actionlint:** no findings in modified steps (lines ~185–220 and ~307–350). Pre-existing style/info warnings in unrelated steps (lines 445, 654, 737) are unchanged.

## Pre-Merge Checklist

- [x] Branched from main (2a4c949b)
- [x] Targets main
- [x] Single-file change: `.github/workflows/release.yml`
- [ ] CI passes
- [ ] Squash merge is FORBIDDEN — use --merge to preserve develop ancestry
- [ ] Post-merge: delete and re-create tag `v1.0.0-rc.22` at main's new tip per RELEASING.md recovery