### PR TITLE
fix(skills): invoke lock helpers via ${CLAUDE_PLUGIN_ROOT}/bin, not repo-relative paths

### DIFF
--- a/plugins/vsdd-factory/skills/factory-health/SKILL.md
+++ b/plugins/vsdd-factory/skills/factory-health/SKILL.md
@@ -98,7 +98,7 @@ test -f .factory/reference-manifest.yaml
 Invoke the shared three-state lock status helper:
 
 ```bash
-plugins/vsdd-factory/bin/factory-lock-status.sh .factory/STATE.md "$(git config user.email)"
+${CLAUDE_PLUGIN_ROOT}/bin/factory-lock-status.sh .factory/STATE.md "$(git config user.email)"
 ```
 
 Append the output line to the health report. The helper returns one of:

--- a/plugins/vsdd-factory/skills/factory-lock/SKILL.md
+++ b/plugins/vsdd-factory/skills/factory-lock/SKILL.md
@@ -16,7 +16,7 @@ acquisition path (BC-6.23.001 Invariant 1 / ADR-025 Decision 6).
 Run the acquire precheck helper with the STATE.md path:
 
 ```bash
-plugins/vsdd-factory/bin/factory-lock-acquire-precheck.sh <STATE_MD_PATH>
+${CLAUDE_PLUGIN_ROOT}/bin/factory-lock-acquire-precheck.sh <STATE_MD_PATH>
 ```
 
 The helper performs (in order):
@@ -36,10 +36,10 @@ The helper performs (in order):
 
 On PROCEED_ACQUIRE, delegate to state-manager. State-manager runs:
 
-1. `plugins/vsdd-factory/bin/factory-lock-write.sh acquire <STATE_MD_PATH>`
+1. `${CLAUDE_PLUGIN_ROOT}/bin/factory-lock-write.sh acquire <STATE_MD_PATH>`
    Writes `factory_lock = { holder: <email>, locked_at: <now>, expires_at: <now+2700s> }`.
 
-2. `plugins/vsdd-factory/bin/factory-cas-push.sh`
+2. `${CLAUDE_PLUGIN_ROOT}/bin/factory-cas-push.sh`
    CAS push: `git fetch origin factory-artifacts` then
    `git push --force-with-lease=factory-artifacts:"${EXPECTED_SHA}" origin factory-artifacts`.
 
@@ -59,7 +59,7 @@ state-manager which invokes `factory-lock-write.sh` + `factory-cas-push.sh` from
 On successful CAS push, emit the acquisition event via the SS-03 event pipeline:
 
 ```bash
-plugins/vsdd-factory/bin/emit-event \
+${CLAUDE_PLUGIN_ROOT}/bin/emit-event \
   type=factory.lock.acquired \
   holder=<email> \
   locked_at=<locked_at_iso8601> \

--- a/plugins/vsdd-factory/skills/factory-unlock/SKILL.md
+++ b/plugins/vsdd-factory/skills/factory-unlock/SKILL.md
@@ -15,7 +15,7 @@ and `--force` break-glass release with mandatory `factory.lock.stolen` audit eve
 Run the unlock decision helper with the STATE.md path, current git email, and optional --force flag:
 
 ```bash
-plugins/vsdd-factory/bin/factory-unlock-decide.sh \
+${CLAUDE_PLUGIN_ROOT}/bin/factory-unlock-decide.sh \
   <STATE_MD_PATH> \
   "$(git config user.email)" \
   [--force]
@@ -49,11 +49,11 @@ state-manager which invokes `factory-lock-write.sh` + `factory-cas-push.sh` from
 On PROCEED_RELEASE, PROCEED_RELEASE_SELF_FORCE, or PROCEED_FORCE_STEAL, delegate to
 state-manager. State-manager runs:
 
-1. `plugins/vsdd-factory/bin/factory-lock-write.sh clear <STATE_MD_PATH>`
+1. `${CLAUDE_PLUGIN_ROOT}/bin/factory-lock-write.sh clear <STATE_MD_PATH>`
    Removes the `factory_lock` key ENTIRELY from STATE.md frontmatter.
    Key deletion, NOT null assignment (BC-5.40.001 PC2 / Invariant "not null").
 
-2. `plugins/vsdd-factory/bin/factory-cas-push.sh`
+2. `${CLAUDE_PLUGIN_ROOT}/bin/factory-cas-push.sh`
    CAS push to origin/factory-artifacts.
 
 On CAS push rejection: Error variant `UnlockCASRejected`; user retries.
@@ -64,7 +64,7 @@ The decision token from Step 1 determines which event to emit:
 
 **For PROCEED_RELEASE or PROCEED_RELEASE_SELF_FORCE:**
 ```bash
-plugins/vsdd-factory/bin/emit-event \
+${CLAUDE_PLUGIN_ROOT}/bin/emit-event \
   type=factory.lock.released \
   holder=<holder_from_decide_output> \
   locked_at=<locked_at_from_decide_output> \
@@ -73,7 +73,7 @@ plugins/vsdd-factory/bin/emit-event \
 
 **For PROCEED_FORCE_STEAL:**
 ```bash
-plugins/vsdd-factory/bin/emit-event \
+${CLAUDE_PLUGIN_ROOT}/bin/emit-event \
   type=factory.lock.stolen \
   stolen_by=<stolen_by_from_decide_output> \
   stolen_from=<stolen_from_from_decide_output> \

--- a/plugins/vsdd-factory/skills/factory-worktree-health/SKILL.md
+++ b/plugins/vsdd-factory/skills/factory-worktree-health/SKILL.md
@@ -154,7 +154,7 @@ After the sync state check, invoke the shared three-state lock status helper and
 output to the health report:
 
 ```bash
-plugins/vsdd-factory/bin/factory-lock-status.sh "${WORKTREE_DIR}/STATE.md" "$(git config user.email)"
+${CLAUDE_PLUGIN_ROOT}/bin/factory-lock-status.sh "${WORKTREE_DIR}/STATE.md" "$(git config user.email)"
 ```
 
 The helper returns one of:


### PR DESCRIPTION
## What

Replaces all 11 repo-relative `plugins/vsdd-factory/bin/<helper>` invocations across the 4 lock-surface skills (`factory-lock`, `factory-unlock`, `factory-health`, `factory-worktree-health`) with `${CLAUDE_PLUGIN_ROOT}/bin/<helper>`.

Refs: #472

## Why

In every installed-plugin context (plugin cache under `~/.claude/plugins/`), the session cwd is the target project and `plugins/vsdd-factory/` does not exist — the helpers are unreachable as written. This is the safety core of BC-6.23.001: when the CAS precheck / unlock-decide helpers can't be found, agents either fail the skill or hand-roll the lock logic that the shared-helper mandate (AC-008) exists to prevent. `${CLAUDE_PLUGIN_ROOT}` is already the plugin's own convention (activate skill, agent-file-review, template references) and resolves in both installed and source-checkout contexts.

Docs-only change (4 SKILL.md files); no helper or test changes. `factory-lock-status.bats`'s skill-integration test greps for helper-name presence only, unaffected.

Scope note: #472 cited 7 call sites at rc.21; develop tip has 11 (factory-lock gained `factory-lock-write.sh` / `factory-cas-push.sh` references since). All 11 converted.

## Test evidence (local, branched from develop @ f5242bef, rust 1.95.0)

```
cargo fmt/clippy(-D warnings)/test --workspace     → clean, 0 failures
bats factory-lock-status.bats                      → 0 failures
bats factory-lock-skills-integration.bats          → 0 failures
bats skills.bats + hooks.bats + bin.bats           → 0 failures
bats template-compliance.bats                      → 0 failures
semgrep ci (diff vs develop)                       → 0 findings
```