### PR TITLE
fix(workflows): phase-4 scenario-rotation — state-manager writes, canonical holdout-scenarios/ path

### DIFF
--- a/plugins/vsdd-factory/workflows/greenfield.lobster
+++ b/plugins/vsdd-factory/workflows/greenfield.lobster
@@ -1007,11 +1007,11 @@ workflow:
     - name: phase-4-scenario-rotation
       type: agent
       depends_on: [phase-3-gate]
-      agent: orchestrator
+      agent: state-manager
       task: >
         Perform scenario rotation for this pipeline run. Randomly select 80% of
         holdout scenarios from .factory/holdout-scenarios/ for evaluation. Write
-        the selected scenario IDs to .factory/holdout-evaluation/scenario-selection.json.
+        the selected scenario IDs to .factory/holdout-scenarios/scenario-selection.json.
         The remaining 20% are held back as "holdout of the holdout" -- scenarios
         the evaluator has never seen for this particular run. Seed the random
         selection from the pipeline run ID for deterministic per-run, different

--- a/plugins/vsdd-factory/workflows/phases/phase-4-holdout-evaluation.lobster
+++ b/plugins/vsdd-factory/workflows/phases/phase-4-holdout-evaluation.lobster
@@ -13,12 +13,12 @@ workflow:
   steps:
     - name: scenario-rotation
       type: agent
-      agent: orchestrator
+      agent: state-manager
       depends_on: []
       task: >
         Perform scenario rotation for this pipeline run. Randomly select 80%
         of holdout scenarios. Write selected scenario IDs to
-        .factory/holdout-evaluation/scenario-selection.json.
+        .factory/holdout-scenarios/scenario-selection.json.
 
     - name: holdout-evaluation
       type: skill


### PR DESCRIPTION
## What

Two one-line fixes to the phase-4 scenario-rotation step, applied in both `workflows/phases/phase-4-holdout-evaluation.lobster` and the inlined copy in `workflows/greenfield.lobster`:

1. `agent: orchestrator` → `agent: state-manager` — the step's task ends in a file write, but the orchestrator's definition denies write/edit and mandates delegation. As written the step can't execute without the orchestrator violating its own constitution or improvising an undocumented delegation. state-manager is the established writer for pipeline-state artifacts throughout these workflows.
2. Output path `.factory/holdout-evaluation/scenario-selection.json` → `.factory/holdout-scenarios/scenario-selection.json` — `holdout-evaluation/` is not part of the canonical `.factory/` tree (factory-health check 5 knows `holdout-scenarios/` and its children; no template or health check references a `holdout-evaluation/` directory). The selection artifact now lands beside the scenarios it selects from.

Refs: #473

## Why

Both defects mean every phase-4 run starts with an unexecutable-as-specified step: the assigned agent is constitutionally unable to perform its task, and the artifact lands in a directory nothing else in the factory knows about. Observed divergence in practice: the orchestrator either violates its write prohibition, spawns state-manager off-book, or skips the artifact.

Sequencing note: information-asymmetry-wise this is unchanged — the rotation step runs before any evaluator dispatch, and state-manager already reads/writes pipeline state; it gains no knowledge it doesn't already hold.

## Test evidence (local, branched from develop @ f5242bef)

```
lobster-parse phase-4-holdout-evaluation.lobster   → parses ("phase-4-holdout-evaluation")
lobster-parse greenfield.lobster                   → parses ("greenfield-vsdd")
bats bin.bats (includes all-15-workflows parse)    → 13/13 ok
cargo fmt/clippy/test --workspace                  → clean, 0 failures
grep -rn "holdout-evaluation/scenario-selection"   → no remaining references
semgrep ci (diff vs develop)                       → 0 findings
```