### PR TITLE
fix(demo-recorder): self-locating cd in tape template — absolute paths break relocation and post-merge replay

### DIFF
--- a/plugins/vsdd-factory/agents/demo-recorder.md
+++ b/plugins/vsdd-factory/agents/demo-recorder.md
@@ -105,6 +105,11 @@ git commit -m "evidence(STORY-NNN): add demo recordings"
   not a guessed duration. Only use `Sleep` for the final frame hold (2s).
 - **Use `Hide`/`Show` for setup** — build commands, `cd`, `clear` should not appear in the demo.
   The viewer should see only the command being demonstrated.
+- **NEVER emit `Type "cd <absolute-path>"`** — your working directory is not portable.
+  Absolute worktree paths break the tape on repo relocation and after the story merges
+  (the `.worktrees/STORY-NNN` directory is cleaned up). Self-locate instead:
+  `Type "cd $(git rev-parse --show-toplevel)"` — resolves correctly from any checkout,
+  before and after merge.
 - **Use `Require`** — verify the binary exists before recording. Fail early.
 - **Both `.gif` + `.webm`** — gif for PR embed, webm for archival. Always output both.
 - **Keep under 15 seconds** — each tape demos ONE acceptance criterion. No multi-AC tapes.

--- a/plugins/vsdd-factory/templates/demo-tape-template.tape
+++ b/plugins/vsdd-factory/templates/demo-tape-template.tape
@@ -40,10 +40,14 @@ Set Framerate 30
 Set TypingSpeed 50ms
 
 # === Hidden Setup ===
-# Build the binary and navigate to the worktree.
+# Build the binary and navigate to the repo root.
 # Everything between Hide/Show is executed but NOT recorded.
+# Self-locate from wherever vhs is invoked: inside a story worktree this
+# resolves to the worktree root; after merge it resolves to the repo root.
+# NEVER hardcode an absolute path here — absolute paths break on repo
+# relocation and after the story worktree is cleaned up post-merge.
 Hide
-Type "cd {worktree_path}"
+Type "cd $(git rev-parse --show-toplevel)"
 Enter
 Wait+Line /\$/
 


### PR DESCRIPTION
## What

- `templates/demo-tape-template.tape`: the hidden-setup `Type "cd {worktree_path}"` becomes `Type "cd $(git rev-parse --show-toplevel)"`, with a comment explaining the anti-pattern.
- `agents/demo-recorder.md`: adds the matching rule to VHS Best Practices — never emit `Type "cd <absolute-path>"`; self-locate instead.

Refs: #418

## Why

In practice the demo-recorder fills `{worktree_path}` with its absolute working directory. Observed: 25 tapes across 5 stories in one project, all hardcoding `/Users/<user>/work/<repo>/.worktrees/S-XXX`. Those tapes break twice over: when the repo relocates on disk, and after the story merges (the worktree is cleaned up), so demos can't be re-rendered or verified against `develop@merge-sha`.

`git rev-parse --show-toplevel` resolves correctly from wherever `vhs` is invoked: inside a story worktree it's the worktree root (pre-merge recording, the current behavior preserved); post-merge it's whatever checkout the operator replays from. git availability is already implicit in the same protocol (`git add`/`git commit` steps).

Template + agent-doc change only; existing rendered `.gif`/`.webm` evidence is untouched.

## Test evidence (local, branched from develop @ f5242bef)

```
bats template-compliance.bats                     → 0 failures
bats skills.bats + hooks.bats + bin.bats          → 0 failures
cargo fmt/clippy/test --workspace                 → clean, 0 failures
semgrep ci (diff vs develop)                      → 0 findings
```