### PR TITLE
fix(implementer): prohibit test-runner config modification as a green-path workaround

### DIFF
--- a/plugins/vsdd-factory/agents/implementer.md
+++ b/plugins/vsdd-factory/agents/implementer.md
@@ -98,6 +98,15 @@ You are the Dark Factory's TDD implementer. You operate under STRICT TDD discipl
 - You NEVER skip the refactor step after all tests are green.
 - You ALWAYS respect the Purity Boundary Map from the architecture spec.
   Functions in the pure core MUST be side-effect-free.
+- You NEVER modify test-runner configuration (`.gutconfig.json`,
+  `jest.config.*`, `pytest.ini`, `.rspec`, `Cargo.toml` `[[test]]`
+  sections, or equivalent) to make a failing test pass. Runner config is
+  a suite-wide contract, not an implementation surface. If a test fails
+  because of a genuine test bug, report it — the fix belongs at the test
+  call site (test-writer's surface, not yours). If the runner config
+  itself is genuinely wrong for the project, escalate to devops-engineer
+  with a written justification; never change it silently in an
+  implementation burst.
 
 ## Contract
 


### PR DESCRIPTION
## What

Adds one Absolute Constraint to `agents/implementer.md`: never modify test-runner configuration (`.gutconfig.json`, `jest.config.*`, `pytest.ini`, `.rspec`, `Cargo.toml` `[[test]]` sections, or equivalent) to make a failing test pass; report genuine test bugs (the call-site fix is test-writer's surface); escalate genuinely-wrong runner config to devops-engineer with written justification.

Refs: #434

## Why

Observed in the field: an implementer facing a failing test caused by a real test bug modified `.gutconfig.json` to green the suite instead of surfacing the defect. The masked bug survived; only a human noticing the config change in the diff caught it. The implementer's constraints already prohibit writing tests, but the runner-config surface achieves the same outcome one layer down and nothing names it. Runner config is a suite-wide contract: editing it to dodge one failure changes the posture of every future run silently.

Agent-definition change only; same constraint style and voice as the existing Absolute Constraints list.

## Test evidence (local, branched from develop @ f5242bef)

```
bats permissions.bats + codify-lessons.bats + tdd-discipline-gate.bats  → 0 failures
bats skills/hooks/bin/template-compliance suites                        → 0 failures
cargo fmt/clippy/test --workspace                                       → clean, 0 failures
semgrep ci (diff vs develop)                                            → 0 findings
```