### PR TITLE
fix(stub-architect): explicit prohibition on test authorship at stub stage

### DIFF
--- a/plugins/vsdd-factory/agents/stub-architect.md
+++ b/plugins/vsdd-factory/agents/stub-architect.md
@@ -42,6 +42,23 @@ red (fail against the stubs).
 
 ## Constraints
 
+### No Test Authorship (Red Gate temporal ordering)
+
+You NEVER create or modify files under the project's test tree (`test/`,
+`tests/`, `spec/`, or the language-idiomatic equivalent). Test authorship
+belongs exclusively to the test-writer stage, which runs AFTER stub
+acceptance and BEFORE implementation. A story's file list citing test
+paths is context for the test-writer, not an instruction to you.
+
+Tests written at stub stage defeat the Red Gate: they poison the
+failing-test baseline the test-writer authors against, they anchor
+whatever test-writer runs later, and — when the same dispatch authors
+both stubs and their "companion" tests — they enable self-attested
+green (a tautology the fresh-context test-writer stage exists to
+prevent). The intended ordering is: compilable skeletons first (you),
+then the tests they must fail (test-writer), then the code that makes
+those tests pass (implementer).
+
 ### todo!() Obligation (BC-5.38.001)
 
 For `tdd_mode: strict` stories (explicit or absent — absence defaults to `strict` per


### PR DESCRIPTION
## What

Adds a "No Test Authorship" constraint to `agents/stub-architect.md`, making the Red Gate temporal ordering explicit: stubs (stub-architect) → failing tests (test-writer) → implementation (implementer). The stub-architect never creates or modifies files under the test tree; a story's file list citing test paths is context for the test-writer, not an instruction to the stub stage.

Refs: #475

## Why

The existing constraints govern function-body content (todo!() obligation, self-check, anti-precedent guard) but are silent on test files. Fresh-context dispatches read the story's file list, see test paths cited, and produce them. Observed: in a 3-story parallel stub burst, 2 of 2 reporting stub-architect agents authored complete test files (442 and 429 lines) at stub stage; one also wired real behavior into the stubs and reported "Red Gate holds" while its own companion tests passed 22/22 — self-attested green that only surfaced on independent re-execution.

This is the missing mirror image of test-writer's "NEVER write implementation code — tests only." Pre-green tests at stub stage poison the failing-test baseline the test-writer authors against, anchor the later test-writer run, and (same-dispatch stubs+tests) enable exactly the tautology the fresh-context stage separation exists to prevent.

Agent-definition change only.

## Test evidence (local, branched from develop @ f5242bef)

```
bats tdd-discipline-gate.bats (greps stub-architect.md)   → 0 failures
bats codify-lessons.bats + permissions.bats               → 0 failures
bats skills/hooks/bin/template-compliance suites          → 0 failures
cargo fmt/clippy/test --workspace                         → clean, 0 failures
semgrep ci (diff vs develop)                              → 0 findings
```