### PR TITLE
fix(test-writer): mandate explicit stdin + timeout for subprocess-spawning tests

### DIFF
--- a/plugins/vsdd-factory/agents/test-writer.md
+++ b/plugins/vsdd-factory/agents/test-writer.md
@@ -88,6 +88,15 @@ implementation code exists. You enforce the Red Gate.
 - ALWAYS name tests using `test_BC_S_SS_NNN_xxx()` pattern
 - ALWAYS verify Red Gate (all tests must fail before implementation begins)
 - MUST NOT import or depend on implementation modules that do not yet exist
+- For any test that spawns a subprocess capable of interactive input (a
+  shell, a REPL, a TUI, or any command that may prompt), ALWAYS set stdin
+  explicitly to the null/closed equivalent and set a per-command timeout.
+  NEVER inherit stdin from the test runner: Rust
+  `.stdin(Stdio::null())`; Node `stdio: ['ignore', ...]`; Go set
+  `cmd.Stdin` to an empty/closed reader (`cmd.Stdin = nil` INHERITS —
+  that is the trap). Inherited stdin is invisible on CI (no TTY, stdin
+  closed) but hangs the suite locally in a terminal, and the hang is
+  routinely misdiagnosed as a product regression.
 
 ## Contract
 


### PR DESCRIPTION
## What

Adds one constraint to `agents/test-writer.md`: any test that spawns a subprocess capable of interactive input (shell, REPL, TUI, anything that may prompt) must set stdin explicitly to the null/closed equivalent and set a per-command timeout — never inherit from the test runner. Includes the per-language forms: Rust `.stdin(Stdio::null())`, Node `stdio: ['ignore', ...]`, Go closed reader (with the `cmd.Stdin = nil` INHERITS trap called out).

Refs: #424

## Why

Test-driver defaults (Rust `std::process::Command`/`assert_cmd`, Go `exec.Command`, Node `spawn`) inherit the runner's stdin. On CI there's no TTY and stdin is closed, so a subprocess that would prompt exits on EOF and the hazard is invisible; run the same suite locally in a terminal and it blocks on an interactive read until the harness times out or a human aborts. Observed shape: a CLI-integration test whose fallback path executes `/bin/sh` — green on CI, hang locally, initially misdiagnosed as a product regression. The fix was one line, but agentic test-writers emit the inherit-default pattern every time because nothing in the constraints says otherwise.

Agent-definition change only. (The adversary-side plumbing check and optional lint from #424's remediation list are intentionally out of scope for this PR — this is the highest-leverage, lowest-risk piece.)

## Test evidence (local, branched from develop @ f5242bef)

```
bats codify-lessons.bats + permissions.bats        → 0 failures
bats skills/hooks/bin/template-compliance suites   → 0 failures
cargo fmt/clippy/test --workspace                  → clean, 0 failures
semgrep ci (diff vs develop)                       → 0 findings
```