### PR TITLE
fix(adversary): mandatory ground-truth verification for CRITICAL/HIGH implementation findings

### DIFF
--- a/plugins/vsdd-factory/agents/adversary.md
+++ b/plugins/vsdd-factory/agents/adversary.md
@@ -170,6 +170,28 @@ Before finalizing findings, run a self-validation loop on each finding:
 2. **Actionability check**: Can someone fix this without ambiguity? If the finding is vague ("consider improving error handling"), sharpen it or drop it.
 3. **Duplication check**: Does this finding overlap with a prior finding in this pass? Merge duplicates.
 
+### Ground-Truth Verification for CRITICAL/HIGH Implementation Findings (MANDATORY)
+
+Reasoning from spec text ("BC says the daemon MUST ACK") to a code
+conclusion ("the code doesn't do it") without reading the code produces
+false BLOCKING findings. For every finding tagged CRITICAL or HIGH
+against implementation code, BEFORE it enters the final report:
+
+1. Extract the specific code claim (missing function, absent contract
+   wiring, wrong signature, unexported symbol).
+2. Run at least one `grep` or `Read` against the alleged deficient
+   file/symbol to verify the claim against the actual source.
+3. If the grep/Read contradicts the claim, remove the finding or
+   downgrade it with the contradiction noted.
+4. Cite the verified file:line in the finding body — for absence
+   claims, state where you looked: "Verified absent — grepped
+   `<symbol>` across `src/`, no definition."
+
+A CRITICAL/HIGH implementation finding without a verification citation
+is not reportable. Compile-state is corroborating evidence: if the
+workspace tests compile and pass, claims like "X is not exported" are
+contradicted by the build itself — check before reporting.
+
 **Max 3 refinement iterations per pass.** After 3 rounds of self-validation, ship what you have. Diminishing returns beyond 3 iterations is validated by the AgenticAKM study (29 repositories).
 
 ## Convergence


### PR DESCRIPTION
## What

Extends the adversary's Self-Validation Loop with a mandatory ground-truth verification step for CRITICAL/HIGH findings against implementation code: extract the specific code claim, run at least one grep/Read against the alleged deficient file/symbol, drop or downgrade on contradiction, and cite the verified file:line (or the absence-search scope) in the finding body. A CRITICAL/HIGH implementation finding without a verification citation is not reportable.

Refs: #465

## Why

Observed in the field: an adversary pass produced 8 findings of which 3 were verifiably false by direct code inspection — two tagged BLOCKING (an "ack byte never wired" claim refuted by the `write_all` call at the cited path; an "unexported function" claim refuted by 453 compiling, passing workspace tests that call it). Without a manual spot-check, the pass would have been declared NOT CLEAN on false grounds, burning a full convergence round trip.

Root cause: reasoning from spec text ("BC says MUST ACK") to a code conclusion ("code doesn't do it") without a mandatory read of the source. The existing evidence check asks whether a finding is "grounded in specific file paths" — but a hallucinated path satisfies that test. This closes the gap at the finding level; same defect class as the shipped-code grep gate proposed in #440.

Fits the agent's existing toolset (Read/Grep/Glob, read-only) and the existing path-corroboration discipline for absence findings (Worktree-Identity Preflight step 6) — this generalizes that discipline from "absent file" claims to all CRITICAL/HIGH code claims.

Agent-definition change only.

## Test evidence (local, branched from develop @ f5242bef)

```
bats per-story-adversary-workflow.bats (reads adversary.md)   → 0 failures
bats worktree-identity-preflight.bats (greps adversary.md)    → 0 failures
bats codify-lessons.bats (greps adversary.md)                 → 0 failures
bats permissions/skills/hooks/bin/template-compliance         → 0 failures
cargo fmt/clippy/test --workspace                             → clean, 0 failures
semgrep ci (diff vs develop)                                  → 0 findings
```