### PR TITLE
feat(per-story-delivery): story-level holdout gate — three-tier holdout evaluation

### DIFF
--- a/docs/guide/phase-3-tdd-delivery.md
+++ b/docs/guide/phase-3-tdd-delivery.md
@@ -23,7 +23,11 @@ graph TD
         RG -->|Fail| S3FIX[Fix tests]
         S3FIX --> RG
         RG -->|Pass| S4[Step 4: Implement via TDD]
-        S4 --> S5[Step 5: Record demos]
+        S4 --> S4A[Step 4A: Adversarial convergence]
+        S4A --> S4B{Step 4B: Story holdout gate}
+        S4B -->|FAIL: observed behavior gap| S4BFIX[Implementer fix + streak reset]
+        S4BFIX --> S4A
+        S4B -->|PASS| S5[Step 5: Record demos]
         S5 --> S6[Step 6: Push branch]
         S6 --> S7[Step 7: PR lifecycle]
         S7 --> S8[Step 8: Cleanup worktree]
@@ -81,6 +85,12 @@ graph LR
     subgraph "Step 4"
         IMP[implementer]
     end
+    subgraph "Step 4A"
+        ADV[adversary<br/>3-CLEAN convergence]
+    end
+    subgraph "Step 4B"
+        HE[holdout-evaluator<br/>story scenarios]
+    end
     subgraph "Step 5"
         DR[demo-recorder]
     end
@@ -97,13 +107,16 @@ graph LR
     DE1 -->|worktree| TW1
     TW1 -->|stubs| TW2
     TW2 -->|RED GATE| IMP
-    IMP -->|green tests| DR
+    IMP -->|green tests| ADV
+    ADV -->|3-CLEAN| HE
+    HE -->|PASS| DR
     DR -->|demos| IMP2
     IMP2 -->|pushed| PM
     PM -->|merged| DE2
 
     style TW2 fill:#f8d7da
     style IMP fill:#d4edda
+    style HE fill:#fff3cd
 ```
 
 ### Step 1: Create Worktree (devops-engineer)
@@ -180,6 +193,26 @@ For each test:
 #### Gene Transfusion
 
 When a story has `implementation_strategy: gene-transfusion`, the implementer reads `.factory/semport/<module>/<module>-target-design.md` and the reference source files listed in the story. It uses the translation strategy from semport analysis. Uncertain translations are marked `// SEMPORT-REVIEW` for human inspection.
+
+### Step 4B: Story-Level Holdout Gate (holdout-evaluator)
+
+After adversarial convergence and before demo recording, the holdout-evaluator runs 2–4 hidden, single-use scenarios authored by the product-owner at story-materialization time against the built binary.
+
+**Why this gate exists.** Unit tests and code-diff adversarial review both operate on the implementation's internal structure. They miss a class of defects that only manifest when the implementation is exercised end-to-end through its public surface: wire-shape mismatches, unreachable spec arms (postconditions that exist in the BC but are only reached through code paths that tests never drive), and composition failures where two individually-correct subsystems interact incorrectly. Field evidence from prism: 3 such defects escaped a 5,483-test suite and 40+ adversarial passes, and were caught only by a live holdout-style audit of observed output. Story-level holdout closes that gap per-story rather than per-wave.
+
+**Three-tier holdout architecture:**
+
+| Tier | When | Scope | Pool | Consumed |
+|------|------|-------|------|---------|
+| **Story** (this gate) | After adversarial convergence, before demo | Story's touched surface only | 2–4 per story, `story-scenarios/STORY-NNN/` | Yes — single-use |
+| **Wave** | After all wave stories merge (wave gate) | Full wave behavioral surface | Wave-scoped `wave-scenarios/<wave>/` | No — cycle-reset |
+| **Final** (Phase 4) | After all waves complete | Full pipeline behavioral surface | Main `HS-NNN` lifecycle pool | No — rotated 80% |
+
+**Information asymmetry wall:** The holdout-evaluator sees ONLY the story's scenario files, the product brief, and the running binary. It cannot read specs, source code, behavioral contracts, or adversarial review history. This is the same wall that applies at the wave and final tiers.
+
+**BLOCKING semantics:** Any unsatisfied scenario (score < 0.80) blocks demo recording. The holdout-evaluator sends OBSERVED_BEHAVIOR_ONLY descriptions to the orchestrator — it never quotes or paraphrases scenario text (contamination control). The orchestrator dispatches the implementer with only the behavioral gap description. After the fix, the adversary convergence streak resets to 0/3 and must reach 3-CLEAN before the next holdout attempt.
+
+**Exit condition:** Every scenario score >= 0.80 AND mean >= 0.80. Consumed scenarios are marked `lifecycle_status: consumed` and moved to `.factory/holdout-scenarios/evaluations/story-STORY-NNN/`.
 
 ### Step 5: Record Demos (demo-recorder)
 
@@ -360,6 +393,12 @@ If the implementer hits bugs during TDD, the `/vsdd-factory:systematic-debugging
 | "I'll skip demo-recording and do it after the merge" | Demos are part of the merge gate. Dispatch demo-recorder before pr-manager. |
 | "Red Gate failed because the tests are too strict" | Red Gate failure means the test or the contract understanding is wrong. Investigate. |
 | "This feels like a lot of context switching" | That is the feature. Fresh context per specialist prevents single-agent drift. |
+| "The story holdout only has 2 scenarios, they're probably not catching anything new" | Each scenario tests a BC arm that unit tests reach only via mocks. Even 1 unsatisfied scenario has blocked ship. |
+| "I'll show the holdout-evaluator the spec so it can test more accurately" | That breaks the asymmetry wall. Evaluator gets only product-brief.md + scenarios + binary. |
+| "The holdout scenario is wrong, let me fix it before running" | Scenarios are authored before implementation. A failing scenario is a finding. Investigate whether the scenario or the implementation is wrong. |
+| "Story holdout scored 0.78, basically 0.80" | 0.80 is the threshold. 0.78 fails. No rounding. |
+| "I'll tell the holdout-evaluator which tests pass so it can focus" | Test pass/fail from the test-writer leaks implementation knowledge. Evaluator runs its own behavioral exercises. |
+| "The story holdout found a gap — I'll just note it and proceed to demos" | Story holdout is BLOCKING. Fix the gap, reset adversary streak, re-gate before demos. |
 
 ### Wave Gate
 

--- a/plugins/vsdd-factory/agents/holdout-evaluator.md
+++ b/plugins/vsdd-factory/agents/holdout-evaluator.md
@@ -16,6 +16,36 @@ Read and follow the output format in:
 
 You are a black-box evaluator. Your job is to determine whether an implementation satisfies hidden acceptance scenarios **without knowledge of how it was built**.
 
+## Evaluation Modes
+
+You operate in two distinct modes. Read the task instruction to determine which applies.
+
+### Mode A — Story-Level Holdout Gate (BC-5.39.003)
+
+Triggered by: `story-holdout-gate` step during per-story delivery (Phase 3).
+
+**Scope:** Single story's touched public surface only — not the full pipeline. Execution should complete in minutes, not hours.
+
+**Scenario source:** `.factory/holdout-scenarios/story-scenarios/STORY-NNN/` (2–4 files). These are SINGLE-USE: mark each scenario `lifecycle_status: consumed` after evaluation. Write evaluation output to `.factory/holdout-scenarios/evaluations/story-STORY-NNN/`.
+
+**Gate threshold:** Every scenario score >= 0.80; mean >= 0.80 across all 2–4 scenarios.
+
+**Reporting discipline (contamination control):** When any scenario is unsatisfied, report OBSERVED_BEHAVIOR_ONLY to the orchestrator — describe what the public surface produced, never quote or paraphrase scenario text. Scenario leakage to the implementer corrupts the asymmetry wall for all future evaluations on this story.
+
+**Consumed scenarios are non-recoverable:** Once consumed, a story-level scenario is never re-run for that story. If the implementer fixes a gap and re-gates, the new gate run uses only the remaining unconsumed scenarios. If all scenarios are consumed before the gate passes, escalate to the orchestrator — do not invent new scenarios.
+
+### Mode B — Wave-Level Holdout Evaluation (Phase 4)
+
+Triggered by: `holdout-eval` skill or `phase-4-holdout-evaluation.lobster` after all wave stories merge.
+
+**Scope:** Full wave behavioral surface.
+
+**Scenario source:** `.factory/holdout-scenarios/wave-scenarios/<wave>/` (wave-scoped pool, cycle-reset).
+
+**Gate threshold:** Mean satisfaction >= 0.85; every critical scenario >= 0.60.
+
+The detailed process for Mode B is described in the Evaluation Process section below.
+
 ## Information Asymmetry Wall
 
 You **CANNOT** access:
@@ -25,15 +55,39 @@ You **CANNOT** access:
 - `.factory/semport/` — no translation artifacts
 - PR history or commit messages with implementation details
 - Test source code (you test behavior, not test structure)
+- `.factory/holdout-scenarios/story-scenarios/` for any story other than the one you are evaluating
 
 You **CAN** access:
-- `.factory/holdout-scenarios/` — your hidden acceptance scenarios
+- `.factory/holdout-scenarios/story-scenarios/STORY-NNN/` (Mode A only — the specific story assigned)
+- `.factory/holdout-scenarios/wave-scenarios/<wave>/` (Mode B only)
 - `.factory/specs/product-brief.md` — high-level product description only
 - Public API surface (CLI help, API endpoints, exported types)
 - Running the application and observing behavior
 - Test output (pass/fail, not test source)
 
-## Evaluation Process
+## Evaluation Process (Mode A — Story-Level)
+
+### 1. Load story scenarios
+
+Read all scenario files from `.factory/holdout-scenarios/story-scenarios/STORY-NNN/`. There will be 2–4 files. If the directory is empty or missing, escalate to the orchestrator — do NOT proceed.
+
+### 2. Build and exercise the story surface
+
+From the worktree path specified in your task:
+- Build the binary if not already built
+- For each scenario: execute the action through the public interface using only the story's touched API surface
+- Observe the actual behavior (output bytes, exit codes, HTTP response shapes)
+
+### 3. Score each scenario and mark consumed
+
+Use the 0.0–1.0 scale below. After scoring, set `lifecycle_status: consumed` on each scenario file. Write the evaluation report to `.factory/holdout-scenarios/evaluations/story-STORY-NNN/story-holdout-evaluation.json`.
+
+### 4. Report gate result
+
+- **PASS**: Every scenario scored >= 0.80 AND mean >= 0.80 → report `story_holdout.gate = PASS`
+- **FAIL**: Any scenario scored < 0.80 → report `story_holdout.gate = FAIL` with OBSERVED_BEHAVIOR_ONLY descriptions (never quote scenario text)
+
+## Evaluation Process (Mode B — Wave-Level)
 
 ### 1. Load scenarios
 
@@ -84,6 +138,11 @@ Write to `.factory/holdout-scenarios/evaluations/`:
 
 ### 5. Gate criteria
 
+**Mode A (story-level):**
+- **PASS**: Every scenario score >= 0.80 AND mean >= 0.80
+- **FAIL**: Any scenario below 0.80 — report OBSERVED_BEHAVIOR_ONLY gaps for implementer
+
+**Mode B (wave-level):**
 - **PASS**: Mean satisfaction ≥ 0.85, every critical scenario ≥ 0.60
 - **FAIL**: Below thresholds — report gaps for remediation
 

--- a/plugins/vsdd-factory/agents/holdout-evaluator.md
+++ b/plugins/vsdd-factory/agents/holdout-evaluator.md
@@ -26,7 +26,7 @@ Triggered by: `story-holdout-gate` step during per-story delivery (Phase 3).
 
 **Scope:** Single story's touched public surface only — not the full pipeline. Execution should complete in minutes, not hours.
 
-**Scenario source:** `.factory/holdout-scenarios/story-scenarios/STORY-NNN/` (2–4 files). These are SINGLE-USE: mark each scenario `lifecycle_status: consumed` after evaluation. Write evaluation output to `.factory/holdout-scenarios/evaluations/story-STORY-NNN/`.
+**Scenario source:** `.factory/holdout-scenarios/story-scenarios/STORY-NNN/` (2–4 files). These are SINGLE-USE. After you report your evaluation results to stdout, the state-manager backup step marks each scenario `lifecycle_status: consumed` and writes the evaluation report to `.factory/holdout-scenarios/evaluations/story-STORY-NNN/` — you do not write files directly (your tool profile is `Bash, Read` only).
 
 **Gate threshold:** Every scenario score >= 0.80; mean >= 0.80 across all 2–4 scenarios.
 
@@ -80,7 +80,7 @@ From the worktree path specified in your task:
 
 ### 3. Score each scenario
 
-Use the 0.0–1.0 scale below. You have `Read` and `Bash` access only — you do NOT write files directly. Output the evaluation JSON to stdout; the `backup-story-holdout-gate` state-manager step writes it to `.factory/holdout-scenarios/evaluations/story-STORY-NNN/story-holdout-evaluation.json` and marks each scenario `lifecycle_status: consumed`.
+Use the 0.0–1.0 scale below. You have `Read` and `Bash` access only — you do NOT write files directly. Output the evaluation JSON to stdout; the state-manager backup step (named `backup-story-holdout` in code-delivery.lobster and `backup-story-holdout-gate` in phase-3-tdd-implementation.lobster) writes it to `.factory/holdout-scenarios/evaluations/story-STORY-NNN/story-holdout-evaluation.json` and marks each scenario `lifecycle_status: consumed`.
 
 ### 4. Report gate result
 

--- a/plugins/vsdd-factory/agents/holdout-evaluator.md
+++ b/plugins/vsdd-factory/agents/holdout-evaluator.md
@@ -32,7 +32,7 @@ Triggered by: `story-holdout-gate` step during per-story delivery (Phase 3).
 
 **Reporting discipline (contamination control):** When any scenario is unsatisfied, report OBSERVED_BEHAVIOR_ONLY to the orchestrator — describe what the public surface produced, never quote or paraphrase scenario text. Scenario leakage to the implementer corrupts the asymmetry wall for all future evaluations on this story.
 
-**Consumed scenarios are non-recoverable:** Once consumed, a story-level scenario is never re-run for that story. If the implementer fixes a gap and re-gates, the new gate run uses only the remaining unconsumed scenarios. If all scenarios are consumed before the gate passes, escalate to the orchestrator — do not invent new scenarios.
+**Consumed scenarios are non-recoverable:** Once consumed (marked by state-manager after your report), a story-level scenario is never re-run for that story. If the implementer fixes a gap and re-gates, the new gate run uses only the remaining unconsumed scenarios. If all scenarios are consumed before the gate passes, escalate to the orchestrator — do not invent new scenarios.
 
 ### Mode B — Wave-Level Holdout Evaluation (Phase 4)
 
@@ -78,9 +78,9 @@ From the worktree path specified in your task:
 - For each scenario: execute the action through the public interface using only the story's touched API surface
 - Observe the actual behavior (output bytes, exit codes, HTTP response shapes)
 
-### 3. Score each scenario and mark consumed
+### 3. Score each scenario
 
-Use the 0.0–1.0 scale below. After scoring, set `lifecycle_status: consumed` on each scenario file. Write the evaluation report to `.factory/holdout-scenarios/evaluations/story-STORY-NNN/story-holdout-evaluation.json`.
+Use the 0.0–1.0 scale below. You have `Read` and `Bash` access only — you do NOT write files directly. Output the evaluation JSON to stdout; the `backup-story-holdout-gate` state-manager step writes it to `.factory/holdout-scenarios/evaluations/story-STORY-NNN/story-holdout-evaluation.json` and marks each scenario `lifecycle_status: consumed`.
 
 ### 4. Report gate result
 

--- a/plugins/vsdd-factory/agents/orchestrator/per-story-delivery.md
+++ b/plugins/vsdd-factory/agents/orchestrator/per-story-delivery.md
@@ -24,6 +24,26 @@ Reference file for the orchestrator. Load during Phase 3 implementation.
       - Loop until passes_clean >= 3 AND last_classification == "NITPICK_ONLY"
       - State file: .factory/cycles/<cycle-id>/<story-id>/adversary-convergence-state.json
       - Step 5 MUST NOT begin while convergence criterion is not met
+      - Context WALL: adversary MUST NOT see .factory/holdout-scenarios/story-scenarios/**
+   c3. Run story-level holdout gate (BC-5.39.003):
+      - Spawn holdout-evaluator with ONLY: .factory/holdout-scenarios/story-scenarios/STORY-NNN/
+        + .factory/specs/product-brief.md + running binary (built in .worktrees/STORY-NNN/)
+      - Evaluator exercises the story's public surface via wire-level output assertions;
+        scope is bounded to the story's TOUCHED surface — minutes, not hours
+      - Scenarios: 2–4 per story; SINGLE-USE; authored by product-owner at story-materialization
+        time (Phase 2); test-writer and implementer have NEVER read them (strict asymmetry wall)
+      - Gate threshold: every scenario score >= 0.80 (mean >= 0.80 across 2–4 scenarios)
+      - BLOCKING: any unsatisfied scenario → holdout-evaluator reports OBSERVED_BEHAVIOR_ONLY
+        to orchestrator (never scenario text — contamination control prevents scenario leakage
+        to implementer) → orchestrator dispatches implementer with observed-behavior description
+        → implementer fixes → adversary convergence streak RESETS to 0/3 → re-gate from c2
+      - PASS: all scenarios satisfied → mark each scenario lifecycle_status: consumed and
+        move to .factory/holdout-scenarios/evaluations/story-STORY-NNN/ (scenarios are
+        single-use: consumed at first evaluation, never re-run for this story)
+      - Three-tier separation: story scenarios (here), wave scenarios (Step 3f wave gate),
+        and end-of-pipeline scenarios (Phase 4) are independent pools — consuming story
+        scenarios does NOT affect the wave or final evaluation pools
+      - Step 5 (demo recording) MUST NOT begin until holdout gate passes
    d. Spawn demo-recorder: "Record per-AC demos in .worktrees/STORY-NNN/.
       Output to docs/demo-evidence/<STORY-ID>/ (committed to feature branch).
       The <STORY-ID> subfolder prevents evidence-report.md and AC-*.md collisions across stories.

--- a/plugins/vsdd-factory/agents/product-owner.md
+++ b/plugins/vsdd-factory/agents/product-owner.md
@@ -264,6 +264,58 @@ When an R-NNN has `NFR candidate: yes` in its Mitigation:
 - Set the NFR's `Risk Source` column to the originating R-NNN
 - The NFR must have a numerical target derived from the risk's quantifiable mitigation
 
+### Per-Story Holdout Scenario Authorship (BC-5.39.003)
+
+At story-materialization time (Phase 2, when each story file is finalized), you author 2–4 hidden, single-use holdout scenarios per story. These are separate from wave-level scenarios (HS-NNN pool) and the end-of-pipeline evaluation pool — they form the first tier of the three-tier holdout architecture.
+
+**Authorship rules:**
+
+1. **Write during Phase 2, not Phase 3.** Scenarios must be authored before test-writer and implementer ever see the story. The holdout wall is established at materialization — scenarios written after implementation begins are compromised.
+
+2. **Single-use.** Each scenario is evaluated exactly once. After the holdout-evaluator runs it, it is marked `lifecycle_status: consumed` and moved to the evaluations directory. Never author replacement scenarios mid-story.
+
+3. **Wire-level assertions on observed output.** Focus on what the public surface emits: exit codes, response bytes, output field values, observable side-effects. Do NOT describe implementation internals.
+
+4. **Scoped to the story's touched surface.** A story-level scenario exercises only the API/CLI surface explicitly extended by this story. Do not test behaviors that belong to other stories.
+
+5. **2–4 per story.** Minimum: 2 (one happy path, one edge/error path). Maximum: 4. More than 4 per story defeats the purpose — keep them focused and fast to evaluate (minutes, not hours).
+
+6. **Cover different spec arms.** Design scenarios to reach BC postcondition arms that synthetic unit tests are unlikely to exercise end-to-end (composition paths, error cascades, output format details).
+
+**Directory layout:**
+
+```
+.factory/holdout-scenarios/
+  story-scenarios/
+    STORY-NNN/
+      SHS-NNN-001-[short-title].md   # happy path
+      SHS-NNN-002-[short-title].md   # edge/error path
+      SHS-NNN-003-[short-title].md   # optional: composition path
+      SHS-NNN-004-[short-title].md   # optional: output-shape assertion
+  evaluations/
+    story-STORY-NNN/                  # written by holdout-evaluator after consumption
+  wave-scenarios/                     # separate pool; you author these at Phase 2 wave planning
+```
+
+**Frontmatter for story-level scenarios:**
+
+Use the standard holdout-scenario template with these additional fields:
+```yaml
+scope: story                         # distinguishes from wave/final scenarios
+story_id: STORY-NNN
+single_use: true
+lifecycle_status: active             # → consumed after evaluation
+```
+
+**What makes a good story-level scenario:**
+
+| Characteristic | Good | Bad |
+|---|---|---|
+| Assertion target | Observable output bytes, exit code, HTTP status + body | Internal state, log lines, database rows |
+| Scope | Story's single new endpoint/command/flag | Full pipeline behavior |
+| Distinctness | Tests a BC arm that unit tests reach only via mocks | Duplicates an existing unit test assertion |
+| Failure guidance | One-sentence behavioral gap description | "Fix the implementation" |
+
 ### Holdout Scenario Generation from ASM/R
 Generate holdout scenarios from high-impact assumptions and risks:
 - Every ASM with Impact-if-Wrong=HIGH or `Holdout candidate: yes` must have at least one holdout scenario with `assumption_source: ASM-NNN` in frontmatter

--- a/plugins/vsdd-factory/templates/holdout-scenario-template.md
+++ b/plugins/vsdd-factory/templates/holdout-scenario-template.md
@@ -15,13 +15,23 @@ must_pass: "true | false"
 priority: "must-pass | should-pass"
 epic_id: "EPIC-NNN"
 behavioral_contracts: []
+# Tier and reuse fields (DF-038)
+# scope: story | wave | final
+#   story — per-story holdout gate (BC-5.39.003); 2-4 per story; single-use;
+#            stored under .factory/holdout-scenarios/story-scenarios/STORY-NNN/
+#   wave  — wave integration holdout pool; cycle-scoped; stored under wave-scenarios/<wave>/
+#   final — end-of-pipeline HS-NNN lifecycle pool; rotated 80%; stored at root level
+scope: final                    # default; set to "story" or "wave" when applicable
+story_id: null                  # STORY-NNN when scope == story (required)
+single_use: false               # true when scope == story (consumed after first evaluation)
 # Lifecycle fields (DF-030)
-lifecycle_status: active        # active | stale | retired
+lifecycle_status: active        # active | stale | retired | consumed (story-scope only)
 introduced: vX.Y.Z             # cycle that created this scenario
 last_evaluated: null            # last cycle where this scenario was evaluated
 staleness_check: null           # last time maintenance sweep checked (YYYY-MM-DD)
 stale_reason: null              # why stale (e.g., "Scenario tests feature removed in v1.2.0")
 retired: null                   # cycle that retired (null if active)
+consumed: null                  # ISO timestamp when consumed by state-manager (story-scope only)
 # ASM/R source traceability (optional)
 assumption_source: null         # ASM-NNN if this scenario tests an assumption
 risk_source: null               # R-NNN if this scenario tests a risk

--- a/plugins/vsdd-factory/workflows/code-delivery.lobster
+++ b/plugins/vsdd-factory/workflows/code-delivery.lobster
@@ -254,6 +254,26 @@ workflow:
                     Re-run tests. Micro-commit each fix.
 
     # =========================================================================
+    # Step 4b-backup: Persist Holdout Evaluation Results (state-manager)
+    # Mirrors backup-story-holdout-gate in phase-3-tdd-implementation.lobster.
+    # This step is the sole write-owner for evaluation artifacts and consumed
+    # scenario marking — holdout-evaluator has Denied: Write by design.
+    # =========================================================================
+
+    - name: backup-story-holdout
+      type: agent
+      agent: state-manager
+      depends_on: [story-holdout-gate]
+      task: >
+        Persist story holdout evaluation results for story [story_id]:
+        1. Write evaluation report to
+           .factory/holdout-scenarios/evaluations/story-[story_id]/story-holdout-evaluation.json
+           (content from holdout-evaluator stdout)
+        2. For each scenario in .factory/holdout-scenarios/story-scenarios/[story_id]/:
+           set lifecycle_status: consumed and consumed: <ISO timestamp>
+        3. Update STATE.md: step: story-holdout-gate, status: complete, story: [story_id]
+
+    # =========================================================================
     # Step 5: E2E Tests (UI/full-stack only)
     # =========================================================================
 
@@ -333,7 +353,7 @@ workflow:
     - name: demo-recording
       type: agent
       agent: demo-recorder
-      depends_on: [story-holdout-gate]
+      depends_on: [backup-story-holdout]
       task: >
         Record per-AC demo evidence for [story_id] in [worktree_path]:
         1. Read story acceptance criteria

--- a/plugins/vsdd-factory/workflows/code-delivery.lobster
+++ b/plugins/vsdd-factory/workflows/code-delivery.lobster
@@ -4,8 +4,9 @@ workflow:
     Reusable per-story delivery sub-workflow. Invoked by greenfield.lobster,
     feature.lobster, maintenance.lobster, and multi-repo.lobster for each
     story that needs to be delivered. Encapsulates the complete flow:
-    worktree -> stubs -> Red Gate -> implement -> micro-commits -> demo ->
-    squash -> PR -> AI review -> security review -> converge -> merge -> cleanup.
+    worktree -> stubs -> Red Gate -> implement -> micro-commits -> adversarial
+    convergence -> story holdout gate -> demo -> squash -> PR -> AI review ->
+    security review -> converge -> merge -> cleanup.
 
     Cross-cutting infrastructure (DF-020-028) applies throughout. See
     docs/factory-paths.md Cross-Cutting Infrastructure section for shared baseline.
@@ -16,6 +17,10 @@ workflow:
     DF-037 additions: Storybook component test loop (D11/D18) with self-healing
     (max 10 iterations), per-story UI quality gate (D16) checking token compliance,
     a11y, component contract compliance, and async state coverage.
+    DF-038 additions: Story-level holdout gate (Step 4b, BC-5.39.003) — 2-4 hidden
+    single-use scenarios per story authored by product-owner at story-materialization
+    time; strict information asymmetry wall; wire-level output assertions scoped to
+    the story's touched surface; BLOCKING before demo recording.
   version: "2.0.0"
 
   inputs:
@@ -145,6 +150,65 @@ workflow:
               Micro-commit each fix.
 
     # =========================================================================
+    # Step 4b: Story-Level Holdout Gate (BC-5.39.003)
+    # 2-4 hidden, single-use scenarios per story authored by product-owner at
+    # story-materialization time. Strict information asymmetry wall: evaluator
+    # sees ONLY story-scenarios/STORY-NNN/ + product-brief.md + running binary.
+    # Wire-level output assertions scoped to the story's touched surface.
+    # BLOCKING: unsatisfied scenario (score < 0.80) → observed-behavior report to
+    # orchestrator (no scenario text) → implementer fix → adversary streak reset.
+    # =========================================================================
+
+    - name: story-holdout-gate
+      type: loop
+      depends_on: [per-story-adversarial-review]
+      loop:
+        max_iterations: 5
+        exit_condition: "story_holdout.gate == 'PASS'"
+        steps:
+          - name: run-story-holdout
+            type: agent
+            agent: holdout-evaluator
+            model_tier: adversary
+            task: >
+              Run story-level holdout evaluation for story [story_id].
+              Scope: bounded to this story's touched public surface only (minutes, not hours).
+              Read 2–4 hidden single-use scenarios from:
+                .factory/holdout-scenarios/story-scenarios/[story_id]/
+              Build and exercise the binary from [worktree_path].
+              Gate: every scenario must score >= 0.80; mean >= 0.80.
+              On completion: mark each scenario lifecycle_status: consumed.
+              Report format: OBSERVED_BEHAVIOR_ONLY — never include scenario text
+              in findings (contamination control prevents scenario leakage to implementer).
+            context:
+              include:
+                - ".factory/holdout-scenarios/story-scenarios/[story_id]/**"
+                - ".factory/specs/product-brief.md"
+              exclude:
+                # ▓ WALL: information asymmetry — no specs, no source, no prior passes
+                - ".factory/specs/prd.md"
+                - ".factory/specs/behavioral-contracts/**"
+                - ".factory/specs/architecture/**"
+                - ".factory/specs/prd-supplements/**"
+                - ".factory/cycles/**"
+                - ".factory/semport/**"
+                - "[worktree_path]/src/**"
+                - "[worktree_path]/tests/**"
+
+          - name: fix-story-holdout-findings
+            type: agent
+            agent: implementer
+            depends_on: [run-story-holdout]
+            condition: "story_holdout.gate == 'FAIL'"
+            task: >
+              Fix implementation gaps identified by story holdout gate.
+              You receive ONLY observed-behavior descriptions — no scenario text.
+              Re-run tests to verify fixes. Micro-commit each fix with message:
+              fix([story_id]): address story holdout observed behavior gap
+              NOTE: adversary convergence streak resets to 0/3 after this fix;
+              per-story-adversarial-review re-gates before next holdout attempt.
+
+    # =========================================================================
     # Step 5: E2E Tests (UI/full-stack only)
     # =========================================================================
 
@@ -224,7 +288,7 @@ workflow:
     - name: demo-recording
       type: agent
       agent: demo-recorder
-      depends_on: [per-story-adversarial-review]
+      depends_on: [story-holdout-gate]
       task: >
         Record per-AC demo evidence for [story_id] in [worktree_path]:
         1. Read story acceptance criteria

--- a/plugins/vsdd-factory/workflows/code-delivery.lobster
+++ b/plugins/vsdd-factory/workflows/code-delivery.lobster
@@ -165,6 +165,11 @@ workflow:
       loop:
         max_iterations: 5
         exit_condition: "story_holdout.gate == 'PASS'"
+        # DESIGN: Each iteration = holdout run → (if FAIL) implementer fix →
+        # adversary re-convergence → next holdout attempt.
+        # The adversary re-convergence step is MANDATORY on any holdout failure:
+        # the implementer fix may introduce regressions and the adversary streak
+        # must restart from 0/3 (per-story-delivery.md step c3, BC-5.39.003).
         steps:
           - name: run-story-holdout
             type: agent
@@ -177,7 +182,8 @@ workflow:
                 .factory/holdout-scenarios/story-scenarios/[story_id]/
               Build and exercise the binary from [worktree_path].
               Gate: every scenario must score >= 0.80; mean >= 0.80.
-              On completion: mark each scenario lifecycle_status: consumed.
+              Report evaluation results for state-manager to persist — do NOT write files
+              directly (state-manager owns the evaluation write and consumed-scenario marking).
               Report format: OBSERVED_BEHAVIOR_ONLY — never include scenario text
               in findings (contamination control prevents scenario leakage to implementer).
             context:
@@ -205,8 +211,47 @@ workflow:
               You receive ONLY observed-behavior descriptions — no scenario text.
               Re-run tests to verify fixes. Micro-commit each fix with message:
               fix([story_id]): address story holdout observed behavior gap
-              NOTE: adversary convergence streak resets to 0/3 after this fix;
-              per-story-adversarial-review re-gates before next holdout attempt.
+
+          - name: re-converge-after-holdout-fix
+            type: loop
+            depends_on: [fix-story-holdout-findings]
+            condition: "story_holdout.gate == 'FAIL'"
+            # Adversary streak resets to 0/3 after any holdout-driven fix.
+            # This nested loop enforces BC-5.39.001 3-CLEAN before the outer
+            # loop retries the holdout evaluation.
+            loop:
+              max_iterations: 10
+              exit_condition: "adversary.verdict == 'CONVERGENCE_REACHED'"
+              steps:
+                - name: re-run-adversary-after-holdout
+                  type: agent
+                  agent: adversary
+                  model_tier: adversary
+                  task: >
+                    Re-run adversarial convergence for story [story_id] after a
+                    story holdout fix. The implementer fixed a behavioral gap;
+                    verify no regression was introduced. Streak resets to 0/3.
+                    Report CONVERGENCE_REACHED only when 3 consecutive passes
+                    are CLEAN (strict: zero findings of any severity).
+                  context:
+                    include:
+                      - "[worktree_path]/src/**"
+                      - "[worktree_path]/tests/**"
+                      - ".factory/stories/[story_id].md"
+                      - ".factory/specs/behavioral-contracts/**"
+                    exclude:
+                      - ".factory/holdout-scenarios/**"
+                      - ".factory/cycles/**/adversarial-reviews/**"
+                      - ".factory/semport/**"
+
+                - name: fix-regression-after-holdout
+                  type: agent
+                  agent: implementer
+                  depends_on: [re-run-adversary-after-holdout]
+                  condition: "adversary.has_blocking_findings == true"
+                  task: >
+                    Fix adversary findings introduced by the holdout fix in [worktree_path].
+                    Re-run tests. Micro-commit each fix.
 
     # =========================================================================
     # Step 5: E2E Tests (UI/full-stack only)

--- a/plugins/vsdd-factory/workflows/phases/phase-3-tdd-implementation.lobster
+++ b/plugins/vsdd-factory/workflows/phases/phase-3-tdd-implementation.lobster
@@ -87,12 +87,31 @@ workflow:
         Update STATE.md: phase: 3, step: adversary-convergence, status: complete.
         Commit adversary-convergence-state.json to factory-artifacts.
 
+    # === Step D.6: Story-Level Holdout Gate (BC-5.39.003) ===
+    # 2-4 hidden single-use scenarios authored by product-owner at story-materialization time.
+    # Strict information asymmetry: evaluator sees only story-scenarios/ + product-brief.md + binary.
+    # BLOCKING: unsatisfied scenario resets adversary streak to 0/3 and requires an implementer fix.
+
+    - name: story-holdout-gate
+      type: skill
+      skill: "skills/deliver-story/steps/step-d6-story-holdout.md"
+      depends_on: [backup-adversary-convergence]
+
+    - name: backup-story-holdout-gate
+      type: agent
+      agent: state-manager
+      depends_on: [story-holdout-gate]
+      task: >
+        Update STATE.md: phase: 3, step: story-holdout-gate, status: complete.
+        Commit story-holdout-evaluation.json and consumed-scenarios.json to factory-artifacts.
+        Mark each evaluated scenario lifecycle_status: consumed in story-scenarios/STORY-NNN/.
+
     # === Step E: Record Demos ===
 
     - name: record-demos
       type: skill
       skill: "skills/deliver-story/steps/step-e-record-demos.md"
-      depends_on: [backup-adversary-convergence]
+      depends_on: [backup-story-holdout-gate]
 
     - name: backup-record-demos
       type: agent
@@ -143,6 +162,8 @@ workflow:
           - "Implementation follows purity boundary map"
           - "No unwrap() in production code"
           - "Clippy/lint passes with zero warnings"
+          - "Story-level holdout gate passed (all 2-4 scenarios satisfied, score >= 0.80)"
+          - "Story holdout scenarios marked consumed and moved to evaluations/"
           - "Demo evidence covers all acceptance criteria"
           - "PR merged to develop"
           - "Worktree cleaned up"


### PR DESCRIPTION
## Summary

- Adds a **story-level holdout gate** (BC-5.39.003) to the per-story delivery cycle, positioned after local adversarial convergence (3-CLEAN) and before demo recording. This is the first tier of a three-tier holdout architecture: story → wave → final.
- Product-owner authors 2–4 hidden, single-use scenarios per story at story-materialization time (Phase 2); test-writer and implementer never see them. Holdout-evaluator exercises the story's touched public surface via wire-level output assertions, bounded to minutes per story. Gate threshold: every scenario >= 0.80, mean >= 0.80.
- BLOCKING: any unsatisfied scenario routes `OBSERVED_BEHAVIOR_ONLY` to the orchestrator (no scenario text — contamination control), implementer fixes, adversary streak resets to 0/3, and re-gates before demo recording can proceed.

## Five design parameters

1. **Strict information asymmetry** — evaluator receives only `story-scenarios/STORY-NNN/` + `product-brief.md` + running binary. No specs, no source, no adversarial history.
2. **Single-use scenarios** — each scenario is marked `lifecycle_status: consumed` after the first evaluation and never re-run for that story. Prevents scenario-gaming.
3. **Contamination control** — findings flow as `OBSERVED_BEHAVIOR_ONLY` (what the public surface produced); scenario text is never quoted in findings to the implementer.
4. **Streak reset on failure** — an implementer fix after holdout failure resets the adversary 3-CLEAN streak to 0/3. The adversary re-gates before the next holdout attempt to prevent regression.
5. **Three-tier separation** — story scenarios (`story-scenarios/`), wave scenarios (`wave-scenarios/<wave>/`), and the lifecycle HS-NNN pool are independent. Consuming story-level scenarios does not affect wave or final evaluation pools.

## Prism field evidence

Motivated by a live holdout-style audit on prism (2026-07-13) that identified 3 behavioral defects escaping a 5,483-test suite and 40+ adversarial passes:
- Wire-shape mismatches not caught by unit tests (which mock at the adapter boundary)
- A BC postcondition arm reachable only through an end-to-end composition path never exercised by TDD tests
- An output-format field whose value was correct in isolation but wrong when composed with a sibling field

Each defect was found within minutes of exercising the public surface with a wire-level assertion. The story-level gate makes this a systematic, per-story practice rather than a one-off audit.

## Integration points

| File | Change |
|---|---|
| `agents/orchestrator/per-story-delivery.md` | New step c3 with full design spec and three-tier separation note |
| `workflows/phases/phase-3-tdd-implementation.lobster` | New steps `story-holdout-gate` + backup, updated `record-demos` depends_on, updated gate criteria |
| `workflows/code-delivery.lobster` | New Step 4b loop with evaluator context walls, updated `demo-recording` depends_on, DF-038 description |
| `agents/holdout-evaluator.md` | Mode A (story-level) + Mode B (wave-level) distinction; consumed semantics; contamination control discipline |
| `agents/product-owner.md` | Per-story holdout scenario authorship obligation at story-materialization time; directory layout; frontmatter fields; quality table |
| `docs/guide/phase-3-tdd-delivery.md` | Updated Mermaid diagrams (both overview and specialist dispatch), Step 4B narrative section, updated red flags table |

Both `.lobster` files parse clean under `bin/lobster-parse`.