### PR TITLE
fix(test-writer): correct Go nil Stdin guidance — nil reads from null device, os.Stdin wiring is the trap

### DIFF
--- a/plugins/vsdd-factory/agents/test-writer.md
+++ b/plugins/vsdd-factory/agents/test-writer.md
@@ -91,13 +91,14 @@ implementation code exists. You enforce the Red Gate.
 - For any test that spawns a subprocess capable of interactive input (a
   shell, a REPL, a TUI, or any command that may prompt), ALWAYS set stdin
   explicitly to the null/closed equivalent and set a per-command timeout.
-  NEVER inherit stdin from the test runner: Rust
-  `.stdin(Stdio::null())`; Node `stdio: ['ignore', ...]`; Go leave
-  `cmd.Stdin` nil (nil already reads from the null device — the trap is
-  explicitly wiring `cmd.Stdin = os.Stdin`). Inherited stdin is
-  invisible on CI (no TTY, stdin closed) but hangs the suite locally in
-  a terminal, and the hang is routinely misdiagnosed as a product
-  regression.
+  NEVER leave the child's stdin interactive or unclosed: Rust
+  `.stdin(Stdio::null())` (spawn/status inherit stdin by default); Node
+  `stdio: ['ignore', ...]` (the default 'pipe' hangs a stdin-reading
+  child if the pipe is never written or closed); Go leave `cmd.Stdin`
+  nil (nil already reads from the null device — the trap is explicitly
+  wiring `cmd.Stdin = os.Stdin`). Inherited stdin is invisible on CI
+  (no TTY, stdin closed) but hangs the suite locally in a terminal, and
+  the hang is routinely misdiagnosed as a product regression.
 
 ## Contract
 

--- a/plugins/vsdd-factory/agents/test-writer.md
+++ b/plugins/vsdd-factory/agents/test-writer.md
@@ -92,11 +92,12 @@ implementation code exists. You enforce the Red Gate.
   shell, a REPL, a TUI, or any command that may prompt), ALWAYS set stdin
   explicitly to the null/closed equivalent and set a per-command timeout.
   NEVER inherit stdin from the test runner: Rust
-  `.stdin(Stdio::null())`; Node `stdio: ['ignore', ...]`; Go set
-  `cmd.Stdin` to an empty/closed reader (`cmd.Stdin = nil` INHERITS —
-  that is the trap). Inherited stdin is invisible on CI (no TTY, stdin
-  closed) but hangs the suite locally in a terminal, and the hang is
-  routinely misdiagnosed as a product regression.
+  `.stdin(Stdio::null())`; Node `stdio: ['ignore', ...]`; Go leave
+  `cmd.Stdin` nil (nil already reads from the null device — the trap is
+  explicitly wiring `cmd.Stdin = os.Stdin`). Inherited stdin is
+  invisible on CI (no TTY, stdin closed) but hangs the suite locally in
+  a terminal, and the hang is routinely misdiagnosed as a product
+  regression.
 
 ## Contract
 


### PR DESCRIPTION
## Summary

Corrects two factual imprecisions in the subprocess-stdin discipline bullet introduced by PR #531 (dc110e03).

**Commit 1 — Go correction (b1ff2457):** PR #531 said \`cmd.Stdin = nil\` INHERITS — that is the trap. This is wrong. Per the Go \`os/exec\` documentation, a nil \`Cmd.Stdin\` means the child reads from the null device (\`os.DevNull\`); nil is the safe default. The actual trap is the opposite: explicitly wiring \`cmd.Stdin = os.Stdin\`, which causes the subprocess to compete with the test runner for terminal input.

**Commit 2 — Node precision (1aafa74b):** The original text implied the Node hazard was stdin inheritance. The actual hazard is that Node's default \`stdio\` option is \`'pipe'\` — a \`'pipe'\` stdin hangs a stdin-reading child process if the pipe is never written to or closed. The fix (\`stdio: ['ignore', ...]\`) is the same; this commit makes the diagnosis accurate so readers understand *why* the fix is needed.

The Rust guidance is also clarified: \`spawn\`/\`status\` inherit stdin by default, so \`.stdin(Stdio::null())\` is the explicit safe form.

No logic changes — doc-only corrections to \`plugins/vsdd-factory/agents/test-writer.md\`. References PR #531.

## Files changed

- \`plugins/vsdd-factory/agents/test-writer.md\` — subprocess-stdin discipline bullet, two clauses corrected

## Test plan

- [ ] Doc-only change; no runtime surface to drive
- [ ] Go clause: nil Cmd.Stdin reads from null device per \`os/exec\` docs
- [ ] Node clause: default \`'pipe'\` hangs unclosed; \`'ignore'\` is the fix