### PR TITLE
fix(bin): preserve trailing newlines in compute-input-hash accumulation

### DIFF
--- a/plugins/vsdd-factory/bin/compute-input-hash
+++ b/plugins/vsdd-factory/bin/compute-input-hash
@@ -215,7 +215,13 @@ case "$FILE" in
     ;;
 esac
 
-CONCAT=""
+# Accumulate raw input bytes into a temp file rather than a shell variable.
+# Command substitution ($(cat file)) strips all trailing newlines, so the hash
+# diverges from any raw-byte reader (md5sum <file, Python rb.read()) — see #637.
+# Appending with `cat file >> tmpfile` does not go through a subshell and
+# preserves every byte, including trailing newlines.
+HASH_INPUT=$(mktemp)
+trap 'rm -f "$HASH_INPUT"' EXIT
 MISSING=0
 MISSING_FILES=""
 
@@ -331,7 +337,7 @@ while IFS= read -r input_file; do
     fi
     while IFS= read -r expanded_file; do
       [[ -z "$expanded_file" ]] && continue
-      CONCAT="${CONCAT}$(cat "$expanded_file")"
+      cat "$expanded_file" >> "$HASH_INPUT"
     done <<< "$EXPANDED"
     continue
   fi
@@ -345,10 +351,10 @@ while IFS= read -r input_file; do
     continue
   fi
 
-  CONCAT="${CONCAT}$(cat "$RESOLVED")"
+  cat "$RESOLVED" >> "$HASH_INPUT"
 done <<< "$INPUTS"
 
-if [[ -z "$CONCAT" ]]; then
+if [[ ! -s "$HASH_INPUT" ]]; then
   if [[ "$MODE" == "--resolve" ]]; then
     echo "compute-input-hash: $(basename "$FILE"): $MISSING MISSING — $MISSING_FILES" >&2
     exit 1
@@ -383,11 +389,13 @@ if [[ "$MISSING" -gt 0 ]]; then
 fi
 
 # --- Compute short MD5 hash (7 chars) ---
+# Hash the accumulated bytes directly from the temp file so trailing newlines
+# are preserved and the digest matches any raw-byte reader (md5sum <file) — #637.
 if command -v md5sum &>/dev/null; then
-  HASH=$(echo -n "$CONCAT" | md5sum | cut -c1-7)
+  HASH=$(md5sum < "$HASH_INPUT" | cut -c1-7)
 elif command -v md5 &>/dev/null; then
   # macOS
-  HASH=$(echo -n "$CONCAT" | md5 | cut -c1-7)
+  HASH=$(md5 < "$HASH_INPUT" | cut -c1-7)
 else
   die "neither md5sum nor md5 available"
 fi

--- a/plugins/vsdd-factory/tests/input-hash.bats
+++ b/plugins/vsdd-factory/tests/input-hash.bats
@@ -295,6 +295,61 @@ EOF
   [[ "$output" == *"nonexistent.md"* ]]
 }
 
+# ===== regression: trailing-newline byte fidelity (#637) =====
+
+@test "compute-input-hash: hash matches byte-accurate reference for input with trailing newlines (#637)" {
+  # Regression for the $(cat file) command-substitution bug: bash strips ALL
+  # trailing newlines from command-substitution output, so the computed hash
+  # diverged from any raw-byte reader (md5sum <file, Python rb.read()). Files
+  # ending in one or more newlines (the normal case for text) MUST hash to the
+  # same digest the byte-accurate reference produces.
+  printf '# Product Brief\nLine two\n\n\n' > "$WORK/.factory/specs/product-brief.md"
+  cat > "$WORK/.factory/specs/prd.md" << 'EOF'
+---
+inputs: [product-brief.md]
+input-hash: "[md5]"
+---
+EOF
+
+  tool_hash=$("$BIN" "$WORK/.factory/specs/prd.md")
+
+  # Byte-accurate reference: the same short MD5 the tool computes, but taken
+  # over the raw file bytes (no command substitution in the pipeline).
+  if command -v md5sum &>/dev/null; then
+    ref_hash=$(md5sum < "$WORK/.factory/specs/product-brief.md" | cut -c1-7)
+  else
+    ref_hash=$(md5 < "$WORK/.factory/specs/product-brief.md" | cut -c1-7)
+  fi
+
+  [ "$tool_hash" = "$ref_hash" ]
+}
+
+@test "compute-input-hash: multi-input hash matches byte-accurate concatenation reference (#637)" {
+  # Trailing newlines between concatenated inputs must survive too — proves the
+  # fix accumulates raw bytes in order, not newline-stripped substitution output.
+  printf '# First\ntrailing\n\n' > "$WORK/.factory/specs/first.md"
+  printf '# Second\nmore\n\n\n' > "$WORK/.factory/specs/second.md"
+  cat > "$WORK/.factory/specs/multi.md" << 'EOF'
+---
+inputs:
+  - first.md
+  - second.md
+input-hash: "[md5]"
+---
+EOF
+
+  tool_hash=$("$BIN" "$WORK/.factory/specs/multi.md")
+
+  cat "$WORK/.factory/specs/first.md" "$WORK/.factory/specs/second.md" > "$WORK/concat-ref"
+  if command -v md5sum &>/dev/null; then
+    ref_hash=$(md5sum < "$WORK/concat-ref" | cut -c1-7)
+  else
+    ref_hash=$(md5 < "$WORK/concat-ref" | cut -c1-7)
+  fi
+
+  [ "$tool_hash" = "$ref_hash" ]
+}
+
 # ===== hooks/validate-input-hash.sh =====
 
 @test "input-hash hook: blocks when hash is placeholder" {


### PR DESCRIPTION
## Why

`compute-input-hash` accumulates each input file's bytes with `CONCAT="${CONCAT}$(cat "$RESOLVED")"`. Bash command substitution strips *all* trailing newlines from `$(cat file)`, so the hash is computed over newline-stripped bytes — but every raw-byte reader (`md5sum <file`, Python `open(f,"rb").read()`) hashes the real bytes. For any text file ending in a newline (the normal case), the two disagree. That divergence is exactly what makes the `validate-input-hash` PostToolUse hook hard-block (exit 2) on false-positive drift, halting the pipeline on artifacts whose inputs never actually changed. This restores byte fidelity so the hook's block can be trusted again, matching the minimal fix laid out in #637.

## What changed

- `plugins/vsdd-factory/bin/compute-input-hash`: replaced the two `CONCAT="${CONCAT}$(cat …)"` accumulations (single-file and glob-expansion paths) with `cat "$file" >> "$HASH_INPUT"`, where `$HASH_INPUT` is a `mktemp` file cleaned up by an `EXIT` trap. Redirection does not go through a subshell, so all bytes — including trailing newlines — are preserved. The final MD5 now reads from that temp file (`md5sum < "$HASH_INPUT"` / `md5 < "$HASH_INPUT"`) instead of `echo -n "$CONCAT"`. The empty-input guard changed from `[[ -z "$CONCAT" ]]` to `[[ ! -s "$HASH_INPUT" ]]` (temp file has zero size when no inputs resolved), preserving the existing `--resolve` / `--check` / default behavior for the no-input case.
- `plugins/vsdd-factory/tests/input-hash.bats`: two regression tests asserting the tool's hash equals a byte-accurate reference (`md5sum` over the raw file bytes / raw concatenation), one single-input and one multi-input, both using files with trailing newlines.

Scope is deliberately the bash `bin/compute-input-hash` accumulation only (issue proposal step 1). The hook calls this same binary, so fixing the binary fixes the hook's comparison hash without touching hook logic.

## Test evidence

Empirical red (unfixed binary), captured against the pristine `upstream/develop` copy of the script:

```
=== tool-computed hash (current buggy $(cat)) ===
TOOL_HASH=8af1b23
=== byte-accurate reference (md5 of raw file bytes) ===
REF_HASH=a9a7d79
cat-substitution bytes:       24
raw file bytes:               27
=== VERDICT ===
RED: tool hash (8af1b23) != byte-accurate reference (a9a7d79) — trailing newlines stripped
```

The two new bats tests, run against the unfixed script, fail as expected:

```
1..2
not ok 1 compute-input-hash: hash matches byte-accurate reference for input with trailing newlines (#637)
#   `[ "$tool_hash" = "$ref_hash" ]' failed
not ok 2 compute-input-hash: multi-input hash matches byte-accurate concatenation reference (#637)
#   `[ "$tool_hash" = "$ref_hash" ]' failed
```

Green after the fix — the same scenario now matches the byte-accurate reference for single and multi-input:

```
=== tool-computed hash (AFTER fix) ===
TOOL_HASH=a9a7d79
REF_HASH=a9a7d79
=== VERDICT ===
GREEN: tool hash (a9a7d79) == byte-accurate reference (a9a7d79) — trailing newlines preserved
multi tool=ddc11c6  ref=ddc11c6
GREEN multi
```

Full suite green (40/40, was 38 before the two new tests):

```
ok 37 compute-input-hash: repo-root-relative input (plugins/…) resolves and contributes to hash
ok 38 compute-input-hash: repo-root-relative input changes hash when SKILL.md changes
ok 39 compute-input-hash: truly-missing repo-root-relative path surfaces MISSING, not silently skipped
ok 40 compute-input-hash: path-traversal input (..) is rejected as MISSING, not resolved
```

No factory-artifact implications — Class 0, touches only develop-tracked files.

Pairs with the sibling PR fixing #623 — independent hunks in the same file; either merges cleanly first.

## Migration note (artifact re-hash at merge)

This re-bases the tool's output for every trailing-newline input: existing
artifacts on `factory-artifacts` carry stored input-hashes computed under the
old accumulation (~2.3k files), and each would report drift from
`validate-input-hash` on its next write until re-hashed. A one-pass
`compute-input-hash --scan .factory --update` sweep at merge time clears the
backlog in a single commit; without it the re-hashes trickle in per-file as
writes occur.

Refs: #637

