### PR TITLE
fix(hooks): stop validate-count-propagation reading epic/ID digits as counts

### DIFF
--- a/plugins/vsdd-factory/hooks/validate-count-propagation.sh
+++ b/plugins/vsdd-factory/hooks/validate-count-propagation.sh
@@ -96,9 +96,15 @@ _extract_counts() {
     # Drop identifier tokens (E-11, S-3, BC-2.1.001, TD-001, SS-01) before
     # count extraction: the digits inside an ID are not a quantity. Without
     # this, "5 E-11 stories" mis-parses "11 stories" as a phantom count and
-    # fires a false count-propagation drift (#690). Matches <letters>-<digits>
-    # with optional dotted segments so multi-part BC/VP ids are dropped whole.
-    line="${line//+([A-Za-z])-+([0-9])?(*(.+([0-9])))/}"
+    # fires a false count-propagation drift (#690). Matches <letters>-<digits-
+    # and-dots> so multi-part BC/VP ids are dropped whole. Deliberately flat:
+    # a nested extglob (`?(*(.+([0-9])))`) matches the same ID tokens but
+    # backtracks super-linearly on long dotted-id lines (33s on a 600-char
+    # line of BC-N.NN.NN tokens vs 0.5s flat), and this runs per line on
+    # repo-controlled content. The flat class additionally eats dots glued to
+    # an ID (e.g. a sentence period in "delivered E-11."), which is harmless
+    # here — a whitespace-separated count token can never contain them.
+    line="${line//+([A-Za-z])-+([0-9.])/}"
     # Pattern A: count before keyword
     if [[ "$line" =~ ([0-9][0-9,]+)[[:space:]]+(BCs|VPs|stories|capabilities|subsystems) ]]; then
       keyword="${BASH_REMATCH[2]}"

--- a/plugins/vsdd-factory/hooks/validate-count-propagation.sh
+++ b/plugins/vsdd-factory/hooks/validate-count-propagation.sh
@@ -17,6 +17,7 @@
 # S-7.02 / BC-7.05.001, BC-7.05.002
 
 set -euo pipefail
+shopt -s extglob
 
 # Source canonical block-message helper if available (provides block_pre).
 _SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -92,6 +93,12 @@ _extract_counts() {
   local path="$1"
   while IFS= read -r line; do
     local count keyword
+    # Drop identifier tokens (E-11, S-3, BC-2.1.001, TD-001, SS-01) before
+    # count extraction: the digits inside an ID are not a quantity. Without
+    # this, "5 E-11 stories" mis-parses "11 stories" as a phantom count and
+    # fires a false count-propagation drift (#690). Matches <letters>-<digits>
+    # with optional dotted segments so multi-part BC/VP ids are dropped whole.
+    line="${line//+([A-Za-z])-+([0-9])?(*(.+([0-9])))/}"
     # Pattern A: count before keyword
     if [[ "$line" =~ ([0-9][0-9,]+)[[:space:]]+(BCs|VPs|stories|capabilities|subsystems) ]]; then
       keyword="${BASH_REMATCH[2]}"
@@ -126,8 +133,13 @@ while IFS=: read -r kw cnt; do
   fi
 done < <(_extract_counts "$FILE_PATH")
 
-# Nothing to compare if no count patterns found
-if [[ ${#SOURCE_COUNTS[@]} -eq 0 ]]; then
+# Nothing to compare if no count patterns found.
+# Guard via ${arr[*]:-} rather than ${#arr[@]}: under `set -u`, expanding the
+# element count of an *empty associative array* is itself an unbound-variable
+# error in bash 4+. Dropping identifier tokens above makes an all-phantom line
+# (e.g. "5 E-11 stories" with no genuine count) leave this array empty, so this
+# no-count path is now reachable and must exit 0 cleanly, not crash.
+if [[ -z "${SOURCE_COUNTS[*]:-}" ]]; then
   exit 0
 fi
 

--- a/plugins/vsdd-factory/tests/hooks.bats
+++ b/plugins/vsdd-factory/tests/hooks.bats
@@ -364,3 +364,17 @@ require_bash4_hook_interp() {
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }
+
+@test "validate-count-propagation: long dotted-id line stays fast and keeps trailing count" {
+  require_bash4_hook_interp
+  # Dense dotted-id lines are normal in index tables. The id-drop pattern must
+  # stay linear on them: a nested-extglob variant of the same drop takes >30s
+  # on this 550-char line (per-line, under PostToolUse). Also asserts the ids
+  # are dropped whole and the genuine trailing count survives extraction.
+  local ids
+  ids="$(printf 'BC-1.11.11 %.0s' $(seq 1 50))"
+  printf '# STATE\n%s41 BCs\n' "$ids" > .factory/STATE.md
+  printf '# BC-INDEX\ntotal_bcs: 41\n' > .factory/BC-INDEX.md
+  run bash -c 'echo "{\"tool_input\":{\"file_path\":\".factory/STATE.md\"}}" | "'"$HOOKS"'/validate-count-propagation.sh" 2>&1'
+  [ "$status" -eq 0 ]
+}

--- a/plugins/vsdd-factory/tests/hooks.bats
+++ b/plugins/vsdd-factory/tests/hooks.bats
@@ -309,3 +309,58 @@ teardown() {
   run bash -c 'echo "{\"tool_input\":{}}" | "'"$HOOKS"'/factory-branch-guard.sh"'
   [ "$status" -eq 0 ]
 }
+
+# ---------- validate-count-propagation ----------
+#
+# The hook uses associative arrays (declare -A), which require bash 4+.
+# It runs via its #!/bin/bash shebang, so the interpreter that matters is
+# /bin/bash — bash 5.x on the ubuntu `validate` CI job, but 3.2 on macOS
+# where these cases skip (the hook's own pre-existing requirement, not a
+# limitation of the fix).
+require_bash4_hook_interp() {
+  local maj
+  maj=$(/bin/bash -c 'echo ${BASH_VERSINFO[0]}')
+  [[ "$maj" -ge 4 ]] || skip "hook requires bash 4+ (declare -A); /bin/bash is ${maj}.x"
+}
+
+@test "validate-count-propagation: epic-id token is not parsed as a count (#690)" {
+  require_bash4_hook_interp
+  # STATE.md references an epic by id next to a countable noun ("5 E-11 stories").
+  # The "11" belongs to the E-11 identifier, not a claimed count of 11 stories.
+  # STORY-INDEX carries the genuine, mutually-consistent story count.
+  printf '# STATE\nPhase 3 complete -> 5 E-11 stories delivered.\n' > .factory/STATE.md
+  printf '# STORY-INDEX\nThis corpus has 42 stories total.\n' > .factory/STORY-INDEX.md
+  run bash -c 'echo "{\"tool_input\":{\"file_path\":\".factory/STATE.md\"}}" | "'"$HOOKS"'/validate-count-propagation.sh" 2>&1'
+  [ "$status" -eq 0 ]
+}
+
+@test "validate-count-propagation: genuine count drift still blocks" {
+  require_bash4_hook_interp
+  printf '# STATE\nDelivered 13 stories this phase.\n' > .factory/STATE.md
+  printf '# STORY-INDEX\nThis corpus has 42 stories total.\n' > .factory/STORY-INDEX.md
+  run bash -c 'echo "{\"tool_input\":{\"file_path\":\".factory/STATE.md\"}}" | "'"$HOOKS"'/validate-count-propagation.sh" 2>&1'
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"COUNT DRIFT DETECTED"* ]]
+}
+
+@test "validate-count-propagation: mixed line keeps genuine count after dropping id" {
+  require_bash4_hook_interp
+  # A genuine count (13) shares a line with an epic id (E-11); dropping the id
+  # must not swallow the real quantity, so drift against the index still fires.
+  printf '# STATE\nPhase 3: E-11 delivered 13 stories.\n' > .factory/STATE.md
+  printf '# STORY-INDEX\nThis corpus has 42 stories total.\n' > .factory/STORY-INDEX.md
+  run bash -c 'echo "{\"tool_input\":{\"file_path\":\".factory/STATE.md\"}}" | "'"$HOOKS"'/validate-count-propagation.sh" 2>&1'
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"13 stories"* ]]
+}
+
+@test "validate-count-propagation: file with no genuine counts exits clean" {
+  require_bash4_hook_interp
+  # After identifier tokens are dropped, an all-phantom line leaves no counts.
+  # This path must exit 0, not trip set -u on the empty associative array.
+  printf '# STATE\nPhase 3 complete -> 5 E-11 stories delivered.\n' > .factory/STATE.md
+  printf '# STORY-INDEX\nNo countable nouns here.\n' > .factory/STORY-INDEX.md
+  run bash -c 'echo "{\"tool_input\":{\"file_path\":\".factory/STATE.md\"}}" | "'"$HOOKS"'/validate-count-propagation.sh" 2>&1'
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}


### PR DESCRIPTION
## Why

`validate-count-propagation` mis-parses an epic/identifier label as a numeric count. In a STATE.md line like "5 E-11 stories", the count extractor's Pattern-A regex `([0-9][0-9,]+)[[:space:]]+(stories|...)` matches the `11` inside the `E-11` epic id and treats it as a claimed count of "11 stories" — firing a spurious `count_propagation_drift` block and forcing operators to reword STATE.md prose to dodge a false positive (#690). This is the ID-substring class from #641 instantiated in this hook (distinct from #567's historical-vs-current comparison bug). The fix follows the maintainer's stated remedy: tokenize and drop identifier tokens before counting, so an id's digits are never read as a quantity while genuine counts on the same line survive.

## What changed

- `plugins/vsdd-factory/hooks/validate-count-propagation.sh`
  - In `_extract_counts`, drop identifier tokens (`<letters>-<digits>` with optional dotted segments: `E-11`, `S-3`, `SS-01`, `TD-001`, `BC-2.1.001`) from each line before the Pattern A/B/C/D matchers run, via a pure-bash extglob substitution (`shopt -s extglob`; no new process/dependency). A genuine count elsewhere on the line is untouched.
  - Hardened the "no counts found" guard: `${#SOURCE_COUNTS[@]}` on an *empty associative array* is itself an unbound-variable error under `set -u` in bash 4+ — the original hook already crashed (exit 1) on any counts-free file, and dropping id tokens makes that path reachable from #690's exact input class ("5 E-11 stories" as the only count token). Switched to `[[ -z "${SOURCE_COUNTS[*]:-}" ]]` so the no-count path exits 0 cleanly instead of crashing — which is what delivering the maintainer's "no false positive, no reword" intent actually requires here.

- `plugins/vsdd-factory/tests/hooks.bats` — added a `validate-count-propagation` regression section (4 cases): epic-id token not parsed as a count (#690 repro → exit 0); genuine count drift still blocks (exit 2); mixed line keeps the genuine count after dropping the id (exit 2); all-phantom line exits clean with no output. The hook uses `declare -A` (bash 4+); the cases carry a skip guard keyed on the `/bin/bash` shebang-interpreter version, so they run on the ubuntu `validate` CI job (bash 5.x) and skip on macOS `/bin/bash` 3.2 rather than fail spuriously — the hook's own pre-existing requirement, not a limitation introduced here.

## Test evidence

Regex-level reproduction (the exact BASH_REMATCH miss):

```
INPUT LINE: Phase 3 complete → 5 E-11 stories delivered
=== Pattern A (current) ===
MATCHED. count=11 keyword=stories
  -> phantom count: 11 stories
```

RED — unfixed hook, STATE.md "5 E-11 stories" with a genuine, consistent 42 in STORY-INDEX.md:

```
exit=2
BLOCKED by validate-count-propagation: Count propagation drift detected in STATE.md: COUNT DRIFT DETECTED: '11 stories' in STATE.md but '42 stories' in STORY-INDEX.md.;   Run: grep -r "stories" .factory/specs/ .factory/STATE.md to reconcile. Fix: Update the lagging index to match the source-of-truth count: BC-INDEX total_bcs, ARCH-INDEX subsystem counts, or STORY-INDEX bcs count — see the specific drift cited above. Code: count_propagation_drift.
```

GREEN — fixed hook, same corpus (phantom `11` gone, no drift):

```
exit=0
[]
```

Regression, fixed hook under CI-equivalent bash 5.x:

```
[PASS] T46 epic-id not a count           (exit 0)
[PASS] T47 genuine drift blocks          (exit 2, "COUNT DRIFT DETECTED")
[PASS] T48 mixed line keeps genuine 13   (exit 2, "13 stories")
[PASS] T49 all-phantom line exits clean  (exit 0, empty output)
```

`bats tests/hooks.bats` locally (macOS /bin/bash 3.2): 49 ok, 4 skipped (the count-propagation cases, per the bash-4+ guard), 0 failures. `bash -n` clean under both bash 3.2 and 5.x. `check-bats-orphans.sh`: all hook references resolve.

Note: the four new cases run in the ubuntu-latest `validate` job (which runs `hooks.bats` under bash 5.x). They cannot execute on the macOS bash-3.2 legs, which run different suites; the skip guard makes that explicit rather than a red X on dev machines.

No factory-artifact implications — Class 0, touches only develop-tracked files.

Refs: #690
