### PR TITLE
fix(config): register holdout scenario-selection path in artifact-path-registry

### DIFF
--- a/crates/hook-plugins/validate-artifact-path/src/tests.rs
+++ b/crates/hook-plugins/validate-artifact-path/src/tests.rs
@@ -1583,3 +1583,87 @@ fn test_F_P18_001_partial_match_rejected_leading_slash_discipline() {
         partial_match
     );
 }
+
+// -----------------------------------------------------------------------
+// Issue #473: scenario-rotation writes .factory/holdout-scenarios/
+// scenario-selection.json, but that path had no registry entry — so
+// validate-artifact-path blocked the state-manager's canonical write with
+// ARTIFACT_PATH_UNREGISTERED.
+//
+// PR #527 corrected the workflow (agent: state-manager, canonical
+// holdout-scenarios/ directory) but the registry still lacked the matching
+// pattern. These tests load the ACTUAL production registry (same harness as
+// EC-007) and assert the canonical selection path now matches with block
+// enforcement, and that the hook allows the write end-to-end.
+//
+// Refs: #473, PR #527.
+// -----------------------------------------------------------------------
+
+/// Locate the shipped production registry by walking up from
+/// CARGO_MANIFEST_DIR until `plugins/vsdd-factory/config/artifact-path-registry.yaml`
+/// is found. Layout-independent (unlike a hard-coded `../` count) so it can
+/// never silently fall back to a fixture and pass vacuously.
+fn production_registry_path_i473() -> std::path::PathBuf {
+    let manifest_dir =
+        std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR must be set during test");
+    let mut dir = std::path::PathBuf::from(&manifest_dir);
+    loop {
+        let candidate = dir.join("plugins/vsdd-factory/config/artifact-path-registry.yaml");
+        if candidate.exists() {
+            return candidate;
+        }
+        if !dir.pop() {
+            panic!(
+                "could not locate plugins/vsdd-factory/config/artifact-path-registry.yaml \
+                 walking up from CARGO_MANIFEST_DIR ({manifest_dir})"
+            );
+        }
+    }
+}
+
+/// Read the shipped production registry as YAML text.
+fn production_registry_yaml_i473() -> String {
+    let path = production_registry_path_i473();
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read registry at {}: {}", path.display(), e))
+}
+
+#[test]
+fn test_issue_473_scenario_selection_matches_production_registry() {
+    // #473: .factory/holdout-scenarios/scenario-selection.json is the canonical
+    // write target for the phase-4 scenario-rotation step (both the phase file
+    // and the inlined greenfield copy). It MUST match a block entry in the
+    // shipped registry, otherwise state-manager's write is blocked with
+    // ARTIFACT_PATH_UNREGISTERED.
+    let registry =
+        load_registry(&production_registry_yaml_i473()).expect("production registry must load");
+    let path = ".factory/holdout-scenarios/scenario-selection.json";
+    let result = matches_canonical(path, &registry);
+    assert_eq!(
+        result,
+        MatchResult::Block,
+        "#473: canonical scenario-rotation output '{}' must match a block entry in the \
+         production registry (currently {:?}). Without the entry, validate-artifact-path \
+         blocks the state-manager write with ARTIFACT_PATH_UNREGISTERED.",
+        path,
+        result
+    );
+}
+
+#[test]
+fn test_issue_473_scenario_selection_hook_allows_write() {
+    // End-to-end: a Write to the canonical selection path must NOT be blocked.
+    // run_logic serves the real registry YAML via the read_file callback, so
+    // this exercises the full hook path against the shipped registry.
+    let payload = make_payload(
+        "Write",
+        Some(".factory/holdout-scenarios/scenario-selection.json"),
+    );
+    let (hook_result, _log, _events) = run_logic(payload, Ok(production_registry_yaml_i473()));
+    assert!(
+        matches!(hook_result, HookResult::Continue),
+        "#473: hook_logic must Continue (allow) the write to the canonical \
+         scenario-selection path; got {:?}",
+        hook_result
+    );
+}

--- a/plugins/vsdd-factory/config/artifact-path-registry.yaml
+++ b/plugins/vsdd-factory/config/artifact-path-registry.yaml
@@ -203,6 +203,11 @@ artifacts:
     description: Holdout evaluation document
     enforcement_level: block
 
+  - artifact_type: holdout-scenario-selection
+    canonical_path_pattern: ".factory/holdout-scenarios/scenario-selection.json"
+    description: Phase-4 scenario-rotation selection written by state-manager (selected holdout scenario IDs)
+    enforcement_level: block
+
   # ── Measurements ─────────────────────────────────────────────────────────
   - artifact_type: measurement
     canonical_path_pattern: ".factory/measurements/{filename}.md"


### PR DESCRIPTION
## Why

The phase-4 scenario-rotation step writes `.factory/holdout-scenarios/scenario-selection.json`, but the artifact-path registry has no entry that matches it. Since `validate-artifact-path` hard-blocks any `.factory/` write with no matching registry entry (`ARTIFACT_PATH_UNREGISTERED`), the canonical write is blocked at dispatch time — the exact remaining gap you kept #473 open for after #527 corrected the workflow's agent and directory. This adds the missing registry pattern so the write the workflow already asks for is actually permitted, and locks it in with a test that loads the real shipped registry.

## What changed

- `plugins/vsdd-factory/config/artifact-path-registry.yaml`: added a `holdout-scenario-selection` entry under the "Holdout Evaluations" section, mirroring the neighboring entries' schema exactly (`artifact_type` / `canonical_path_pattern` / `description` / `enforcement_level: block`). Pattern is the literal canonical path both phase-4 workflow files write: `.factory/holdout-scenarios/scenario-selection.json` (phase-4-holdout-evaluation.lobster:21 and the inlined greenfield.lobster:1014).
- `crates/hook-plugins/validate-artifact-path/src/tests.rs`: two tests that load the **actual production registry** (walking up from `CARGO_MANIFEST_DIR` — see note below) and assert the selection path returns `MatchResult::Block`, plus an end-to-end `hook_logic` check that the write is allowed (`Continue`). A helper hard-fails if the registry can't be located, so the tests can never pass vacuously.

Note: the existing EC-007 benchmark tries to load the production registry via a hard-coded `../../../../` path that resolves one level too high, so it silently falls back to a fixture. The new tests use an ancestor-walk instead; happy to file that as a separate observation if useful.

## Test evidence

RED (before the registry entry, tests already in place):

```
running 2 tests
test tests::test_issue_473_scenario_selection_hook_allows_write ... FAILED
test tests::test_issue_473_scenario_selection_matches_production_registry ... FAILED

---- test_issue_473_scenario_selection_matches_production_registry ----
assertion `left == right` failed: #473: canonical scenario-rotation output
'.factory/holdout-scenarios/scenario-selection.json' must match a block entry
in the production registry (currently NoMatch).
  left: NoMatch
 right: Block

---- test_issue_473_scenario_selection_hook_allows_write ----
#473: hook_logic must Continue (allow) the write ...; got Block { reason:
"... Write to '.factory/holdout-scenarios/scenario-selection.json' under
.factory/ has no matching entry ... Code: ARTIFACT_PATH_UNREGISTERED." }

test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 48 filtered out
```

GREEN (after adding the registry entry):

```
running 2 tests
test tests::test_issue_473_scenario_selection_matches_production_registry ... ok
test tests::test_issue_473_scenario_selection_hook_allows_write ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 48 filtered out
```

Full crate suite (no regressions):

```
test result: ok. 50 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out   (lib)
test result: ok. 4 passed; 0 failed; ...                                       (kani_path_matching)
test result: ok. 6 passed; 0 failed; ...                                       (proptest_registry_load)
```

No factory-artifact implications — Class 0, touches only develop-tracked files.

Pairs with the sibling registry PR for #300 — separate entries in different sections; either merges cleanly first (verified: both patches apply to develop tip in either order, and the combined tree compiles + passes).

Refs: #473
