### PR TITLE
fix(bin): compute-input-hash --update upserts absent input-hash field

### DIFF
--- a/plugins/vsdd-factory/bin/compute-input-hash
+++ b/plugins/vsdd-factory/bin/compute-input-hash
@@ -399,7 +399,17 @@ case "$MODE" in
     ;;
 
   --update)
-    # Read current input-hash value
+    # Determine whether an input-hash: field already exists in the frontmatter,
+    # and read its current value if so.  Presence and value are DISTINCT: an
+    # absent field and a placeholder field both yield an empty/placeholder
+    # value, but only a present field can be replaced by in-place substitution.
+    # Conflating them made --update silently no-op (report success, write
+    # nothing) when the field was absent (#623) — the sed s/^input-hash:.*/
+    # matched no line and produced no change.
+    FIELD_PRESENT=$(awk '
+      /^---$/{ fm++; if (fm>=2) exit; next }
+      fm==1 && /^input-hash:/ { print "yes"; exit }
+    ' "$FILE")
     CURRENT=$(awk '
       /^---$/{ fm++; next }
       fm==1 && /^input-hash:/ {
@@ -410,20 +420,44 @@ case "$MODE" in
       }
     ' "$FILE")
 
-    if [[ "$CURRENT" == "$HASH" ]]; then
+    if [[ -n "$FIELD_PRESENT" ]] && [[ "$CURRENT" == "$HASH" ]]; then
       echo "compute-input-hash: $FILE input-hash already current ($HASH)" >&2
       exit 0
     fi
 
-    # Update the frontmatter in place
-    if [[ -z "$CURRENT" ]] || [[ "$CURRENT" == "[md5]" ]] || [[ "$CURRENT" == "null" ]]; then
-      # Field exists with placeholder — replace
+    if [[ -n "$FIELD_PRESENT" ]]; then
+      # Field exists (placeholder or stale hash) — replace it in place.
       sed -i.bak "s/^input-hash:.*/input-hash: \"$HASH\"/" "$FILE"
+      rm -f "${FILE}.bak"
     else
-      # Field exists with old hash — replace
-      sed -i.bak "s/^input-hash:.*/input-hash: \"$HASH\"/" "$FILE"
+      # Field absent — insert it (find-or-create, per #623 suggested fix (a)).
+      # --update is only reachable after an inputs: field was parsed from the
+      # frontmatter, so a frontmatter block is guaranteed here; insert the new
+      # field just before the closing fence (the second '^---$' line).
+      awk -v hash="$HASH" '
+        /^---$/ { fm++; if (fm==2 && !inserted) { print "input-hash: \"" hash "\""; inserted=1 } }
+        { print }
+      ' "$FILE" > "${FILE}.tmp" && mv "${FILE}.tmp" "$FILE"
     fi
-    rm -f "${FILE}.bak"
+
+    # Verify the write actually landed before reporting success.  A bookkeeping
+    # tool must never report success on a no-op (#623): if the field is still
+    # absent or not equal to the computed hash (e.g. malformed frontmatter with
+    # no closing fence, so there was nowhere to insert), fail loudly instead of
+    # exiting 0.
+    WROTE=$(awk '
+      /^---$/{ fm++; next }
+      fm==1 && /^input-hash:/ {
+        sub(/^input-hash:[ \t]*/, "")
+        gsub(/["'"'"']/, "")
+        print
+        exit
+      }
+    ' "$FILE")
+    if [[ "$WROTE" != "$HASH" ]]; then
+      die "failed to write input-hash into $FILE (frontmatter may be malformed — no closing '---' fence to anchor the field)"
+    fi
+
     echo "$HASH"
     echo "compute-input-hash: updated $FILE input-hash → $HASH" >&2
     ;;

--- a/plugins/vsdd-factory/tests/input-hash.bats
+++ b/plugins/vsdd-factory/tests/input-hash.bats
@@ -84,6 +84,70 @@ EOF
   [[ "${#stored}" -eq 7 ]]
 }
 
+@test "compute-input-hash: --update creates input-hash field when absent (#623)" {
+  # Regression for #623: --update silently no-oped (reported success, wrote
+  # nothing) when the frontmatter had NO input-hash field at all — the sed
+  # find-and-replace matched no line. It must now insert the field and exit 0
+  # with the field genuinely present.
+  cat > "$WORK/.factory/specs/prd.md" << 'EOF'
+---
+document_type: prd
+inputs: [product-brief.md]
+---
+# PRD body
+EOF
+  # Field genuinely absent to start with.
+  ! grep -q '^input-hash:' "$WORK/.factory/specs/prd.md"
+
+  run "$BIN" "$WORK/.factory/specs/prd.md" --update
+  [ "$status" -eq 0 ]
+  # stdout's first line is the emitted hash (run merges the stderr "updated"
+  # message into $output, so assert against ${lines[0]}).
+  [[ "${#lines[0]}" -eq 7 ]]
+
+  # Field must now exist with the computed hash — a single new line, frontmatter
+  # fence and body preserved.
+  stored=$(awk '/^input-hash:/ { sub(/.*: *"?/, ""); sub(/"?$/, ""); print; exit }' "$WORK/.factory/specs/prd.md")
+  [ "$stored" = "${lines[0]}" ]
+  [[ "${#stored}" -eq 7 ]]
+  [ "$(grep -c '^input-hash:' "$WORK/.factory/specs/prd.md")" -eq 1 ]
+  grep -q '^# PRD body' "$WORK/.factory/specs/prd.md"
+}
+
+@test "compute-input-hash: --update on field-absent file is idempotent on re-run (#623)" {
+  cat > "$WORK/.factory/specs/prd.md" << 'EOF'
+---
+document_type: prd
+inputs: [product-brief.md]
+---
+EOF
+  first=$("$BIN" "$WORK/.factory/specs/prd.md" --update)
+  stored1=$(awk '/^input-hash:/ { sub(/.*: *"?/, ""); sub(/"?$/, ""); print; exit }' "$WORK/.factory/specs/prd.md")
+
+  # Second run: field is now current, so nothing changes — value stays identical
+  # and no duplicate field is appended.
+  run "$BIN" "$WORK/.factory/specs/prd.md" --update
+  [ "$status" -eq 0 ]
+  stored2=$(awk '/^input-hash:/ { sub(/.*: *"?/, ""); sub(/"?$/, ""); print; exit }' "$WORK/.factory/specs/prd.md")
+
+  [ "$stored1" = "$first" ]
+  [ "$stored2" = "$first" ]
+  [ "$(grep -c '^input-hash:' "$WORK/.factory/specs/prd.md")" -eq 1 ]
+}
+
+@test "compute-input-hash: --update fails loudly on malformed frontmatter with no closing fence (#623)" {
+  # A bookkeeping tool must never report success on a no-op. If the frontmatter
+  # has an inputs: field but no closing '---' fence to anchor insertion, --update
+  # must exit nonzero rather than silently writing nothing.
+  printf -- '---\ninputs: [product-brief.md]\n# body with no closing fence\n' \
+    > "$WORK/.factory/specs/malformed.md"
+
+  run "$BIN" "$WORK/.factory/specs/malformed.md" --update
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"failed to write input-hash"* ]]
+  ! grep -q '^input-hash:' "$WORK/.factory/specs/malformed.md"
+}
+
 @test "compute-input-hash: --check passes when hash matches" {
   cat > "$WORK/.factory/specs/prd.md" << 'EOF'
 ---


### PR DESCRIPTION
## Why

`compute-input-hash --update` is bookkeeping the pipeline trusts as ground truth for drift tracking, yet it silently no-ops when the target file has no `input-hash:` field at all: it prints the hash, logs "updated", and exits 0 while writing nothing. The root cause is that the code reads the field's *value* into `CURRENT` and can't distinguish "absent" from "placeholder" (both are empty), so both branches run the same `sed s/^input-hash:.*/…/` find-and-replace — which matches no line and changes nothing when the field is absent. Any downstream step that trusts "`--update` succeeded, therefore the field is populated" is silently wrong for every file that started without the field. This makes the write actually happen (find-or-create) and makes a no-op-with-success structurally impossible.

## What changed

- `plugins/vsdd-factory/bin/compute-input-hash` (`--update` branch):
  - Added a `FIELD_PRESENT` check (distinct from the value read) so presence and value are no longer conflated.
  - Field present (placeholder or stale hash) → keep the existing in-place `sed` replace.
  - Field absent → insert `input-hash: "<hash>"` just before the closing `---` fence via `awk` (find-or-create, per the issue's suggested fix (a)). `--update` is only reachable after an `inputs:` field is parsed, so a frontmatter block is guaranteed; the fence is the anchor.
  - Added a post-write verification guard: after writing, re-read the field and `die` (nonzero exit, explicit stderr) if it doesn't equal the computed hash. This closes the malformed-frontmatter edge — a file with `inputs:` but no closing fence (nowhere to insert) now fails loudly instead of reporting success on a no-op (the issue's fallback (b)). Silent success on a no-op is no longer possible for either path.
  - The pre-existing "already current" early-exit is now gated on the field actually being present, so it can't short-circuit an absent-field insert.

Judgment call flagged: for a file with `inputs:` but **no closing `---` fence**, there is no unambiguous insertion point, so I chose fallback (b) — fail loudly — rather than guessing where the frontmatter ends. Well-formed files (opening + closing fence, the normal factory artifact shape) take the insert path and succeed.

- `plugins/vsdd-factory/tests/input-hash.bats`: three regression tests — field-absent → field created with the correct value, single field, fence + body preserved, exit 0; idempotence on re-run (value stable, no duplicate field); malformed-frontmatter → nonzero exit with `failed to write input-hash` and no field written.

## Test evidence

Empirical red (unfixed binary) — field absent, reports success, writes nothing:

```
--- BEFORE ---
---
document_type: prd
inputs: [product-brief.md]
---
# PRD body
--- stdout: 6ab4caf | exit: 0 | stderr: compute-input-hash: updated …/prd.md input-hash → 6ab4caf ---
--- AFTER ---
---
document_type: prd
inputs: [product-brief.md]
---
# PRD body
=== VERDICT ===
RED: reports success (exit 0, prints hash '6ab4caf') but NO input-hash field was written
```

Green after the fix — same input, field now created; idempotent; placeholder-replace preserved; malformed frontmatter fails loudly:

```
############ SCENARIO 1: field absent (the #623 bug) ############
--- AFTER ---
---
document_type: prd
inputs: [product-brief.md]
input-hash: "6ab4caf"
---
# PRD body
>>> GREEN: field created

############ Idempotence (durable state) ############
first-write hash=6ab4caf  stored-after-1=6ab4caf  stored-after-2=6ab4caf  field-count=1
>>> GREEN: idempotent — value stable, single field, no duplication

############ Existing behavior preserved: placeholder replace ############
placeholder replaced with: 6ab4caf  count=1
>>> GREEN: placeholder still replaced in place

############ Malformed frontmatter (inputs, no closing fence) → loud fail ############
stdout: '' | exit: 1 | stderr: compute-input-hash: failed to write input-hash into …/mal.md (frontmatter may be malformed — no closing '---' fence to anchor the field)
>>> GREEN: fails loudly (exit 1) rather than reporting success on a no-op
```

The three new bats tests, run against the pristine unfixed script, fail as expected:

```
1..3
not ok 1 compute-input-hash: --update creates input-hash field when absent (#623)
not ok 2 compute-input-hash: --update on field-absent file is idempotent on re-run (#623)
not ok 3 compute-input-hash: --update fails loudly on malformed frontmatter with no closing fence (#623)
```

Full suite green after the fix (41/41, was 38 before the three new tests):

```
ok 4 compute-input-hash: --update writes hash to frontmatter
ok 5 compute-input-hash: --update creates input-hash field when absent (#623)
ok 6 compute-input-hash: --update on field-absent file is idempotent on re-run (#623)
ok 7 compute-input-hash: --update fails loudly on malformed frontmatter with no closing fence (#623)
```

No factory-artifact implications — Class 0, touches only develop-tracked files.

Pairs with the sibling PR fixing #637 — independent hunks in the same file; either merges cleanly first.

Closes: #623
