### PR TITLE
fix(hooks): recognize named S-<PREFIX>.<NAME> story IDs in merge-prereq extraction

### DIFF
--- a/plugins/vsdd-factory/hooks/validate-pr-merge-prerequisites.sh
+++ b/plugins/vsdd-factory/hooks/validate-pr-merge-prerequisites.sh
@@ -46,10 +46,23 @@ if ! echo "$PROMPT" | grep -qiE "gh pr merge|pr merge|merge.*PR"; then
   exit 0  # not a merge dispatch
 fi
 
-# Extract story ID from prompt
+# Extract story ID from prompt.
+#
+# Precedence matters: named story IDs (S-<PREFIX>.<NAME>, e.g.
+# S-BL.DISCOVERY-WIRE) must be recognized BEFORE the pure-numeric S-N.NN form.
+# Otherwise a numeric substring elsewhere in the prompt — typically a merged
+# dependency such as S-7.02 — hijacks the match and the hook blocks citing the
+# wrong story's missing evidence (issue #658). Most-specific-first:
+#   1. STORY-NNN            (explicit long form)
+#   2. S-<PREFIX>.<NAME>    (named story, alpha prefix)
+#   3. S-N.NN               (pure-numeric story)
 STORY_ID=$(echo "$PROMPT" | grep -oE 'STORY-[0-9]+' | head -1 || true)
 if [[ -z "$STORY_ID" ]]; then
-  # Try S-N.NN format
+  # Named story: alpha prefix, alnum/hyphen name (e.g. S-BL.DISCOVERY-WIRE)
+  STORY_ID=$(echo "$PROMPT" | grep -oE 'S-[A-Za-z]+\.[A-Za-z0-9-]+' | head -1 || true)
+fi
+if [[ -z "$STORY_ID" ]]; then
+  # Pure-numeric story (e.g. S-7.02)
   STORY_ID=$(echo "$PROMPT" | grep -oE 'S-[0-9]+\.[0-9]+' | head -1 || true)
 fi
 if [[ -z "$STORY_ID" ]]; then

--- a/plugins/vsdd-factory/tests/pr-lifecycle-hooks.bats
+++ b/plugins/vsdd-factory/tests/pr-lifecycle-hooks.bats
@@ -240,6 +240,56 @@ EOF
   [[ "$output" == *"WARNING"* ]]
 }
 
+# ------------------------------------------------------------------------
+# Named story-ID extraction precedence (issue #658)
+#
+# S-<PREFIX>.<NAME> ids (e.g. S-BL.DISCOVERY-WIRE) must be recognized before
+# the pure-numeric S-N.NN form. Otherwise a numeric substring elsewhere in the
+# prompt — typically a merged dependency (S-7.02) — hijacks the match and the
+# hook blocks citing the wrong story's missing evidence.
+# ------------------------------------------------------------------------
+
+@test "pr-merge-prerequisites: resolves named story, not a numeric dependency in the prompt (issue #658)" {
+  # Named target story: fully evidenced.
+  mkdir -p "$WORK/.factory/code-delivery/S-BL.DISCOVERY-WIRE"
+  echo "# Description" > "$WORK/.factory/code-delivery/S-BL.DISCOVERY-WIRE/pr-description.md"
+  echo "# Review" > "$WORK/.factory/code-delivery/S-BL.DISCOVERY-WIRE/pr-review.md"
+  echo "# Security" > "$WORK/.factory/code-delivery/S-BL.DISCOVERY-WIRE/security-review.md"
+  # Merged dependency directory exists but carries no evidence — the old regex
+  # would resolve here and block.
+  mkdir -p "$WORK/.factory/code-delivery/S-7.02"
+  _run_pretool_agent "vsdd-factory:github-ops" \
+    "cd $WORK && gh pr merge 123 --squash for story S-BL.DISCOVERY-WIRE depends on S-7.02"
+  [ "$status" -eq 0 ]
+}
+
+@test "pr-merge-prerequisites: blocks citing the named story ID when its evidence is missing (issue #658)" {
+  mkdir -p "$WORK/.factory/code-delivery/S-BL.PE-RECEIVE-LOOP"
+  _run_pretool_agent "vsdd-factory:github-ops" \
+    "cd $WORK && gh pr merge 88 --squash for story S-BL.PE-RECEIVE-LOOP"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"S-BL.PE-RECEIVE-LOOP"* ]]
+}
+
+@test "pr-merge-prerequisites: STORY-NNN still takes precedence over any S-form in the prompt" {
+  echo "# Description" > "$WORK/.factory/code-delivery/STORY-001/pr-description.md"
+  echo "# Review" > "$WORK/.factory/code-delivery/STORY-001/pr-review.md"
+  echo "# Security" > "$WORK/.factory/code-delivery/STORY-001/security-review.md"
+  mkdir -p "$WORK/.factory/code-delivery/S-BL.OTHER"
+  _run_pretool_agent "vsdd-factory:github-ops" \
+    "cd $WORK && gh pr merge 42 --squash for STORY-001 referencing S-BL.OTHER"
+  [ "$status" -eq 0 ]
+}
+
+@test "pr-merge-prerequisites: pure-numeric S-N.NN still resolves when no named id present" {
+  mkdir -p "$WORK/.factory/code-delivery/S-7.02"
+  echo "# Description" > "$WORK/.factory/code-delivery/S-7.02/pr-description.md"
+  echo "# Review" > "$WORK/.factory/code-delivery/S-7.02/pr-review.md"
+  echo "# Security" > "$WORK/.factory/code-delivery/S-7.02/security-review.md"
+  _run_pretool_agent "vsdd-factory:github-ops" "cd $WORK && gh pr merge 7 --squash for S-7.02"
+  [ "$status" -eq 0 ]
+}
+
 # ========================================================================
 # pr-manager Step 8 remote-branch-deletion verification (issue #128)
 # ========================================================================


### PR DESCRIPTION
## Why

`validate-pr-merge-prerequisites.sh` extracts the target story ID from the
github-ops dispatch prompt by trying `STORY-[0-9]+` and then `S-[0-9]+\.[0-9]+`.
A named story such as `S-BL.DISCOVERY-WIRE` matches neither pattern, so
extraction falls through to the first `S-N.NN`-shaped substring anywhere in the
prompt — typically a merged dependency like `S-7.02`. The hook then blocks the
merge citing the *wrong* story's missing evidence files, a story that has
nothing to do with the PR being merged. Any project using named story IDs
(alpha-prefixed) hits this on every merge dispatch whose prompt mentions a
numeric dependency.

## What changed

Added a precedence-aware third branch to the extraction chain. Order is
most-specific-first: `STORY-NNN`, then the named form `S-<PREFIX>.<NAME>`
(`S-[A-Za-z]+\.[A-Za-z0-9-]+`), then the pure-numeric `S-N.NN`. The named
pattern is inserted *before* the numeric pattern rather than appended after it —
appending would leave `S-N.NN` winning first and would not fix the bug. When a
named ID is present it is now resolved even if a numeric dependency ID also
appears elsewhere in the prompt.

Extended `tests/pr-lifecycle-hooks.bats` with four cases: named target resolves
past a numeric dependency (pass), named target blocks citing its own ID when
evidence is missing, `STORY-NNN` still wins over any S-form, and pure-numeric
still resolves when no named ID is present.

## Test evidence

Extraction repro, before the fix (raw logic), target is `S-BL.DISCOVERY-WIRE`:

```
$ echo 'gh pr merge 123 story S-BL.DISCOVERY-WIRE depends on S-7.02' | grep -oE 'S-[0-9]+\.[0-9]+' | head -1
S-7.02          # dependency hijacks the match
```

New regression tests against the UNFIXED hook (red):

```
1..2
not ok 1 pr-merge-prerequisites: resolves named story, not a numeric dependency in the prompt (issue #658)
#   `[ "$status" -eq 0 ]' failed
not ok 2 pr-merge-prerequisites: blocks citing the named story ID when its evidence is missing (issue #658)
#   `[ "$status" -eq 2 ]' failed
```

Full `pr-lifecycle-hooks.bats` suite against the FIXED hook (green), 49/49:

```
1..49
ok 11 pr-merge-prerequisites: passes when all evidence files exist
...
ok 19 pr-merge-prerequisites: warns when delivery dir not found
ok 20 pr-merge-prerequisites: resolves named story, not a numeric dependency in the prompt (issue #658)
ok 21 pr-merge-prerequisites: blocks citing the named story ID when its evidence is missing (issue #658)
ok 22 pr-merge-prerequisites: STORY-NNN still takes precedence over any S-form in the prompt
ok 23 pr-merge-prerequisites: pure-numeric S-N.NN still resolves when no named id present
...
ok 49 pr-manager step-8d: force-delete error taxonomy classifies transient errors
```

No factory-artifact implications — Class 0, touches only develop-tracked files.

Closes: #658
