### PR TITLE
fix(hooks): accept 7-char short SHAs in verify-sha-currency develop cite

### DIFF
--- a/plugins/vsdd-factory/templates/verify-sha-currency.sh
+++ b/plugins/vsdd-factory/templates/verify-sha-currency.sh
@@ -148,12 +148,12 @@ fi
 
 if [ "$CITED_DEV_STATE" != "NOT_FOUND" ] \
     && [ "${ACTUAL_DEV_FULL:0:${#CITED_DEV_STATE}}" != "$CITED_DEV_STATE" ]; then
-  echo "FAIL: develop SHA in STATE.md is stale (cited=$CITED_DEV_STATE actual=$ACTUAL_DEV)"
+  echo "FAIL: develop SHA in STATE.md is stale (cited=$CITED_DEV_STATE actual=${ACTUAL_DEV_FULL:0:${#CITED_DEV_STATE}} full=$ACTUAL_DEV_FULL)"
   FAIL=1
 fi
 if [ "$CITED_DEV_HANDOFF" != "NOT_FOUND" ] && [ "$CITED_DEV_HANDOFF" != "NO_HANDOFF" ] \
     && [ "${ACTUAL_DEV_FULL:0:${#CITED_DEV_HANDOFF}}" != "$CITED_DEV_HANDOFF" ]; then
-  echo "FAIL: develop SHA in SESSION-HANDOFF.md is stale (cited=$CITED_DEV_HANDOFF actual=$ACTUAL_DEV)"
+  echo "FAIL: develop SHA in SESSION-HANDOFF.md is stale (cited=$CITED_DEV_HANDOFF actual=${ACTUAL_DEV_FULL:0:${#CITED_DEV_HANDOFF}} full=$ACTUAL_DEV_FULL)"
   FAIL=1
 fi
 

--- a/plugins/vsdd-factory/templates/verify-sha-currency.sh
+++ b/plugins/vsdd-factory/templates/verify-sha-currency.sh
@@ -106,8 +106,14 @@ if [ ! -f "$STATE_MD" ]; then
   exit 1
 fi
 
-CITED_DEV_STATE=$(grep -oE 'develop_head: "?[0-9a-f]{8,40}' "$STATE_MD" 2>/dev/null \
-  | head -1 | grep -oE '[0-9a-f]{8,40}' | cut -c1-8 || echo "NOT_FOUND")
+# A develop_head cite may be a 7-char short SHA (git's common default) up to a
+# full 40-char SHA. Accept the whole 7..40 range and keep the cited value intact
+# — do NOT truncate. The comparison below is a prefix match against the actual
+# full develop SHA, which is correct for any short-SHA length (issue #629). The
+# prior {8,40} + `cut -c1-8` form reported NOT_FOUND for 7-char cites and then
+# silently PASSed, defeating the check on exactly the field it exists to verify.
+CITED_DEV_STATE=$(grep -oE 'develop_head: "?[0-9a-f]{7,40}' "$STATE_MD" 2>/dev/null \
+  | head -1 | grep -oE '[0-9a-f]{7,40}' | head -1 || echo "NOT_FOUND")
 
 if [ -f "$HANDOFF_MD" ]; then
   CITED_DEV_HANDOFF=$(grep -oE 'develop HEAD[^|`]*`?[0-9a-f]{8}' "$HANDOFF_MD" 2>/dev/null \
@@ -120,14 +126,33 @@ echo "STATE.md    develop cited      : $CITED_DEV_STATE"
 echo "HANDOFF.md  develop cited      : $CITED_DEV_HANDOFF"
 echo ""
 
-# ---------- develop SHA must match exactly (cross-branch cite, no loop) ----------
+# ---------- WARN: develop_head present but unextractable ----------
+#
+# If STATE.md declares a develop_head field but no hex SHA could be pulled from
+# it, that is a diagnostic-integrity failure: the currency comparison would be
+# silently skipped (the exact silent-skip-PASS class this hook exists to catch,
+# issue #629). Surface it as a WARN so the drift can't normalize again.
+if [ "$CITED_DEV_STATE" = "NOT_FOUND" ] \
+    && grep -qE '^\s*develop_head:' "$STATE_MD" 2>/dev/null; then
+  echo "WARN: STATE.md declares develop_head but no 7-40 char hex SHA could be extracted —"
+  echo "      develop-currency comparison skipped. Cite a valid short or full SHA."
+  WARN=1
+fi
 
-if [ "$CITED_DEV_STATE" != "NOT_FOUND" ] && [ "$ACTUAL_DEV" != "$CITED_DEV_STATE" ]; then
+# ---------- develop SHA must match (cross-branch cite, no loop) ----------
+#
+# Prefix comparison against the FULL actual SHA so a short cite of any length
+# (7..40 chars) compares correctly. Truncating the actual to the cited length
+# is the git-canonical way to compare a short SHA — string-equality against a
+# fixed 8-char actual would false-positive on a legitimate 7-char cite.
+
+if [ "$CITED_DEV_STATE" != "NOT_FOUND" ] \
+    && [ "${ACTUAL_DEV_FULL:0:${#CITED_DEV_STATE}}" != "$CITED_DEV_STATE" ]; then
   echo "FAIL: develop SHA in STATE.md is stale (cited=$CITED_DEV_STATE actual=$ACTUAL_DEV)"
   FAIL=1
 fi
 if [ "$CITED_DEV_HANDOFF" != "NOT_FOUND" ] && [ "$CITED_DEV_HANDOFF" != "NO_HANDOFF" ] \
-    && [ "$ACTUAL_DEV" != "$CITED_DEV_HANDOFF" ]; then
+    && [ "${ACTUAL_DEV_FULL:0:${#CITED_DEV_HANDOFF}}" != "$CITED_DEV_HANDOFF" ]; then
   echo "FAIL: develop SHA in SESSION-HANDOFF.md is stale (cited=$CITED_DEV_HANDOFF actual=$ACTUAL_DEV)"
   FAIL=1
 fi

--- a/plugins/vsdd-factory/tests/verify-sha-currency.bats
+++ b/plugins/vsdd-factory/tests/verify-sha-currency.bats
@@ -1,0 +1,76 @@
+#!/usr/bin/env bats
+# verify-sha-currency.bats — regression suite for the develop_head cite
+# extraction + prefix comparison in templates/verify-sha-currency.sh.
+#
+# Pins the #629 fix: a correct 7-char short-SHA cite must PASS (the prior
+# {8,40} + cut -c1-8 form reported NOT_FOUND and silently skipped the check),
+# a stale short cite must FAIL, and a declared-but-unextractable develop_head
+# must WARN instead of silently skipping.
+#
+# Fixture: throwaway git repo with a develop branch and a plain .factory/
+# holding STATE.md; the script is invoked with --project-root so no live
+# factory state is touched.
+
+setup() {
+  PLUGIN_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  SCRIPT="$PLUGIN_ROOT/templates/verify-sha-currency.sh"
+  WORK="$(mktemp -d)"
+  cd "$WORK"
+  git init --quiet -b develop
+  git config user.email "test@test.com"
+  git config user.name "test"
+  git commit --allow-empty -qm "chore: fixture root"
+  DEV_FULL="$(git rev-parse develop)"
+  mkdir -p .factory
+}
+
+teardown() {
+  cd /
+  rm -rf "$WORK"
+}
+
+_state_with_cite() {  # $1 = cite value
+  printf 'develop_head: "%s"\n' "$1" > .factory/STATE.md
+}
+
+@test "verify-sha-currency: correct 7-char cite passes (#629 primary case)" {
+  _state_with_cite "${DEV_FULL:0:7}"
+  run bash "$SCRIPT" --project-root "$WORK"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"NOT_FOUND"* ]]
+  [[ "$output" != *"FAIL"* ]]
+}
+
+@test "verify-sha-currency: correct 8-char cite passes (no regression)" {
+  _state_with_cite "${DEV_FULL:0:8}"
+  run bash "$SCRIPT" --project-root "$WORK"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"FAIL"* ]]
+}
+
+@test "verify-sha-currency: correct 40-char cite passes" {
+  _state_with_cite "$DEV_FULL"
+  run bash "$SCRIPT" --project-root "$WORK"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"FAIL"* ]]
+}
+
+@test "verify-sha-currency: stale 7-char cite fails with FAIL line (#629 counterpart)" {
+  # A hex string of the right shape that cannot prefix-match the actual SHA.
+  local stale="abcdef1"
+  [ "${DEV_FULL:0:7}" = "$stale" ] && stale="1234567"
+  _state_with_cite "$stale"
+  run bash "$SCRIPT" --project-root "$WORK"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"FAIL: develop SHA in STATE.md is stale"* ]]
+  # The message shows the actual at the cited length, so cited/actual are
+  # visually comparable (review F2).
+  [[ "$output" == *"actual=${DEV_FULL:0:7}"* ]]
+}
+
+@test "verify-sha-currency: develop_head present but unextractable warns, exits 0" {
+  printf 'develop_head: "TBD"\n' > .factory/STATE.md
+  run bash "$SCRIPT" --project-root "$WORK"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"WARN: STATE.md declares develop_head but no 7-40 char hex SHA"* ]]
+}


### PR DESCRIPTION
## Why

`verify-sha-currency.sh` extracts the cited develop SHA with
`grep -oE 'develop_head: "?[0-9a-f]{8,40}'` and truncates it to 8 chars. Git's
common default short-SHA length is 7. A STATE.md that cites `develop_head: 4c276d9`
(7 chars, correct value) reports `develop cited: NOT_FOUND`, and because the
comparison is guarded by `!= "NOT_FOUND"` the currency check is silently
*skipped* while the overall run still PASSes — a false negative on exactly the
field this check exists to verify. State-manager agents had normalized this as
"pre-existing known, doesn't fail the check."

## What changed

- Extraction regex `{8,40}` → `{7,40}` and dropped the `cut -c1-8` truncation so
  the cited value is preserved at whatever length it was written.
- The develop comparison is now a prefix match against the *full* actual SHA
  (`${ACTUAL_DEV_FULL:0:${#CITED_DEV_STATE}}`), which is the git-canonical way to
  compare a short SHA of any length (7..40). String-equality against a fixed
  8-char `ACTUAL_DEV` would have false-positive FAILed a legitimate 7-char cite
  once the regex accepted it. The same prefix comparison is applied to the
  HANDOFF.md cite for consistency.
- Added a WARN when STATE.md declares a `develop_head:` field but no hex SHA can
  be extracted from it, so the silent-skip-PASS class cannot recur — an
  unparseable cite is now surfaced instead of swallowed.

## Test evidence

`templates/` scripts have no bats suite in the repo (verified: no `.bats` file
references `verify-sha-currency` or invokes any `templates/*.sh`). Red/green was
done by direct invocation against a throwaway git fixture whose STATE.md cites
the correct develop head as a 7-char short SHA.

Before the fix (upstream script, 7-char correct cite):

```
Actual develop HEAD      : 203fdca5
STATE.md    develop cited      : NOT_FOUND
PASS: all SHA currency + burst hygiene checks pass      # exit 0 — silently skipped
```

After the fix, across SHA-length and drift cases:

```
1. correct 7-char cite  -> exit 0 ; cited: 203fdca ; PASS: all SHA currency + burst hygiene checks pass
2. correct 8-char cite  -> exit 0 ; PASS
3. correct 40-char cite -> exit 0 ; PASS
4. STALE 7-char cite     -> exit 1 ; FAIL: SHA drift or burst-hygiene issues detected
5. empty develop_head    -> exit 0 ; WARN emitted ; PASS (with WARN)
6. no develop_head field -> exit 0 ; no WARN ; PASS
```

A correct 7-char cite now PASSes with the SHA actually extracted; a stale cite
FAILs; a declared-but-unextractable field WARNs; an absent field stays clean.

No factory-artifact implications — Class 0, touches only develop-tracked files.

Closes: #629
