### PR TITLE
fix(hooks): scope validate-bc-title index lookup to the Title-header table

### DIFF
--- a/plugins/vsdd-factory/hooks/validate-bc-title.sh
+++ b/plugins/vsdd-factory/hooks/validate-bc-title.sh
@@ -66,17 +66,31 @@ if [[ ! -f "$BC_INDEX" ]]; then
   exit 0  # BC-INDEX doesn't exist yet
 fi
 
-# Extract the title for this BC from BC-INDEX
+# Extract the title for this BC from BC-INDEX.
 # Table format: | BC-S.SS.NNN | Title | ... |
+#
+# The BC id can legitimately appear in BC-INDEX more than once — e.g. in a
+# capability-satisfaction table (| BC | Satisfies | ... |) that precedes the
+# §2 navigation table. Matching the first occurrence anywhere grabbed the
+# satisfaction cell (e.g. "CAP-001") and reported it as the indexed title,
+# firing a false bc_h1_index_drift (#566). Scope the lookup to the table
+# whose header row carries a "Title" column; only that table's title cell is
+# authoritative. Fall back to the first occurrence when no Title-headed table
+# is present (headerless single-row indexes), preserving prior behavior.
 INDEX_TITLE=$(awk -F'|' -v bc="$BC_ID" '
+  function trim(s) { gsub(/^[ \t]+|[ \t]+$/, "", s); return s }
   {
-    gsub(/^[ \t]+|[ \t]+$/, "", $2)
-    if ($2 == bc) {
-      gsub(/^[ \t]+|[ \t]+$/, "", $3)
-      print $3
-      exit
+    # Non-table line ends any table scope.
+    if ($0 !~ /^[ \t]*\|/) { in_title_table = 0; next }
+    c2 = trim($2); c3 = trim($3)
+    # A header row with "Title" in the 2nd data column opens a scoped table.
+    if (tolower(c3) == "title") { in_title_table = 1; next }
+    if (c2 == bc) {
+      if (in_title_table && scoped == "") scoped = c3
+      if (fallback == "") fallback = c3
     }
   }
+  END { if (scoped != "") print scoped; else print fallback }
 ' "$BC_INDEX")
 
 if [[ -z "$INDEX_TITLE" ]]; then

--- a/plugins/vsdd-factory/tests/hooks.bats
+++ b/plugins/vsdd-factory/tests/hooks.bats
@@ -378,3 +378,71 @@ require_bash4_hook_interp() {
   run bash -c 'echo "{\"tool_input\":{\"file_path\":\".factory/STATE.md\"}}" | "'"$HOOKS"'/validate-count-propagation.sh" 2>&1'
   [ "$status" -eq 0 ]
 }
+
+# ---------- validate-bc-title ----------
+
+@test "validate-bc-title: title lookup scopes to the Title-header table (#566)" {
+  # The BC id appears first in a capability-satisfaction table (adjacent cell
+  # "CAP-001") before the §2 navigation table. The nav table title agrees with
+  # the H1, so this edit must pass — the matcher must not grab the CAP-001 cell.
+  local bc_dir=".factory/specs/behavioral-contracts"
+  cat > "$bc_dir/BC-2.01.001.md" <<'EOF'
+# BC-2.01.001: Drop-In SSH_AUTH_SOCK Replacement
+EOF
+  cat > "$bc_dir/BC-INDEX.md" <<'EOF'
+# BC-INDEX
+
+## 1. Capability Satisfaction
+
+| BC | Satisfies | Notes |
+|----|-----------|-------|
+| BC-2.01.001 | CAP-001 | primary |
+
+## 2. Navigation
+
+| BC | Title | Subsystem | Priority |
+|----|-------|-----------|----------|
+| BC-2.01.001 | Drop-In SSH_AUTH_SOCK Replacement | SS-02 | P0 |
+EOF
+  run bash -c 'echo "{\"tool_input\":{\"file_path\":\".factory/specs/behavioral-contracts/BC-2.01.001.md\"}}" | "'"$HOOKS"'/validate-bc-title.sh" 2>&1'
+  [ "$status" -eq 0 ]
+}
+
+@test "validate-bc-title: genuine H1/index drift in the nav table still blocks" {
+  local bc_dir=".factory/specs/behavioral-contracts"
+  cat > "$bc_dir/BC-2.01.001.md" <<'EOF'
+# BC-2.01.001: Drop-In SSH_AUTH_SOCK Replacement
+EOF
+  cat > "$bc_dir/BC-INDEX.md" <<'EOF'
+# BC-INDEX
+
+## 1. Capability Satisfaction
+
+| BC | Satisfies | Notes |
+|----|-----------|-------|
+| BC-2.01.001 | CAP-001 | primary |
+
+## 2. Navigation
+
+| BC | Title | Subsystem | Priority |
+|----|-------|-----------|----------|
+| BC-2.01.001 | Stale Divergent Title | SS-02 | P0 |
+EOF
+  run bash -c 'echo "{\"tool_input\":{\"file_path\":\".factory/specs/behavioral-contracts/BC-2.01.001.md\"}}" | "'"$HOOKS"'/validate-bc-title.sh" 2>&1'
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"bc_h1_index_drift"* ]]
+  [[ "$output" == *"Stale Divergent Title"* ]]
+}
+
+@test "validate-bc-title: headerless single-row index falls back and still blocks" {
+  # No Title-header table present — preserve prior behavior (first-occurrence
+  # fallback) so a genuine drift in a minimal index is still caught.
+  local bc_dir=".factory/specs/behavioral-contracts"
+  cat > "$bc_dir/BC-1.01.001.md" <<'EOF'
+# BC-1.01.001: Correct Title
+EOF
+  printf '| BC-1.01.001 | Wrong Title | SS-01 |\n' > "$bc_dir/BC-INDEX.md"
+  run bash -c 'echo "{\"tool_input\":{\"file_path\":\".factory/specs/behavioral-contracts/BC-1.01.001.md\"}}" | "'"$HOOKS"'/validate-bc-title.sh" 2>&1'
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"Wrong Title"* ]]
+}


### PR DESCRIPTION
## Why

`validate-bc-title` fires a false `bc_h1_index_drift` on every edit to a BC whose id appears in BC-INDEX *before* the §2 navigation table — e.g. in a capability-satisfaction table where the adjacent cell is `CAP-001` (#566). The title-lookup awk matched the first BC-INDEX row whose 2nd pipe-field equals the BC id, with no section scoping, so it grabbed the satisfaction cell and reported "CAP-001" as the indexed title even though the §2 nav-table title agreed with the H1 the whole time. This is a validator matching bug (false positive), not stale derived content — and it trains agents to ignore a hook whose entire job is catching real H1↔index drift. Any BC referenced in a table above §2 is affected, so it's structural, not project-specific. The fix anchors the lookup to the table that actually carries titles.

## What changed

- `plugins/vsdd-factory/hooks/validate-bc-title.sh`
  - Rewrote the index-title awk to scope to the navigation table: a header row whose 2nd data column is `Title` (case-insensitive) opens a "title table"; only a BC-id row *inside* such a table is treated as authoritative. A blank/non-`|` line closes the scope. When no Title-headed table exists (headerless single-row indexes, as in the existing `canonical-format-invariant.bats` fixture), it falls back to the first-occurrence match — preserving prior behavior for those cases.

- `plugins/vsdd-factory/tests/hooks.bats` — added a `validate-bc-title` regression section (3 cases): the #566 false-positive fixture (satisfaction table with `CAP-001` before a §2 Title table that agrees with the H1) now asserts exit 0; a genuine H1-vs-nav-table drift still blocks (exit 2, `bc_h1_index_drift`); a headerless single-row index still blocks on real drift via the fallback (exit 2). The pre-existing `validate-bc-title` case in `canonical-format-invariant.bats` (headerless index, mismatched title) still passes.

## Test evidence

BC-INDEX layout under test: a capability-satisfaction table (BC-2.1.001 → `CAP-001`) precedes the §2 navigation table whose title cell correctly matches the BC's H1 ("Drop-In SSH_AUTH_SOCK Replacement").

RED — unfixed hook, edit to BC-2.1.001.md (H1 and nav row untouched):

```
exit=2
BLOCKED by validate-bc-title: BC H1 title "Drop-In SSH_AUTH_SOCK Replacement" != BC-INDEX title "CAP-001" (POLICY 7: bc_h1_is_title_source_of_truth). Fix: Update BC-INDEX title to match H1, or fix H1 if it is wrong. Code: bc_h1_index_drift.
```

GREEN — fixed hook, same fixture (lookup scopes to the §2 Title table, agrees with H1):

```
exit=0
[]
```

GREEN regression — fixed hook, nav-table title changed to "Stale Divergent Title" (a real drift) still blocks:

```
exit=2
BLOCKED by validate-bc-title: BC H1 title "Drop-In SSH_AUTH_SOCK Replacement" != BC-INDEX title "Stale Divergent Title" (POLICY 7: bc_h1_is_title_source_of_truth). Fix: Update BC-INDEX title to match H1, or fix H1 if it is wrong. Code: bc_h1_index_drift.
```

Full suites, local (macOS): `bats tests/hooks.bats` 48 ok / 0 fail; `bats tests/integration/hooks/canonical-format-invariant.bats` 19 ok / 0 fail (pre-existing validate-bc-title block case intact). `bash -n` clean. `check-bats-orphans.sh`: all hook references resolve.

No factory-artifact implications — Class 0, touches only develop-tracked files.

Closes: #566
