### PR TITLE
fix(hooks): normalize leading v prefix in changelog frontmatter cross-check

### DIFF
--- a/plugins/vsdd-factory/hooks/validate-changelog-monotonicity.sh
+++ b/plugins/vsdd-factory/hooks/validate-changelog-monotonicity.sh
@@ -143,9 +143,17 @@ while IFS= read -r line; do
   fi
 done < "$FILE_PATH"
 
-# Cross-check frontmatter version vs top changelog row
+# Cross-check frontmatter version vs top changelog row.
+#
+# Normalize a single leading 'v'/'V' from both operands before comparing so a
+# bare frontmatter ("1.5") and a v-prefixed changelog row ("v1.5") are treated
+# as equal (issue #660). Without this, a bare-vs-prefixed pair false-positive
+# blocks on every bump, AND a v-prefixed tracked file cannot be normalized to
+# the bare convention (doing so trips this check) — freezing the drift in place.
 if [[ -n "$FM_VERSION" ]] && [[ -n "$FIRST_VERSION" ]]; then
-  if [[ "$FM_VERSION" != "$FIRST_VERSION" ]]; then
+  FM_VERSION_NORM="${FM_VERSION#[vV]}"
+  FIRST_VERSION_NORM="${FIRST_VERSION#[vV]}"
+  if [[ "$FM_VERSION_NORM" != "$FIRST_VERSION_NORM" ]]; then
     ERRORS="${ERRORS:+$ERRORS\n}Frontmatter version '$FM_VERSION' != top changelog version '$FIRST_VERSION'"
     [[ -z "$FIRST_CODE" ]] && FIRST_CODE="changelog_frontmatter_mismatch"
   fi

--- a/plugins/vsdd-factory/tests/corpus-lint.bats
+++ b/plugins/vsdd-factory/tests/corpus-lint.bats
@@ -201,6 +201,55 @@ EOF
   [[ "$output" == *"Frontmatter version"* ]]
 }
 
+@test "changelog-monotonicity: treats bare frontmatter and v-prefixed changelog row as equal (issue #660)" {
+  cat > "$WORK/.factory/specs/behavioral-contracts/BC-test.md" << 'EOF'
+---
+version: "1.5"
+---
+# BC Test
+## Changelog
+| Version | Burst | Date | Author | Change |
+|---------|-------|------|--------|--------|
+| v1.5 | pass-10 | 2026-04-20 | po | Latest |
+| v1.4 | pass-5 | 2026-04-19 | po | Prior |
+EOF
+  _run_hook validate-changelog-monotonicity.sh "$WORK/.factory/specs/behavioral-contracts/BC-test.md"
+  [ "$status" -eq 0 ]
+}
+
+@test "changelog-monotonicity: treats v-prefixed frontmatter and bare changelog row as equal (issue #660)" {
+  cat > "$WORK/.factory/specs/behavioral-contracts/BC-test.md" << 'EOF'
+---
+version: "v1.1"
+---
+# BC Test
+## Changelog
+| Version | Burst | Date | Author | Change |
+|---------|-------|------|--------|--------|
+| 1.1 | pass-3 | 2026-04-20 | po | Latest |
+| 1.0 | pass-1 | 2026-04-19 | po | Initial |
+EOF
+  _run_hook validate-changelog-monotonicity.sh "$WORK/.factory/specs/behavioral-contracts/BC-test.md"
+  [ "$status" -eq 0 ]
+}
+
+@test "changelog-monotonicity: still blocks a genuine version mismatch after v-normalization (issue #660)" {
+  cat > "$WORK/.factory/specs/behavioral-contracts/BC-test.md" << 'EOF'
+---
+version: "v1.1"
+---
+# BC Test
+## Changelog
+| Version | Burst | Date | Author | Change |
+|---------|-------|------|--------|--------|
+| v1.3 | pass-10 | 2026-04-20 | po | Latest |
+| v1.2 | pass-5 | 2026-04-19 | po | Previous |
+EOF
+  _run_hook validate-changelog-monotonicity.sh "$WORK/.factory/specs/behavioral-contracts/BC-test.md"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"Frontmatter version"* ]]
+}
+
 @test "changelog-monotonicity: ignores STATE.md" {
   cat > "$WORK/.factory/STATE.md" << 'EOF'
 ---


### PR DESCRIPTION
## Why

`validate-changelog-monotonicity.sh` cross-checks the frontmatter `version:`
against the top changelog-table row by raw string comparison, with no `v`-prefix
normalization. It treats `"1.5"` and `"v1.5"` as unequal, producing two failures:
a false-positive block whenever bare frontmatter meets a `vX.Y` changelog row
(fires on every version bump), and — more insidiously — an un-fixable tracked
file, because normalizing a `"v1.1"` frontmatter to the bare convention while the
changelog row stays `v1.1` trips the check, freezing the convention drift in
place. A governance hook that prevents a convention-conformance fix is doing the
opposite of its job.

## What changed

Strip a single optional leading `[vV]` from *both* operands
(`${FM_VERSION#[vV]}` / `${FIRST_VERSION#[vV]}`) before comparing. Minimal
normalization only — no full semver parsing was introduced, matching the
existing string-compare design of the ordering checks and the sibling
`validate-state-pin-freshness.sh` hook, which already normalizes v-prefixes.
`"1.5"` ≡ `"v1.5"` now, both the false-positive and the normalization-lock paths
are unblocked, and a genuine version mismatch is still caught.

Extended `tests/corpus-lint.bats` with three cases: bare-vs-v-prefixed (pass),
v-prefixed-vs-bare (pass), and a genuine mismatch after normalization (still
blocks, exit 2).

## Test evidence

Before the fix (unfixed hook), bare `"1.5"` frontmatter vs `v1.5` changelog row:

```
BLOCKED by validate-changelog-monotonicity: CHANGELOG MONOTONICITY VIOLATION in BC-vpfx.md: Frontmatter version '1.5' != top changelog version 'v1.5'. Fix: Set frontmatter 'version:' to match the top changelog row. Code: changelog_frontmatter_mismatch.
exit=2
```

New regression tests against the UNFIXED hook (red — the mismatch guard stays
green, proving it is a real check, not always-green):

```
1..3
not ok 1 changelog-monotonicity: treats bare frontmatter and v-prefixed changelog row as equal (issue #660)
not ok 2 changelog-monotonicity: treats v-prefixed frontmatter and bare changelog row as equal (issue #660)
ok 3 changelog-monotonicity: still blocks a genuine version mismatch after v-normalization (issue #660)
```

Full `corpus-lint.bats` suite against the FIXED hook (green), 89/89:

```
1..89
ok 14 changelog-monotonicity: blocks frontmatter/changelog version mismatch
ok 15 changelog-monotonicity: treats bare frontmatter and v-prefixed changelog row as equal (issue #660)
ok 16 changelog-monotonicity: treats v-prefixed frontmatter and bare changelog row as equal (issue #660)
ok 17 changelog-monotonicity: still blocks a genuine version mismatch after v-normalization (issue #660)
...
```

No factory-artifact implications — Class 0, touches only develop-tracked files.

Closes: #660
