### PR TITLE
fix(config): register L1 product-brief path in artifact-path-registry

### DIFF
--- a/crates/hook-plugins/validate-artifact-path/src/tests.rs
+++ b/crates/hook-plugins/validate-artifact-path/src/tests.rs
@@ -384,6 +384,86 @@ fn test_BC_4_11_001_ac002_matches_canonical_prd_path_returns_match() {
     }
 }
 
+// -----------------------------------------------------------------------
+// Issue #300: skills/create-brief writes the canonical L1 product brief to
+// .factory/specs/product-brief.md, but the registry had no matching entry —
+// so the brief (root of the traces_to chain) fell outside path governance
+// and its own canonical write would be blocked by validate-artifact-path
+// with ARTIFACT_PATH_UNREGISTERED.
+//
+// These tests load the ACTUAL production registry (walking up from
+// CARGO_MANIFEST_DIR) and assert the product-brief path now matches with
+// block enforcement, and that the hook allows the write end-to-end.
+//
+// Refs: #300.
+// -----------------------------------------------------------------------
+
+/// Locate the shipped production registry by walking up from
+/// CARGO_MANIFEST_DIR until `plugins/vsdd-factory/config/artifact-path-registry.yaml`
+/// is found. Layout-independent (unlike a hard-coded `../` count) so it can
+/// never silently fall back to a fixture and pass vacuously.
+fn production_registry_path_i300() -> std::path::PathBuf {
+    let manifest_dir =
+        std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR must be set during test");
+    let mut dir = std::path::PathBuf::from(&manifest_dir);
+    loop {
+        let candidate = dir.join("plugins/vsdd-factory/config/artifact-path-registry.yaml");
+        if candidate.exists() {
+            return candidate;
+        }
+        if !dir.pop() {
+            panic!(
+                "could not locate plugins/vsdd-factory/config/artifact-path-registry.yaml \
+                 walking up from CARGO_MANIFEST_DIR ({manifest_dir})"
+            );
+        }
+    }
+}
+
+/// Read the shipped production registry as YAML text.
+fn production_registry_yaml_i300() -> String {
+    let path = production_registry_path_i300();
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read registry at {}: {}", path.display(), e))
+}
+
+#[test]
+fn test_issue_300_product_brief_matches_production_registry() {
+    // #300: .factory/specs/product-brief.md is the canonical write target for
+    // skills/create-brief (SKILL.md § Output). It MUST match a block entry in
+    // the shipped registry, otherwise the brief's own write is blocked with
+    // ARTIFACT_PATH_UNREGISTERED and the L1 root of the traceability chain
+    // falls outside template/drift/register governance.
+    let registry =
+        load_registry(&production_registry_yaml_i300()).expect("production registry must load");
+    let path = ".factory/specs/product-brief.md";
+    let result = matches_canonical(path, &registry);
+    assert_eq!(
+        result,
+        MatchResult::Block,
+        "#300: canonical product-brief output '{}' must match a block entry in the \
+         production registry (currently {:?}). Without the entry, validate-artifact-path \
+         blocks the create-brief write with ARTIFACT_PATH_UNREGISTERED.",
+        path,
+        result
+    );
+}
+
+#[test]
+fn test_issue_300_product_brief_hook_allows_write() {
+    // End-to-end: a Write to the canonical product-brief path must NOT be blocked.
+    // run_logic serves the real registry YAML via the read_file callback, so
+    // this exercises the full hook path against the shipped registry.
+    let payload = make_payload("Write", Some(".factory/specs/product-brief.md"));
+    let (hook_result, _log, _events) = run_logic(payload, Ok(production_registry_yaml_i300()));
+    assert!(
+        matches!(hook_result, HookResult::Continue),
+        "#300: hook_logic must Continue (allow) the write to the canonical \
+         product-brief path; got {:?}",
+        hook_result
+    );
+}
+
 #[test]
 fn test_BC_4_11_001_ac002_matches_canonical_cycle_doc_path_returns_match() {
     let yaml = multi_entry_registry_yaml();

--- a/plugins/vsdd-factory/config/artifact-path-registry.yaml
+++ b/plugins/vsdd-factory/config/artifact-path-registry.yaml
@@ -133,6 +133,11 @@ artifacts:
     enforcement_level: block
 
   # ── Product Requirements / State ─────────────────────────────────────────
+  - artifact_type: product-brief
+    canonical_path_pattern: ".factory/specs/product-brief.md"
+    description: L1 product brief written by skills/create-brief — root of the traces_to chain
+    enforcement_level: block
+
   - artifact_type: prd
     canonical_path_pattern: ".factory/specs/prd.md"
     description: Product requirements document


### PR DESCRIPTION
## Why

`skills/create-brief` writes the canonical L1 product brief to `.factory/specs/product-brief.md`, but the artifact-path registry has no entry that matches it. Because `validate-artifact-path` hard-blocks any `.factory/` write with no matching registry entry (`ARTIFACT_PATH_UNREGISTERED`), the brief's own canonical write is blocked — and the brief, the root of the `traces_to` chain that every downstream artifact points back to, silently falls outside template-compliance, drift-check, and register-artifact governance. This adds the missing entry so the brief is both writable and governed, locked in with a test against the real shipped registry.

## What changed

- `plugins/vsdd-factory/config/artifact-path-registry.yaml`: added a `product-brief` entry under the "Product Requirements / State" section (beside `prd`), mirroring the neighboring entries' schema exactly (`artifact_type` / `canonical_path_pattern` / `description` / `enforcement_level: block`). Pattern is the literal path create-brief documents in its § Output: `.factory/specs/product-brief.md`.
- `crates/hook-plugins/validate-artifact-path/src/tests.rs`: two tests that load the **actual production registry** (walking up from `CARGO_MANIFEST_DIR`) and assert the product-brief path returns `MatchResult::Block`, plus an end-to-end `hook_logic` check that the write is allowed (`Continue`). A helper hard-fails if the registry can't be located, so the tests can never pass vacuously.

Note: `plugins/vsdd-factory/tests/generate-registry.bats` covers the *hooks* registry generator (`hooks-registry.toml`), not `artifact-path-registry.yaml`, and the existing artifact-path-registry coverage lives entirely in the `validate-artifact-path` Rust tests — so that's where this coverage belongs, alongside the neighboring canonical-path match tests.

## Test evidence

RED (before the registry entry, tests already in place):

```
running 2 tests
test tests::test_issue_300_product_brief_hook_allows_write ... FAILED
test tests::test_issue_300_product_brief_matches_production_registry ... FAILED

---- test_issue_300_product_brief_matches_production_registry ----
assertion `left == right` failed: #300: canonical product-brief output
'.factory/specs/product-brief.md' must match a block entry in the production
registry (currently NoMatch).
  left: NoMatch
 right: Block

---- test_issue_300_product_brief_hook_allows_write ----
#300: hook_logic must Continue (allow) the write ...; got Block { reason:
"... Write to '.factory/specs/product-brief.md' under .factory/ has no
matching entry ... Code: ARTIFACT_PATH_UNREGISTERED." }

test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 48 filtered out
```

GREEN (after adding the registry entry):

```
running 2 tests
test tests::test_issue_300_product_brief_hook_allows_write ... ok
test tests::test_issue_300_product_brief_matches_production_registry ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 48 filtered out
```

Full crate suite (no regressions):

```
test result: ok. 50 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out   (lib)
test result: ok. 4 passed; 0 failed; ...                                       (kani_path_matching)
test result: ok. 6 passed; 0 failed; ...                                       (proptest_registry_load)
```

No factory-artifact implications — Class 0, touches only develop-tracked files.

Pairs with the sibling registry PR for #473 — separate entries in different sections; either merges cleanly first (verified: both patches apply to develop tip in either order, and the combined tree compiles + passes).

Closes: #300
