### PR TITLE
fix(tests): skip live sprint-state.yaml assertions under CI — restore documented local-only design

### DIFF
--- a/plugins/vsdd-factory/tests/sprint-state-format.bats
+++ b/plugins/vsdd-factory/tests/sprint-state-format.bats
@@ -161,14 +161,15 @@ teardown() {
 # concrete instance: a PC3 def-b ordering violation in sprint-state.yaml failed
 # ten unrelated PRs at once).
 #
-# This guard restores the documented local-only design explicitly: skip under
-# GitHub Actions, keep full enforcement in local runs (and in the factory's
-# own hooks). If push-run enforcement is wanted, narrow the condition to
-# [ "${GITHUB_EVENT_NAME:-}" = "pull_request" ].
+# This guard skips only pull_request runs, where the base-mount mismatch
+# applies. Push runs on develop keep these tests live as a canary: there CI
+# mounts the artifact state develop actually ships, so a real sprint-state
+# corruption still surfaces on the push run. Local runs and the factory's
+# own hooks keep full enforcement either way.
 # ---------------------------------------------------------------------------
 _skip_live_artifact_in_ci() {
-  if [ -n "${GITHUB_ACTIONS:-}" ]; then
-    skip "live .factory artifact assertions are local-only by design (PORTABILITY notes; issue #724) — CI mounts the base repo's factory-artifacts, which a PR cannot modify"
+  if [ "${GITHUB_EVENT_NAME:-}" = "pull_request" ]; then
+    skip "live .factory artifact assertions skip on pull_request runs (PORTABILITY notes; issue #724) — CI mounts the base repo's factory-artifacts, which a PR cannot modify; push runs keep this canary"
   fi
 }
 

--- a/plugins/vsdd-factory/tests/sprint-state-format.bats
+++ b/plugins/vsdd-factory/tests/sprint-state-format.bats
@@ -149,6 +149,30 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
+# Live-artifact CI guard (issue #724)
+#
+# The five live-production-file tests below were designed per the PORTABILITY
+# notes above to SKIP in CI and run locally — the original guard keyed on the
+# .factory/ mount being absent, which was true in CI when they were authored.
+# CI now mounts factory-artifacts, which re-enabled these tests in CI runs.
+# In a pull_request run, CI mounts the BASE repo's artifact branch — a PR can
+# never modify what these tests assert — so any base-side artifact drift fails
+# every unrelated PR with the failure attributed to the PR (issue #724 is the
+# concrete instance: a PC3 def-b ordering violation in sprint-state.yaml failed
+# ten unrelated PRs at once).
+#
+# This guard restores the documented local-only design explicitly: skip under
+# GitHub Actions, keep full enforcement in local runs (and in the factory's
+# own hooks). If push-run enforcement is wanted, narrow the condition to
+# [ "${GITHUB_EVENT_NAME:-}" = "pull_request" ].
+# ---------------------------------------------------------------------------
+_skip_live_artifact_in_ci() {
+  if [ -n "${GITHUB_ACTIONS:-}" ]; then
+    skip "live .factory artifact assertions are local-only by design (PORTABILITY notes; issue #724) — CI mounts the base repo's factory-artifacts, which a PR cannot modify"
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # Helper: _count_stories_per_story_entries FILE
 # Count entries in the `stories:` YAML list that are per-story objects (have `id:`).
 # Returns 0 when the stories: key is a count-summary mapping (legacy format).
@@ -247,6 +271,7 @@ _leading_terminal_run() {
 # ---------------------------------------------------------------------------
 
 @test "test_sprint_state_stories_list_present" {
+  _skip_live_artifact_in_ci
   # Guard: skip when production file is absent (CI without factory-artifacts worktree)
   if [ ! -f "${_PRODUCTION_SPRINT_STATE}" ]; then
     skip ".factory/stories/sprint-state.yaml absent — factory-artifacts worktree not mounted (CI without .factory/ mount)"
@@ -939,6 +964,7 @@ EOF
 # ---------------------------------------------------------------------------
 
 @test "test_real_production_file_round_trip" {
+  _skip_live_artifact_in_ci
   # Guard: skip when production file is absent (CI without factory-artifacts worktree)
   if [ ! -f "${_PRODUCTION_SPRINT_STATE}" ]; then
     skip ".factory/stories/sprint-state.yaml absent — factory-artifacts worktree not mounted (CI); SKIP is expected in CI"
@@ -1290,6 +1316,7 @@ EOF
 # ---------------------------------------------------------------------------
 
 @test "test_real_production_file_completeness_and_status_fidelity" {
+  _skip_live_artifact_in_ci
   # Guard: skip when production files are absent (CI without factory-artifacts worktree)
   if [ ! -f "${_PRODUCTION_SPRINT_STATE}" ]; then
     skip ".factory/stories/sprint-state.yaml absent — factory-artifacts worktree not mounted (CI); SKIP is expected in CI"
@@ -1470,6 +1497,7 @@ EOF
 # ---------------------------------------------------------------------------
 
 @test "test_supersession_edge_tolerated_partition_placement" {
+  _skip_live_artifact_in_ci
   # Guard: skip when production file is absent (CI without factory-artifacts worktree)
   if [ ! -f "${_PRODUCTION_SPRINT_STATE}" ]; then
     skip ".factory/stories/sprint-state.yaml absent — factory-artifacts worktree not mounted (CI); SKIP is expected in CI"
@@ -1693,6 +1721,7 @@ EOF
 # ---------------------------------------------------------------------------
 
 @test "test_partitions_sorted_by_full_graph_depth_def_b" {
+  _skip_live_artifact_in_ci
   # Guard: skip when production files are absent (CI without factory-artifacts worktree)
   if [ ! -f "${_PRODUCTION_SPRINT_STATE}" ]; then
     skip ".factory/stories/sprint-state.yaml absent — factory-artifacts worktree not mounted (CI); SKIP is expected in CI"


### PR DESCRIPTION
## Fix: sprint-state-format.bats live-artifact assertions under CI (D-865)

**Finding:** \`sprint-state-format.bats\` live sprint-state.yaml assertions (\`test_real_production_file_completeness_and_status_fidelity\`, \`test_partitions_sorted_by_full_graph_depth_def_b\`, and related) unconditionally access factory-artifacts data. In \`pull_request\` CI runs, the runner mounts the BASE repo's factory-artifacts (data a PR cannot modify), so these tests fail on every PR regardless of the PR's own changes. This restores the documented local-only design.

**Severity:** LOW (test-infra only; production hook chain unaffected)

### What Changed

Added \`_skip_live_artifact_in_ci\` guard function to \`plugins/vsdd-factory/tests/sprint-state-format.bats\` with 5 callsites covering all tests that access the live \`_PRODUCTION_SPRINT_STATE\` factory-artifacts file.

Guard keys on \`GITHUB_EVENT_NAME == "pull_request"\` — the correct narrow signal:
- \`pull_request\` runs: skip cleanly (BASE factory-artifacts mount; PR cannot modify)
- \`push\` runs on develop: full enforcement maintained (canary for data drift)
- Local runs (env var unset): full enforcement maintained

### Why

Resolves persistent \`pull_request\` CI failures on any PR that touches develop when the live sprint-state.yaml data has drift. The \`pull_request\`-scoped guard is more production-grade than a blanket \`GITHUB_ACTIONS\` skip because it preserves the live canary on develop push runs.

Related: #724

### Testing

- [x] CI: all 13 checks green including \`bats-full-suite (linux)\`
- [x] Guard function fires on \`pull_request\` events; local and push runs fall through
- [x] 5 callsites cover all live-data-accessing tests in scope