### PR TITLE
fix(factory-obs+emit-event): correct JSON smoke-test to key=value and leave a breadcrumb when a JSON blob is dropped

### DIFF
--- a/plugins/vsdd-factory/bin/emit-event
+++ b/plugins/vsdd-factory/bin/emit-event
@@ -86,9 +86,18 @@ fi
 jq_args=()
 filter='{}'
 idx=0
+saw_jsonish_arg=0
 for arg in "$@"; do
   case "$arg" in
     *=*) ;;
+    # Breadcrumb for the #296 footgun: an arg with no `=` is silently
+    # dropped (this is deliberate garbage-tolerance). But an arg that
+    # *looks like* a JSON object/array is almost certainly a caller who
+    # mistook this tool for a JSON sink — the entire payload vanishes with
+    # no signal. Flag it in the emitted event (never stdout/stderr — the
+    # exit-0/silent contract above is inviolable) so the next operator has
+    # a trail instead of a bare heartbeat line.
+    \{*|\[*) saw_jsonish_arg=1; continue ;;
     *) continue ;;   # skip args without =
   esac
   key="${arg%%=*}"
@@ -115,6 +124,15 @@ TS_EPOCH=$(date +%s 2>/dev/null) || exit 0
 
 jq_args+=(--arg _ts "$TS" --arg _ts_epoch "$TS_EPOCH")
 filter="${filter} | .ts = \$_ts | .ts_epoch = (\$_ts_epoch | tonumber) | .schema_version = 1"
+
+# --- Breadcrumb: caller passed a JSON-looking arg with no key=value pair ----
+# See the arg-parsing loop above. Records that the payload was dropped, so an
+# operator running the (historically JSON-form) smoke test isn't fooled by a
+# bare heartbeat line into thinking ingestion is healthy. Preserves the
+# exit-0/no-stderr contract — the signal rides in the event itself.
+if [ "$saw_jsonish_arg" -eq 1 ]; then
+  filter="${filter} | ._emit_parse_warning = \"arg dropped: expected key=value pairs, got a JSON-looking token (see emit-event usage)\""
+fi
 
 # --- Auto-inject session_id from env if caller didn't provide one ----------
 # Priority order: caller-provided key (already in filter) > VSDD_SESSION_ID

--- a/plugins/vsdd-factory/skills/factory-obs/SKILL.md
+++ b/plugins/vsdd-factory/skills/factory-obs/SKILL.md
@@ -97,7 +97,7 @@ After `up`, it's helpful to remind the user that events only appear once a
 factory hook fires. A quick smoke test:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT}/bin/emit-event" '{"type":"hook.action","hook":"manual-test","action":"smoke"}'
+"${CLAUDE_PLUGIN_ROOT}/bin/emit-event" type=hook.action hook=manual-test action=smoke
 ```
 
 Events should be visible in Grafana within ~10 seconds.

--- a/plugins/vsdd-factory/tests/emit-event.bats
+++ b/plugins/vsdd-factory/tests/emit-event.bats
@@ -56,6 +56,63 @@ _logfile() {
   [ "$status" -eq 0 ]
 }
 
+# ---------- JSON-form footgun breadcrumb (#296) ----------
+# emit-event takes key=value pairs, not JSON. A JSON blob has no top-level `=`,
+# so every field is silently dropped. When the sole/leading token looks like a
+# JSON object or array, leave a breadcrumb IN THE EVENT (never stdout/stderr —
+# the silent/exit-0 contract is inviolable) so the drop is detectable.
+
+@test "emit-event: JSON-form arg still exits 0 (contract preserved)" {
+  run "$HELPER" '{"type":"hook.action","hook":"manual-test","action":"smoke"}'
+  [ "$status" -eq 0 ]
+}
+
+@test "emit-event: JSON-form arg produces no stdout/stderr" {
+  run "$HELPER" '{"type":"hook.action"}'
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "emit-event: JSON-object arg leaves _emit_parse_warning breadcrumb" {
+  run "$HELPER" '{"type":"hook.action","hook":"manual-test","action":"smoke"}'
+  [ "$status" -eq 0 ]
+  local f
+  f=$(_logfile)
+  [ -n "$f" ]
+  [ "$(jq -r '._emit_parse_warning // "ABSENT"' < "$f")" != "ABSENT" ]
+  # The JSON payload's fields were still dropped (the breadcrumb documents that).
+  [ "$(jq -r '.hook // "ABSENT"' < "$f")" = "ABSENT" ]
+}
+
+@test "emit-event: JSON-array arg also leaves the breadcrumb" {
+  run "$HELPER" '["type","hook.action"]'
+  [ "$status" -eq 0 ]
+  local f
+  f=$(_logfile)
+  [ "$(jq -r '._emit_parse_warning // "ABSENT"' < "$f")" != "ABSENT" ]
+}
+
+@test "emit-event: normal key=value call has NO breadcrumb" {
+  run "$HELPER" type=hook.action hook=manual-test action=smoke
+  [ "$status" -eq 0 ]
+  local f
+  f=$(_logfile)
+  [ "$(jq -r '._emit_parse_warning // "ABSENT"' < "$f")" = "ABSENT" ]
+  # And the documented smoke-test fields DO survive.
+  [ "$(jq -r '.hook' < "$f")" = "manual-test" ]
+}
+
+@test "emit-event: plain non-JSON garbage arg does NOT trigger the breadcrumb" {
+  # Only JSON-looking tokens ({ or [ prefix) are flagged; ordinary no-= args
+  # remain silently tolerated (existing garbage-tolerance behavior).
+  run "$HELPER" xxx yyy type=test
+  [ "$status" -eq 0 ]
+  local f
+  f=$(_logfile)
+  [ "$(jq -r '._emit_parse_warning // "ABSENT"' < "$f")" = "ABSENT" ]
+  [ "$(jq -r '.type' < "$f")" = "test" ]
+}
+
 @test "emit-event: exits 0 with binary data in value" {
   run "$HELPER" type=test val=$'\x01\x02\x03'
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Why

The `factory-obs` skill documents a smoke test that passes a JSON string to `emit-event`, but `emit-event` only parses `key=value` positional pairs — a JSON blob has no top-level `=`, so every field is silently dropped while the script still writes a line and exits 0. An operator running the documented smoke test sees the event file grow and a clean exit and reasonably concludes ingestion is healthy, when the event is actually empty. This is the only JSON-form invocation in the shipped plugin; every other doc already uses `key=value`. The one-line doc fix stops leading operators into the footgun, and a payload-preserving breadcrumb makes the drop detectable for anyone who hits it another way.

## What changed

- `skills/factory-obs/SKILL.md`: the smoke test now uses `type=hook.action hook=manual-test action=smoke` (the correct `key=value` form). The emitted event now carries the named fields, so the Grafana verification step is meaningful again.
- `bin/emit-event`: when an argument has no `=` **and** looks like a JSON object/array (`{`/`[` prefix), the emitter records an `_emit_parse_warning` field in the event it writes. This is the issue's option (b): it preserves the tool's inviolable contract (exit 0 on every path, no stdout/stderr on success, only ever writes the daily log) and matches the tool's existing self-instrumenting style (it already auto-injects `ts`/`schema_version`/`session_id`). A stderr warning was deliberately NOT chosen — the header contract at lines 8-12 promises "No output on stdout or stderr on success," and breaking that could break the hooks that call `emit-event`. Ordinary no-`=` garbage args remain silently tolerated (unchanged); only JSON-looking tokens are flagged, since those are almost certainly a caller who mistook the tool for a JSON sink.
- `tests/emit-event.bats`: 6 new tests (44 → 50 `@test` blocks) following the existing drop-path pattern — JSON-form still exits 0, produces no stdout/stderr, leaves the `_emit_parse_warning` breadcrumb (object and array forms), and confirms the dropped payload; plus two regression guards (normal `key=value` call has no breadcrumb and its fields survive; plain non-JSON garbage does not trigger the breadcrumb).

## Test evidence

RED — the documented JSON-form command drops the payload (before the doc fix):

```
$ VSDD_LOG_DIR=$TMP ./bin/emit-event '{"type":"hook.action","hook":"manual-test","action":"smoke"}'
exit=0
--- emitted line ---
{"ts":"2026-07-20T12:20:24-0500","ts_epoch":1784568024,"schema_version":1}
--- does it contain hook=manual-test? ---
ABSENT
--- fields present ---
schema_version,ts,ts_epoch
```

GREEN (a) — corrected `key=value` smoke test carries the fields:

```
$ VSDD_LOG_DIR=$TMP ./bin/emit-event type=hook.action hook=manual-test action=smoke
exit=0
{"type":"hook.action","hook":"manual-test","action":"smoke","ts":"...","ts_epoch":...,"schema_version":1}
--- hook field: manual-test ---
```

GREEN (b) — JSON-form now leaves a breadcrumb, still exit 0, still no stderr:

```
$ STDERR=$(VSDD_LOG_DIR=$TMP ./bin/emit-event '{"type":"hook.action",...}' 2>&1 >/dev/null)
exit=0 stderr=''
{"ts":"...","ts_epoch":...,"schema_version":1,"_emit_parse_warning":"arg dropped: expected key=value pairs, got a JSON-looking token (see emit-event usage)"}
--- _emit_parse_warning: arg dropped: expected key=value pairs, got a JSON-looking token (see emit-event usage) ---
```

Regression — normal call and plain garbage do NOT trigger the breadcrumb:

```
$ ./bin/emit-event type=test hook=x        → warn=ABSENT
$ ./bin/emit-event xxx yyy type=test       → warn=ABSENT  hook_survives=test
```

Full bats suite (macOS, bash 5.3, jq /usr/bin, bats 1.x) — 50 pass, 1 skip (jq-missing sim not possible when jq is in /usr/bin):

```
$ bats tests/emit-event.bats
ok 1..50 (test 21 skipped: jq installed in /usr/bin)
```

No factory-artifact implications — Class 0, touches only develop-tracked files.

Closes: #296

