### PR TITLE
fix(tooling): resolve .factory worktree cwd-independently in factory-cas-push.sh

### DIFF
--- a/plugins/vsdd-factory/bin/factory-cas-push.sh
+++ b/plugins/vsdd-factory/bin/factory-cas-push.sh
@@ -7,19 +7,21 @@
 # Usage:
 #   factory-cas-push.sh
 #
-# No arguments. Operates on the .factory/ worktree relative to the caller's working
-# directory (consistent with state-manager burst discipline). Requires git >= 2.6 for
+# No arguments. Operates on the .factory/ worktree. The worktree is located
+# cwd-independently (see FACTORY_DIR resolution below): it works from the repo
+# root, from inside the .factory worktree itself (the state-manager's natural
+# cwd — issue #631), and from a sibling story worktree. Requires git >= 2.6 for
 # the --force-with-lease=<refname>:<sha> explicit form (ADR-025 Decision 8).
 #
 # Sequence:
-#   Step 1: git -C .factory fetch origin factory-artifacts
+#   Step 1: git -C "$FACTORY_DIR" fetch origin factory-artifacts
 #           On non-zero exit → print AC-010 fetch-failure error to stderr; exit non-zero.
 #           The push MUST NOT proceed with a potentially stale EXPECTED_SHA.
 #
-#   Step 2: EXPECTED_SHA=$(git -C .factory rev-parse origin/factory-artifacts)
+#   Step 2: EXPECTED_SHA=$(git -C "$FACTORY_DIR" rev-parse origin/factory-artifacts)
 #           Capture the expected remote tip SHA immediately after fetch.
 #
-#   Step 3: git -C .factory push --force-with-lease=factory-artifacts:"${EXPECTED_SHA}" \
+#   Step 3: git -C "$FACTORY_DIR" push --force-with-lease=factory-artifacts:"${EXPECTED_SHA}" \
 #               origin factory-artifacts
 #           On non-zero exit (--force-with-lease check failed = concurrent write detected) →
 #           print AC-005 CASPushRejected error to stderr; exit non-zero.
@@ -41,11 +43,48 @@
 set -euo pipefail
 
 # ---------------------------------------------------------------------------
+# Resolve the .factory worktree cwd-independently (issue #631).
+#
+# The former relative `git -C .factory` assumed the caller was standing in the
+# repo root. When the caller's cwd IS the .factory worktree — the natural cwd
+# for a state-manager-role agent whose whole job lives there — the relative
+# `.factory` resolved to `.factory/.factory` and every git step died with
+# "cannot change to '.factory': No such file or directory", which then got
+# reported as a fetch error, sending the operator down a network rabbit-hole.
+#
+# The .factory worktree is always `<main-worktree>/.factory` (created via
+# `git worktree add .factory factory-artifacts`). The main worktree is the
+# first entry of `git worktree list --porcelain` regardless of which worktree
+# we invoke from — this is the same idiom emit-event, factory-query,
+# factory-sla, and factory-dashboard already use to locate the factory dir.
+#
+# Resolution order:
+#   1. cwd/.factory exists → repo-root invocation. Use it directly (relative,
+#      byte-identical to the historical behavior; no git call needed).
+#   2. else derive <main-worktree>/.factory from `git worktree list`. Covers
+#      the caller standing INSIDE .factory (where cwd/.factory would be
+#      .factory/.factory — absent) and callers in sibling story worktrees.
+#   3. else fail with an actionable message (not the raw `cd` error).
+# ---------------------------------------------------------------------------
+
+if [ -d ".factory" ]; then
+  FACTORY_DIR=".factory"
+else
+  MAIN_WT="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2; exit}')" || MAIN_WT=""
+  if [ -n "$MAIN_WT" ] && [ -d "$MAIN_WT/.factory" ]; then
+    FACTORY_DIR="$MAIN_WT/.factory"
+  else
+    printf 'state-burst CAS push failed — could not locate the .factory worktree from %s. Run from the repo root or the .factory worktree.\n' "$(pwd)" >&2
+    exit 1
+  fi
+fi
+
+# ---------------------------------------------------------------------------
 # Step 1: Fetch to synchronize origin/factory-artifacts before capturing SHA.
 # On failure, abort immediately — do NOT proceed with a stale EXPECTED_SHA.
 # ---------------------------------------------------------------------------
 
-if ! git -C .factory fetch origin factory-artifacts 2>&1; then
+if ! git -C "$FACTORY_DIR" fetch origin factory-artifacts 2>&1; then
   printf 'state-burst CAS push failed — fetch error before push. Retry after resolving network.\n' >&2
   exit 1
 fi
@@ -56,7 +95,7 @@ fi
 # CASPushRejected-class message and abort — do NOT push with an invalid SHA.
 # ---------------------------------------------------------------------------
 
-if ! EXPECTED_SHA="$(git -C .factory rev-parse origin/factory-artifacts 2>&1)"; then
+if ! EXPECTED_SHA="$(git -C "$FACTORY_DIR" rev-parse origin/factory-artifacts 2>&1)"; then
   printf 'state-burst CAS push failed — stale SHA after fetch: origin/factory-artifacts ref could not be resolved. Re-fetch and retry.\n' >&2
   exit 1
 fi
@@ -66,7 +105,7 @@ fi
 # object is absent from the local store (e.g., partial fetch, GC'd object).
 # Pushing a ghost SHA is unsafe — abort with CASPushRejected (EC-008 / F-R1-003).
 # ---------------------------------------------------------------------------
-if ! git -C .factory cat-file -e "${EXPECTED_SHA}^{commit}" 2>/dev/null; then
+if ! git -C "$FACTORY_DIR" cat-file -e "${EXPECTED_SHA}^{commit}" 2>/dev/null; then
   printf 'state-burst CAS push failed — stale SHA after fetch: object %s is absent from local store. Re-fetch and retry.\n' "$EXPECTED_SHA" >&2
   exit 1
 fi
@@ -77,7 +116,7 @@ fi
 # (non-zero exit), which is the desired CASPushRejected behavior.
 # ---------------------------------------------------------------------------
 
-if ! git -C .factory push \
+if ! git -C "$FACTORY_DIR" push \
     "--force-with-lease=factory-artifacts:${EXPECTED_SHA}" \
     origin factory-artifacts 2>&1; then
   printf 'state-burst CAS push failed — concurrent write detected.\n' >&2

--- a/plugins/vsdd-factory/bin/factory-cas-push.sh
+++ b/plugins/vsdd-factory/bin/factory-cas-push.sh
@@ -70,7 +70,12 @@ set -euo pipefail
 if [ -d ".factory" ]; then
   FACTORY_DIR=".factory"
 else
-  MAIN_WT="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2; exit}')" || MAIN_WT=""
+  # First `worktree` line is the main worktree (guaranteed git property).
+  # `--porcelain` emits the path RAW after "worktree " — never field-split it
+  # ($2 truncates paths containing spaces); strip the prefix instead. No awk
+  # `exit` on match: consuming the whole (small) stream avoids the
+  # pipefail/SIGPIPE edge of closing the pipe early.
+  MAIN_WT="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree / && !found { sub(/^worktree /, ""); print; found=1 }')" || MAIN_WT=""
   if [ -n "$MAIN_WT" ] && [ -d "$MAIN_WT/.factory" ]; then
     FACTORY_DIR="$MAIN_WT/.factory"
   else

--- a/plugins/vsdd-factory/tests/factory-cas-push.bats
+++ b/plugins/vsdd-factory/tests/factory-cas-push.bats
@@ -575,3 +575,80 @@ STUB
   # --force-with-lease allow-path must come before the block for --force
   [ "$lease_line" -lt "$force_block_line" ]
 }
+
+# ---------------------------------------------------------------------------
+# cwd-independent .factory resolution (issue #631)
+#
+# The helper formerly ran a relative `git -C .factory`, which assumes the caller
+# stands in the repo root. When the caller's cwd IS the .factory worktree — the
+# state-manager's natural cwd — `.factory` resolved to `.factory/.factory` and
+# every git step died with "cannot change to '.factory'", misreported as a fetch
+# error. These tests use a REAL main-worktree + linked .factory worktree + bare
+# origin (no git stub) so the resolution logic is exercised end-to-end.
+#
+# Fixture layout (built by _setup_worktree_fixture):
+#   $WORK/origin.git          — bare remote
+#   $WORK/main                — main worktree (branch: develop)
+#   $WORK/main/.factory       — linked worktree (branch: factory-artifacts)
+#   $WORK/story-S1            — sibling story worktree (branch: story/S-1)
+# ---------------------------------------------------------------------------
+
+_setup_worktree_fixture() {
+  # GHA runners lack a global git identity; scope one to this process only.
+  export GIT_AUTHOR_NAME="cas-push-test"
+  export GIT_AUTHOR_EMAIL="cas-push@test.local"
+  export GIT_COMMITTER_NAME="cas-push-test"
+  export GIT_COMMITTER_EMAIL="cas-push@test.local"
+
+  ORIGIN="$WORK/origin.git"
+  MAIN="$WORK/main"
+  git init --bare -q "$ORIGIN"
+  git clone -q "$ORIGIN" "$MAIN" 2>/dev/null
+
+  git -C "$MAIN" commit --allow-empty -q -m init
+  # factory-artifacts branch with a STATE.md, pushed to origin
+  git -C "$MAIN" checkout -q -b factory-artifacts
+  echo "state: initial" > "$MAIN/STATE.md"
+  git -C "$MAIN" add STATE.md
+  git -C "$MAIN" commit -q -m "init factory-artifacts"
+  git -C "$MAIN" push -q origin factory-artifacts
+  # primary working branch + linked .factory worktree
+  git -C "$MAIN" checkout -q -b develop
+  git -C "$MAIN" worktree add -q .factory factory-artifacts
+}
+
+@test "cwd-resolution: invocation from repo root succeeds (#631)" {
+  _setup_worktree_fixture
+  run bash -c "cd '$MAIN' && bash '$HELPER'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"state-burst CAS push succeeded"* ]]
+}
+
+@test "cwd-resolution: invocation from INSIDE .factory worktree succeeds (#631)" {
+  _setup_worktree_fixture
+  # This is the exact scenario that failed before the fix: cwd IS .factory,
+  # so the old relative `git -C .factory` looked for .factory/.factory.
+  run bash -c "cd '$MAIN/.factory' && bash '$HELPER'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"state-burst CAS push succeeded"* ]]
+  # And it must NOT emit the old raw cd failure masquerading as a fetch error.
+  [[ "$output" != *"cannot change to '.factory'"* ]]
+}
+
+@test "cwd-resolution: invocation from a sibling story worktree succeeds (#631)" {
+  _setup_worktree_fixture
+  git -C "$MAIN" worktree add -q -b story/S-1 "$WORK/story-S1" develop
+  run bash -c "cd '$WORK/story-S1' && bash '$HELPER'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"state-burst CAS push succeeded"* ]]
+}
+
+@test "cwd-resolution: invocation from an unrelated non-git dir fails clearly (#631)" {
+  UNREL="$WORK/unrelated"
+  mkdir -p "$UNREL"
+  run bash -c "cd '$UNREL' && bash '$HELPER'"
+  [ "$status" -ne 0 ]
+  # Actionable message, NOT the raw git cd error.
+  [[ "$output" == *"could not locate the .factory worktree"* ]]
+  [[ "$output" == *"Run from the repo root or the .factory worktree."* ]]
+}

--- a/plugins/vsdd-factory/tests/factory-cas-push.bats
+++ b/plugins/vsdd-factory/tests/factory-cas-push.bats
@@ -643,6 +643,19 @@ _setup_worktree_fixture() {
   [[ "$output" == *"state-burst CAS push succeeded"* ]]
 }
 
+@test "cwd-resolution: main worktree path containing a SPACE resolves correctly (#631 review)" {
+  # git worktree list --porcelain emits the path raw; field-splitting it
+  # ($2) truncated "…/App Dir/main" to "…/App" and the fallback died with
+  # the could-not-locate error. Space-path fixture pins the prefix-strip fix.
+  WORK="$WORK/space dir"
+  mkdir -p "$WORK"
+  _setup_worktree_fixture
+  git -C "$MAIN" worktree add -q -b story/S-2 "$WORK/story-S2" develop
+  run bash -c "cd '$WORK/story-S2' && bash '$HELPER'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"state-burst CAS push succeeded"* ]]
+}
+
 @test "cwd-resolution: invocation from an unrelated non-git dir fails clearly (#631)" {
   UNREL="$WORK/unrelated"
   mkdir -p "$UNREL"


### PR DESCRIPTION
## Why

`bin/factory-cas-push.sh` ran a relative `git -C .factory` throughout, assuming it was always invoked from the repo root. When the caller's working directory is the `.factory` worktree — the natural cwd for a state-manager-role agent whose entire job lives inside that worktree — the relative path resolved to `.factory/.factory` and the script died with `cannot change to '.factory': No such file or directory`. Worse, that raw `cd` failure surfaced through the fetch step and got reported as `state-burst CAS push failed — fetch error ... Retry after resolving network`, sending the operator down a network rabbit-hole for a cwd bug. This makes the CAS-push tooling reliable from the one cwd where it is most likely to be run.

## What changed

- `bin/factory-cas-push.sh`: added a cwd-independent `.factory` resolution block and routed all four git steps (fetch, rev-parse, cat-file, push) through the resolved `$FACTORY_DIR`. Resolution order:
  1. `cwd/.factory` exists → use it directly (repo-root invocation; relative, byte-identical to the historical behavior, no git call).
  2. else derive `<main-worktree>/.factory` from `git worktree list --porcelain` (first entry is always the main worktree, from any worktree). This covers the caller standing inside `.factory` (where `cwd/.factory` would be `.factory/.factory`, absent) and callers in sibling story worktrees.
  3. else fail with an actionable message (`could not locate the .factory worktree from <pwd>. Run from the repo root or the .factory worktree.`) instead of the raw `cd` error.

  This mirrors the repo's own convention: emit-event, factory-query, factory-sla, and factory-dashboard already locate the factory dir via the same `git worktree list --porcelain` first-entry idiom. Checking `cwd/.factory` first is deliberate — it's the fast path, keeps repo-root behavior identical, and avoids invoking git in the common case.
- `tests/factory-cas-push.bats`: 4 new tests using a real bare-origin + main-worktree + linked `.factory` fixture (no git stub): repo-root succeeds, inside-`.factory` succeeds (and does NOT emit the old `cannot change to '.factory'` error), sibling story worktree succeeds, and an unrelated non-git dir fails with the actionable message.

## Test evidence

RED — pristine upstream/develop script, run from inside `.factory` and from an unrelated dir:

```
===== ORIGINAL from INSIDE .factory =====
fatal: cannot change to '.factory': No such file or directory
state-burst CAS push failed — fetch error before push. Retry after resolving network.
exit=1
===== ORIGINAL from unrelated dir =====
fatal: cannot change to '.factory': No such file or directory
state-burst CAS push failed — fetch error before push. Retry after resolving network.
exit=1
```

GREEN — fixed script across all four cwd scenarios (real bare-origin + main + linked `.factory` fixture):

```
===== from repo root =====
state-burst CAS push succeeded (SHA: 490a1ec...)
exit=0
===== from INSIDE .factory =====
state-burst CAS push succeeded (SHA: 490a1ec...)
exit=0
===== from a sibling story worktree =====
state-burst CAS push succeeded (SHA: 5dbf574...)
exit=0
===== from an unrelated non-git dir =====
state-burst CAS push failed — could not locate the .factory worktree from /tmp/... . Run from the repo root or the .factory worktree.
exit=1
```

Full bats suite (macOS, bash 5.3, bats 1.x) — the 5 pre-existing CAS-push tests plus the 4 new cwd-resolution tests all pass:

```
$ bats tests/factory-cas-push.bats
1..9
ok 1 test_BC_5_40_001_cas_push_rejected_on_concurrent_write
ok 2 test_BC_5_40_001_cas_push_stale_sha_after_fetch
ok 3 test_BC_5_40_001_cas_push_object_absent_after_fetch
ok 4 test_BC_5_40_001_fetch_failure_aborts_push
ok 5 test_BC_5_40_001_verify_git_push_hook_unchanged
ok 6 cwd-resolution: invocation from repo root succeeds (#631)
ok 7 cwd-resolution: invocation from INSIDE .factory worktree succeeds (#631)
ok 8 cwd-resolution: invocation from a sibling story worktree succeeds (#631)
ok 9 cwd-resolution: invocation from an unrelated non-git dir fails clearly (#631)
```

The 4 new tests were confirmed genuinely RED against the pristine upstream script (test 7 fails on exit 1 with the raw cd error; test 9's actionable-message assertions fail because the original emits the generic fetch-error message) — not tautological.

No factory-artifact implications — Class 0, touches only develop-tracked files.

Closes: #631
