### PR TITLE
fix(hooks/validate-count-propagation): exclude historical sections from count-drift comparison

### DIFF
--- a/plugins/vsdd-factory/hooks/validate-count-propagation.sh
+++ b/plugins/vsdd-factory/hooks/validate-count-propagation.sh
@@ -83,16 +83,42 @@ if [[ ${#SIBLING_FILES[@]} -eq 0 ]]; then
   exit 0
 fi
 
+# H2 sections whose count mentions are historical/frozen by project convention:
+# changelog rows, phase-history rows, and decision-log rows. A count inside one
+# of these ("Lists all 36 BCs" in a changelog entry, "PRD (38 BCs)" in a Phase
+# Progress row) is an immutable record and MUST be allowed to disagree with the
+# current count — comparing it as drift is the #567 false positive. Boundaries
+# use the same "^## opens, next ^## closes" idiom as
+# validate-changelog-monotonicity.sh.
+_is_historical_heading() {
+  case "${1,,}" in
+    "## changelog"* | "## change log"* | "## historical content"* | \
+    "## phase progress"* | "## decisions log"*)
+      return 0 ;;
+  esac
+  return 1
+}
+
 # Extract count-bearing pairs from a file.
 # Outputs lines of format: KEYWORD:COUNT
 # Supported patterns:
 #   "NNN BCs" / "NNN,NNN BCs" — count before keyword
 #   "BCs | NNN" / "BCs: NNN" — keyword before count (table or YAML)
 #   "total_bcs: NNN" / "total_vps: NNN" — YAML frontmatter keys
+# Count mentions inside historical H2 sections (see _is_historical_heading) are
+# skipped so frozen records are never compared against the current count (#567).
 _extract_counts() {
   local path="$1"
+  local in_historical=0
   while IFS= read -r line; do
     local count keyword
+    # Track historical-section boundaries; skip counts while inside one.
+    # Runs BEFORE the ID-token drop below so headings are inspected verbatim
+    # and historical lines skip the per-line mutation entirely.
+    if [[ "$line" =~ ^##[[:space:]] ]]; then
+      if _is_historical_heading "$line"; then in_historical=1; else in_historical=0; fi
+    fi
+    [[ "$in_historical" -eq 1 ]] && continue
     # Drop identifier tokens (E-11, S-3, BC-2.1.001, TD-001, SS-01) before
     # count extraction: the digits inside an ID are not a quantity. Without
     # this, "5 E-11 stories" mis-parses "11 stories" as a phantom count and
@@ -142,8 +168,10 @@ done < <(_extract_counts "$FILE_PATH")
 # Nothing to compare if no count patterns found.
 # Guard via ${arr[*]:-} rather than ${#arr[@]}: under `set -u`, expanding the
 # element count of an *empty associative array* is itself an unbound-variable
-# error in bash 4+. Dropping identifier tokens above makes an all-phantom line
-# (e.g. "5 E-11 stories" with no genuine count) leave this array empty, so this
+# error in bash 4+. Two paths above can leave this array empty: the ID-token
+# drop (an all-phantom line like "5 E-11 stories" with no genuine count) and
+# the historical-section skip (a file whose only counts were changelog/
+# phase-history rows). Either way this
 # no-count path is now reachable and must exit 0 cleanly, not crash.
 if [[ -z "${SOURCE_COUNTS[*]:-}" ]]; then
   exit 0

--- a/plugins/vsdd-factory/tests/hooks.bats
+++ b/plugins/vsdd-factory/tests/hooks.bats
@@ -310,7 +310,7 @@ teardown() {
   [ "$status" -eq 0 ]
 }
 
-# ---------- validate-count-propagation ----------
+# ---------- validate-count-propagation (#690 id-drop + #567 historical exclusion) ----------
 #
 # The hook uses associative arrays (declare -A), which require bash 4+.
 # It runs via its #!/bin/bash shebang, so the interpreter that matters is
@@ -445,4 +445,55 @@ EOF
   run bash -c 'echo "{\"tool_input\":{\"file_path\":\".factory/specs/behavioral-contracts/BC-1.01.001.md\"}}" | "'"$HOOKS"'/validate-bc-title.sh" 2>&1'
   [ "$status" -eq 2 ]
   [[ "$output" == *"Wrong Title"* ]]
+}
+
+@test "validate-count-propagation: historical count in sibling is not drift (#567)" {
+  require_bash4_hook_interp
+  # Editing BC-INDEX (current total_bcs: 41). The only BC count in the STATE.md
+  # sibling is a frozen Phase Progress row, "PRD (38 BCs)". Pre-fix, the sibling's
+  # historical 38 was compared against the current 41 and fired drift; post-fix the
+  # historical section is skipped, the sibling has no current count, and absence is
+  # not drift.
+  printf '%s\n' '---' 'total_bcs: 41' '---' '# BC-INDEX' > .factory/BC-INDEX.md
+  printf '# STATE\n## Phase Progress\n| PRD | done | PRD (38 BCs) at phase-1 close |\n' > .factory/STATE.md
+  run bash -c 'echo "{\"tool_input\":{\"file_path\":\"'$WORK'/.factory/BC-INDEX.md\"}}" | "'"$HOOKS"'/validate-count-propagation.sh" 2>&1'
+  [ "$status" -eq 0 ]
+}
+
+@test "validate-count-propagation: historical count in source before current is not drift (#567)" {
+  require_bash4_hook_interp
+  # Editing STATE.md. Its frozen Phase Progress row ("PRD (38 BCs)") appears before
+  # the live Count Verification row ("41 BCs"). Pre-fix, first-match picked the
+  # historical 38 as the source count and fired drift against BC-INDEX's 41; post-fix
+  # the historical section is skipped and the live 41 is the source count — no drift.
+  printf '%s\n' '---' 'total_bcs: 41' '---' '# BC-INDEX' > .factory/BC-INDEX.md
+  printf '# STATE\n## Phase Progress\n| PRD | done | PRD (38 BCs) at phase-1 close |\n## Count Verification\nCurrent corpus: 41 BCs verified.\n' > .factory/STATE.md
+  run bash -c 'echo "{\"tool_input\":{\"file_path\":\"'$WORK'/.factory/STATE.md\"}}" | "'"$HOOKS"'/validate-count-propagation.sh" 2>&1'
+  [ "$status" -eq 0 ]
+}
+
+@test "validate-count-propagation: genuine current-count drift still blocks (#567)" {
+  require_bash4_hook_interp
+  # STATE's LIVE Count Verification section says 39 while BC-INDEX frontmatter says
+  # 41 — a real current-site disagreement that must still fire even though the same
+  # file carries a frozen Phase Progress row (38) that is correctly ignored.
+  printf '%s\n' '---' 'total_bcs: 41' '---' '# BC-INDEX' > .factory/BC-INDEX.md
+  printf '# STATE\n## Phase Progress\n| PRD | done | PRD (38 BCs) at phase-1 close |\n## Count Verification\nCurrent corpus: 39 BCs verified.\n' > .factory/STATE.md
+  run bash -c 'echo "{\"tool_input\":{\"file_path\":\"'$WORK'/.factory/STATE.md\"}}" | "'"$HOOKS"'/validate-count-propagation.sh" 2>&1'
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"COUNT DRIFT DETECTED"* ]]
+  [[ "$output" == *"39 BCs"* ]]
+}
+
+@test "validate-count-propagation: source with only historical counts exits clean, no crash (#567)" {
+  require_bash4_hook_interp
+  # Editing STATE.md whose only count is a frozen changelog row, with no current
+  # count anywhere. After the historical section is skipped the source-count map is
+  # empty; that path must exit 0, not trip set -u on the empty associative array
+  # (the reason the ${arr[*]:-} guard replaces ${#arr[@]}). Sibling carries no count.
+  printf '%s\n' '---' 'document_type: index' '---' '# BC-INDEX' 'Prose only, no counts.' > .factory/BC-INDEX.md
+  printf '# STATE\n## Changelog\n| 1.0 | 2026-06-27 | Lists all 36 BCs |\n' > .factory/STATE.md
+  run bash -c 'echo "{\"tool_input\":{\"file_path\":\"'$WORK'/.factory/STATE.md\"}}" | "'"$HOOKS"'/validate-count-propagation.sh" 2>&1'
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
 }


### PR DESCRIPTION
## Why

`count_propagation_drift` fires on every edit to BC-INDEX.md / STATE.md once any
count has ever changed, because `_extract_counts` scans every line — including
frozen changelog rows and phase-history rows — and compares those historical
mentions against the current count. A changelog entry that correctly records
"Lists all 36 BCs" for v1.0, or a Phase Progress row that froze "PRD (38 BCs)"
at phase-1 close, is flagged as drift against the live `total_bcs: 41`. That is
permanent alert fatigue on a check meant to catch real drift, and it creates a
perverse incentive to rewrite immutable history to silence the hook — which, per
the issue thread, already induced a real history-integrity violation. This
restricts count extraction to current-count sites so frozen records are allowed
to disagree, while genuine current-count drift still blocks.

## What changed

- `hooks/validate-count-propagation.sh`: `_extract_counts` now tracks H2 section
  boundaries and skips count mentions inside historical sections — `## Changelog`,
  `## Change Log`, `## Historical Content`, `## Phase Progress`, `## Decisions Log`.
  Boundary detection uses the repo's own idiom (`^## <name>` opens, next `^## `
  closes), the same convention `validate-changelog-monotonicity.sh` uses. A new
  `_is_historical_heading` helper holds the section list.
- Same file: the no-count guard changes from `[[ ${#SOURCE_COUNTS[@]} -eq 0 ]]`
  to `[[ -z "${SOURCE_COUNTS[*]:-}" ]]`. Under `set -u`, expanding the element
  count of an *empty associative array* is itself an unbound-variable error in
  bash 4+. Skipping historical sections can leave a file whose only counts were
  historical with an empty source map, making that path reachable — so it must
  exit 0 cleanly, not crash. (This is a pre-existing latent bug: on plain develop
  the same crash already occurs for any triggering file with zero count patterns;
  this change fixes it as a side effect of making the path reachable.)
- `tests/hooks.bats`: four regression cases (historical count in sibling not
  drift; historical count before current not drift; genuine current-count drift
  still blocks; source with only historical counts exits clean without crashing).
  Guarded by `require_bash4_count_prop` — the hook needs bash 4+ (`declare -A`),
  which is present on the ubuntu `validate` CI job (`/bin/bash` is bash 5.x) but
  not on macOS (`/bin/bash` is 3.2, where the cases skip).

## Test evidence

Verified with `/opt/homebrew/bin/bash` (bash 5.3) — the interpreter class CI's
`validate` job runs, since the hook's `#!/bin/bash` resolves to bash 5.x there.

RED — pristine hook on plain develop, editing BC-INDEX.md whose STATE.md sibling
has a frozen Phase Progress row "PRD (38 BCs)" and current `total_bcs: 41`:

```
$ echo '{...BC-INDEX.md}' | bash validate-count-propagation.sh   # BEFORE
BLOCKED by validate-count-propagation: Count propagation drift detected in BC-INDEX.md: COUNT DRIFT DETECTED: '41 BCs' in BC-INDEX.md but '38 BCs' in STATE.md.; ... Code: count_propagation_drift.
exit=2
```

GREEN — patched hook, same inputs; historical section skipped:

```
$ echo '{...BC-INDEX.md}' | bash validate-count-propagation.sh   # AFTER
exit=0
```

GREEN control — patched hook, STATE.md whose LIVE `## Count Verification` says
39 while frontmatter says 41 (a real current-site disagreement); still blocks:

```
$ echo '{...STATE.md, live 39 vs 41}' | bash validate-count-propagation.sh
BLOCKED by validate-count-propagation: ... COUNT DRIFT DETECTED: '39 BCs' in STATE.md but '41 BCs' in BC-INDEX.md. ... Code: count_propagation_drift.
exit=2
```

The four bats cases, forced under bash 5.3:

```
1..4
ok 1 validate-count-propagation: historical count in sibling is not drift (#567)
ok 2 validate-count-propagation: historical count in source before current is not drift (#567)
ok 3 validate-count-propagation: genuine current-count drift still blocks (#567)
ok 4 validate-count-propagation: source with only historical counts exits clean, no crash (#567)
```

Full `tests/hooks.bats` on macOS (bash 3.2) — 49 tests pass, the four new cases
skip cleanly per the bash-4 guard (mirroring how they behave vs the CI matrix).

No factory-artifact implications — Class 0, touches only develop-tracked files.

## Coordination — merge order vs PR #716

PR #716 (`fix/count-propagation-epic-id`, patch 690) also modifies this hook and
appends to `hooks.bats`, for a sibling false-positive (identifier substrings
mis-parsed as counts, e.g. "5 E-11 stories" → phantom "11 stories"). The two
changes are complementary and both wanted, but they textually conflict — in
BOTH apply orders — at two points:

1. `hooks/validate-count-propagation.sh` inside `_extract_counts`: #716 inserts
   an ID-token-drop line at the top of the loop body; this PR inserts the
   historical-section-skip block at the same spot. Resolution is to keep BOTH
   (skip historical sections, then drop ID tokens) — they compose.
2. The no-count guard line: BOTH PRs independently replace
   `${#SOURCE_COUNTS[@]}` with the identical `${SOURCE_COUNTS[*]:-}` fix (only
   the explanatory comment differs). Keep either; a merged comment covers both
   reasons.
3. `tests/hooks.bats`: both append a test block at the tail. This PR's guard is
   named `require_bash4_count_prop` and #716's is `require_bash4_hook_interp`
   (distinct names, distinct `@test` names), so resolution is pure concatenation
   — keep both blocks and both guard functions.

I applied both patches to a scratch branch and resolved the merge as above:
the merged hook syntax-checks clean, and all 8 count-propagation cases (4 from
#716 + 4 here) pass under bash 5.3, full merged suite 53/53. Whichever lands
first, the second will need this trivial resolution; no logic changes are
required to either side.

## Scope note on #567

This PR resolves the **historical-sections** false-positive mode — the one in
#567's original report. The issue thread carries three further items this PR
does not address: the **identifier-substring** mode (second comment; #716 adds
ID-token dropping in this same hook covering `E-11` / `BC-2.1.001`-shaped
fragments), the `total_bcs:` vs `bc_count:` frontmatter-key reconciliation
(first comment), and the canonical-anchor + fix-instruction-wording suggestions
from the escalation comment. Using `Refs` rather than `Closes` so the merge
doesn't auto-close an issue with remaining scope; a comment on #567 maps the
modes to PRs.

Refs: #567


