### PR TITLE
fix(observability): correct dashboard LogQL to query structured metadata, not JSON body

### DIFF
--- a/plugins/vsdd-factory/tests/grafana-dashboards.bats
+++ b/plugins/vsdd-factory/tests/grafana-dashboards.bats
@@ -1,0 +1,45 @@
+#!/usr/bin/env bats
+# grafana-dashboards.bats — static guards for Grafana dashboard JSON
+#
+# There is no harness exercising Grafana panel `expr` (factory-dashboard.bats
+# covers the terminal renderer, not these panels), which is why the
+# `attributes_`-prefixed LogQL idiom (#243, #244, #245) shipped and sat
+# broken: the OTEL collector promotes those attributes to structured
+# metadata, so `| json | attributes_x` parses the log BODY and matches
+# nothing. These grep-level guards are the cheap ratchet against the same
+# class recurring — they assert the stale idiom stays out of the dashboards
+# without needing a live Loki stack.
+#
+# Refs: #243
+
+setup() {
+  PLUGIN_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  DASHBOARDS="$PLUGIN_ROOT/tools/observability/grafana-dashboards"
+}
+
+@test "grafana-dashboards: dashboard dir exists and is non-empty" {
+  [ -d "$DASHBOARDS" ]
+  count=$(find "$DASHBOARDS" -maxdepth 1 -name '*.json' | wc -l)
+  [ "$count" -gt 0 ]
+}
+
+@test "grafana-dashboards: no '| json | attributes_' body-parse stage survives" {
+  # The exact broken pipeline shape: parse body as JSON, then filter on an
+  # attributes_-prefixed field that only exists pre-promotion.
+  run grep -l 'json | attributes_' "$DASHBOARDS"/*.json
+  [ "$status" -ne 0 ]
+}
+
+@test "grafana-dashboards: no attributes_-prefixed label reference anywhere" {
+  # Broader ratchet: attributes_ prefixes (exprs, legendFormat,
+  # ${__field.labels.attributes_*} displayNames) are the stale pre-promotion
+  # idiom in every form. Structured-metadata labels carry the bare name.
+  run grep -l 'attributes_' "$DASHBOARDS"/*.json
+  [ "$status" -ne 0 ]
+}
+
+@test "grafana-dashboards: every dashboard is valid JSON" {
+  for f in "$DASHBOARDS"/*.json; do
+    jq empty "$f" || { echo "invalid JSON: $f"; return 1; }
+  done
+}

--- a/plugins/vsdd-factory/tools/observability/grafana-dashboards/claude-overview.json
+++ b/plugins/vsdd-factory/tools/observability/grafana-dashboards/claude-overview.json
@@ -61,7 +61,7 @@
       "id": 2,
       "title": "Unique sessions",
       "type": "stat",
-      "description": "Distinct Claude sessions. Derived from attributes.session.id parsed via | json (Loki flattens dotted keys with underscores -> attributes_session_id).",
+      "description": "Distinct Claude sessions. Derived from the session_id structured-metadata field on each Claude OTel log entry (filtered with the `| session_id != \"\"` metadata pipe, not `| json`).",
       "datasource": { "type": "loki", "uid": "loki" },
       "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
       "fieldConfig": {
@@ -91,7 +91,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "count(count by (attributes_session_id) (count_over_time({service_name=\"claude-code\"} | json | attributes_session_id != \"\" [$__range])))"
+          "expr": "count(count by (session_id) (count_over_time({service_name=\"claude-code\"} | session_id != \"\" [$__range])))"
         }
       ]
     },
@@ -129,7 +129,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "sum(count_over_time({service_name=\"claude-code\"} | json | attributes_event_name = \"tool_result\" [$__range]))"
+          "expr": "sum(count_over_time({service_name=\"claude-code\"} | event_name = \"tool_result\" [$__range]))"
         }
       ]
     },
@@ -167,7 +167,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "sum(count_over_time({service_name=\"claude-code\"} | json | attributes_event_name = \"api_request\" [$__range]))"
+          "expr": "sum(count_over_time({service_name=\"claude-code\"} | event_name = \"api_request\" [$__range]))"
         }
       ]
     },
@@ -201,8 +201,8 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "sum by (attributes_event_name) (count_over_time({service_name=\"claude-code\"} | json [$__interval]))",
-          "legendFormat": "{{attributes_event_name}}"
+          "expr": "sum by (event_name) (count_over_time({service_name=\"claude-code\"} [$__interval]))",
+          "legendFormat": "{{event_name}}"
         }
       ]
     },
@@ -230,8 +230,8 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "topk(10, sum by (attributes_tool_name) (count_over_time({service_name=\"claude-code\"} | json | attributes_tool_name != \"\" [$__range])))",
-          "legendFormat": "{{attributes_tool_name}}"
+          "expr": "topk(10, sum by (tool_name) (count_over_time({service_name=\"claude-code\"} | tool_name != \"\" [$__range])))",
+          "legendFormat": "{{tool_name}}"
         }
       ]
     },

--- a/plugins/vsdd-factory/tools/observability/grafana-dashboards/factory-prs.json
+++ b/plugins/vsdd-factory/tools/observability/grafana-dashboards/factory-prs.json
@@ -53,7 +53,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "sum(count_over_time({service_name=\"vsdd-factory\",event_type=\"agent.start\"} | json | attributes_subagent = \"vsdd-factory:pr-manager\" [$__range]))"
+          "expr": "sum(count_over_time({service_name=\"vsdd-factory\",event_type=\"agent.start\"} | subagent = \"vsdd-factory:pr-manager\" [$__range]))"
         }
       ]
     },
@@ -212,7 +212,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "sum(count_over_time({service_name=\"vsdd-factory\",hook=\"pr-manager-completion-guard\",event_type=\"hook.block\"} [$__range])) / sum(count_over_time({service_name=\"vsdd-factory\",event_type=\"agent.start\"} | json | attributes_subagent = \"vsdd-factory:pr-manager\" [$__range]))"
+          "expr": "sum(count_over_time({service_name=\"vsdd-factory\",hook=\"pr-manager-completion-guard\",event_type=\"hook.block\"} [$__range])) / sum(count_over_time({service_name=\"vsdd-factory\",event_type=\"agent.start\"} | subagent = \"vsdd-factory:pr-manager\" [$__range]))"
         }
       ]
     },
@@ -246,7 +246,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "sum(count_over_time({service_name=\"vsdd-factory\",event_type=\"agent.start\"} | json | attributes_subagent = \"vsdd-factory:pr-manager\" [$__interval]))"
+          "expr": "sum(count_over_time({service_name=\"vsdd-factory\",event_type=\"agent.start\"} | subagent = \"vsdd-factory:pr-manager\" [$__interval]))"
         }
       ]
     },
@@ -260,7 +260,7 @@
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "palette-classic" },
-          "displayName": "stopped at step ${__field.labels.attributes_last_step}"
+          "displayName": "stopped at step ${__field.labels.last_step}"
         }
       },
       "options": {
@@ -275,8 +275,8 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "topk(10, sum by (attributes_last_step) (count_over_time({service_name=\"vsdd-factory\",hook=\"pr-manager-completion-guard\"} | json | attributes_last_step != \"\" [$__range])))",
-          "legendFormat": "step {{attributes_last_step}}"
+          "expr": "topk(10, sum by (last_step) (count_over_time({service_name=\"vsdd-factory\",hook=\"pr-manager-completion-guard\"} | last_step != \"\" [$__range])))",
+          "legendFormat": "step {{last_step}}"
         }
       ]
     },
@@ -332,7 +332,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "sum(sum_over_time({service_name=\"vsdd-factory\",event_type=\"pr.merged\"} | json | unwrap attributes_open_to_merge_seconds [$__range])) / sum(count_over_time({service_name=\"vsdd-factory\",event_type=\"pr.merged\"} | json | attributes_open_to_merge_seconds != \"\" [$__range]))"
+          "expr": "sum(sum_over_time({service_name=\"vsdd-factory\",event_type=\"pr.merged\"} | unwrap open_to_merge_seconds [$__range])) / sum(count_over_time({service_name=\"vsdd-factory\",event_type=\"pr.merged\"} | open_to_merge_seconds != \"\" [$__range]))"
         }
       ]
     },
@@ -362,7 +362,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "sum(count_over_time({service_name=\"vsdd-factory\",event_type=\"pr.merged\"} | json | attributes_open_to_merge_seconds != \"\" [$__range]))"
+          "expr": "sum(count_over_time({service_name=\"vsdd-factory\",event_type=\"pr.merged\"} | open_to_merge_seconds != \"\" [$__range]))"
         }
       ]
     }

--- a/plugins/vsdd-factory/tools/observability/grafana-dashboards/factory-roi.json
+++ b/plugins/vsdd-factory/tools/observability/grafana-dashboards/factory-roi.json
@@ -244,7 +244,7 @@
             "type": "loki",
             "uid": "loki"
           },
-          "expr": "count(count by (attributes_story_id) (count_over_time({service_name=\"vsdd-factory\",event_type=\"agent.start\"} | json | attributes_story_id != \"\" [$__range])))"
+          "expr": "count(count by (story_id) (count_over_time({service_name=\"vsdd-factory\",event_type=\"agent.start\"} | story_id != \"\" [$__range])))"
         }
       ]
     },
@@ -450,7 +450,7 @@
             "type": "loki",
             "uid": "loki"
           },
-          "expr": "count(count by (attributes_story_id) (count_over_time({service_name=\"vsdd-factory\",event_type=\"agent.start\"} | json | attributes_story_id != \"\" [$__range])))",
+          "expr": "count(count by (story_id) (count_over_time({service_name=\"vsdd-factory\",event_type=\"agent.start\"} | story_id != \"\" [$__range])))",
           "queryType": "instant",
           "hide": false
         },
@@ -706,7 +706,7 @@
           "color": {
             "mode": "palette-classic"
           },
-          "displayName": "${__field.labels.attributes_subagent}"
+          "displayName": "${__field.labels.subagent}"
         }
       },
       "options": {
@@ -727,8 +727,8 @@
             "type": "loki",
             "uid": "loki"
           },
-          "expr": "topk(10, sum by (attributes_subagent) (count_over_time({service_name=\"vsdd-factory\",event_type=\"agent.start\"} | json | attributes_subagent != \"\" [$__range])))",
-          "legendFormat": "{{attributes_subagent}}"
+          "expr": "topk(10, sum by (subagent) (count_over_time({service_name=\"vsdd-factory\",event_type=\"agent.start\"} | subagent != \"\" [$__range])))",
+          "legendFormat": "{{subagent}}"
         }
       ]
     },

--- a/plugins/vsdd-factory/tools/observability/grafana-dashboards/factory-subagents.json
+++ b/plugins/vsdd-factory/tools/observability/grafana-dashboards/factory-subagents.json
@@ -71,7 +71,7 @@
         {
           "refId": "A",
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "count(count by (attributes_subagent) (count_over_time({service_name=\"vsdd-factory\",event_type=\"agent.start\"} | json | attributes_subagent != \"\" [$__range])))"
+          "expr": "count(count by (subagent) (count_over_time({service_name=\"vsdd-factory\",event_type=\"agent.start\"} | subagent != \"\" [$__range])))"
         }
       ]
     },
@@ -99,7 +99,7 @@
         {
           "refId": "A",
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "sum(count_over_time({service_name=\"vsdd-factory\",event_type=\"agent.stop\"} | json | attributes_exit_class = \"ok\" [$__range]))"
+          "expr": "sum(count_over_time({service_name=\"vsdd-factory\",event_type=\"agent.stop\"} | exit_class = \"ok\" [$__range]))"
         }
       ]
     },
@@ -134,7 +134,7 @@
         {
           "refId": "A",
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "sum(count_over_time({service_name=\"vsdd-factory\",event_type=\"agent.stop\"} | json | attributes_exit_class != \"ok\" | attributes_exit_class != \"\" [$__range]))"
+          "expr": "sum(count_over_time({service_name=\"vsdd-factory\",event_type=\"agent.stop\"} | exit_class != \"ok\" | exit_class != \"\" [$__range]))"
         }
       ]
     },
@@ -148,7 +148,7 @@
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "palette-classic" },
-          "displayName": "${__field.labels.attributes_subagent}"
+          "displayName": "${__field.labels.subagent}"
         }
       },
       "options": {
@@ -160,8 +160,8 @@
         {
           "refId": "A",
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "topk(15, sum by (attributes_subagent) (count_over_time({service_name=\"vsdd-factory\",event_type=\"agent.start\"} | json | attributes_subagent != \"\" [$__range])))",
-          "legendFormat": "{{attributes_subagent}}"
+          "expr": "topk(15, sum by (subagent) (count_over_time({service_name=\"vsdd-factory\",event_type=\"agent.start\"} | subagent != \"\" [$__range])))",
+          "legendFormat": "{{subagent}}"
         }
       ]
     },
@@ -188,8 +188,8 @@
         {
           "refId": "A",
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "sum by (attributes_subagent, attributes_exit_class) (count_over_time({service_name=\"vsdd-factory\",event_type=\"agent.stop\"} | json | attributes_subagent != \"\" | attributes_exit_class != \"\" [$__range]))",
-          "legendFormat": "{{attributes_subagent}} — {{attributes_exit_class}}"
+          "expr": "sum by (subagent, exit_class) (count_over_time({service_name=\"vsdd-factory\",event_type=\"agent.stop\"} | subagent != \"\" | exit_class != \"\" [$__range]))",
+          "legendFormat": "{{subagent}} — {{exit_class}}"
         }
       ]
     },
@@ -218,8 +218,8 @@
         {
           "refId": "A",
           "datasource": { "type": "loki", "uid": "loki" },
-          "expr": "sum by (attributes_subagent) (count_over_time({service_name=\"vsdd-factory\",event_type=\"agent.start\"} | json | attributes_subagent != \"\" [$__interval]))",
-          "legendFormat": "{{attributes_subagent}}"
+          "expr": "sum by (subagent) (count_over_time({service_name=\"vsdd-factory\",event_type=\"agent.start\"} | subagent != \"\" [$__interval]))",
+          "legendFormat": "{{subagent}}"
         }
       ]
     },

--- a/plugins/vsdd-factory/tools/observability/grafana-dashboards/factory-today.json
+++ b/plugins/vsdd-factory/tools/observability/grafana-dashboards/factory-today.json
@@ -131,7 +131,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "sum(count_over_time({service_name=\"claude-code\"} | json | attributes_event_name = \"tool_result\" [$__range]))"
+          "expr": "sum(count_over_time({service_name=\"claude-code\"} | event_name = \"tool_result\" [$__range]))"
         }
       ]
     },
@@ -169,7 +169,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "count(count by (attributes_session_id) (count_over_time({service_name=\"claude-code\"} | json | attributes_session_id != \"\" [$__range])))"
+          "expr": "count(count by (session_id) (count_over_time({service_name=\"claude-code\"} | session_id != \"\" [$__range])))"
         }
       ]
     },
@@ -286,7 +286,7 @@
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "palette-classic" },
-          "displayName": "${__field.labels.attributes_tool_name}"
+          "displayName": "${__field.labels.tool_name}"
         }
       },
       "options": {
@@ -301,8 +301,8 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "topk(10, sum by (attributes_tool_name) (count_over_time({service_name=\"claude-code\"} | json | attributes_tool_name != \"\" [$__range])))",
-          "legendFormat": "{{attributes_tool_name}}"
+          "expr": "topk(10, sum by (tool_name) (count_over_time({service_name=\"claude-code\"} | tool_name != \"\" [$__range])))",
+          "legendFormat": "{{tool_name}}"
         }
       ]
     },
@@ -316,7 +316,7 @@
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "palette-classic" },
-          "displayName": "${__field.labels.attributes_story_id}"
+          "displayName": "${__field.labels.story_id}"
         }
       },
       "options": {
@@ -331,8 +331,8 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "topk(15, sum by (attributes_story_id) (count_over_time({service_name=\"vsdd-factory\",event_type=\"agent.start\"} | json | attributes_story_id != \"\" [$__range])))",
-          "legendFormat": "{{attributes_story_id}}"
+          "expr": "topk(15, sum by (story_id) (count_over_time({service_name=\"vsdd-factory\",event_type=\"agent.start\"} | story_id != \"\" [$__range])))",
+          "legendFormat": "{{story_id}}"
         }
       ]
     },


### PR DESCRIPTION
## Why

Five of the seven shipped Grafana dashboards filter and group Claude/factory
events with `| json | attributes_<field>`, but the shipped Loki config only
promotes a handful of factory attributes to stream labels and leaves every
other event field as structured metadata — the log *body* is a plain string,
not JSON, so `| json` extracts nothing and the `attributes_` names never
exist. Every affected panel returns zero series even when the underlying data
is present by the tens of thousands. This makes the Claude-side of the
observability story silently broken for anyone who brings the stack up. The
fix is the mechanical rewrite the issue prescribes, grounded against the
shipped config and event-emitter code.

## What changed

Rewrote every broken query across the five dashboards to the structured-metadata
pipe form and removed the no-op `| json` stage:

- `| json | attributes_<X> = "<v>"` → `| <X> = "<v>"`
- `| json | attributes_<X> != ""` → `| <X> != ""`
- `by (attributes_<X>)` → `by (<X>)`, and `{{attributes_<X>}}` / `${__field.labels.attributes_<X>}` → `{{<X>}}` / `${__field.labels.<X>}`
- `| json | unwrap attributes_open_to_merge_seconds` → `| unwrap open_to_merge_seconds`
- bare `| json [$__interval]` (used only to enable a `by (attributes_event_name)`) → dropped entirely; the group-by now reads the `event_name` metadata directly

Files touched (39 query/label occurrences, matching the issue count):
- `plugins/vsdd-factory/tools/observability/grafana-dashboards/claude-overview.json`
- `plugins/vsdd-factory/tools/observability/grafana-dashboards/factory-today.json`
- `plugins/vsdd-factory/tools/observability/grafana-dashboards/factory-prs.json`
- `plugins/vsdd-factory/tools/observability/grafana-dashboards/factory-roi.json`
- `plugins/vsdd-factory/tools/observability/grafana-dashboards/factory-subagents.json`

Also corrected one stale panel description in `claude-overview.json` ("Unique
sessions") that documented the old `| json … attributes_session_id` mechanism.
All other descriptions were left untouched. The diff is confined to `expr`,
`legendFormat`, `displayName`, and that one `description` — no structural JSON
changes.

## Test evidence

Ground-truth chain (no live Loki available in this environment, so every claim
is anchored to shipped files):

1. **Label promotion — only five attributes become stream labels.**
   `tools/observability/loki-config.yaml:66-76` (`limits_config.otlp_config.resource_attributes.attributes_config`, `action: index_label`) promotes exactly `service.name`, `event_type`, `hook`, `reason`, `severity`. Nothing else is indexed; `allow_structured_metadata: true` (line 64) means all other fields arrive as structured metadata.

2. **The Claude pipeline promotes nothing extra.**
   `tools/observability/otel-collector-config.yaml:197-200` — the `logs/claude` pipeline runs only `[batch, resource/claude]`; `resource/claude` (lines 126-130) sets `service.name` and nothing else. So `event_name`, `tool_name`, `session_id`, etc. reach Loki as structured metadata, never as JSON body and never as stream labels.

3. **Factory event fields are flat top-level JSON keys, emitted per-line.**
   `bin/emit-event:89-117` builds each event as a flat object of `key=value` pairs plus `ts`/`ts_epoch`/`schema_version`. The collector's filelog `move` operators (`otel-collector-config.yaml:56-74`) relocate only `type→event_type`, `hook`, `reason`, `severity` to promoted resource attributes; `subagent`, `story_id`, `exit_class`, `session_id`, etc. stay as metadata. Confirmed against the shipped test fixtures in `tests/factory-sla.bats:10-16` (`{"type":"agent.start","subagent":"pr-manager","session_id":"…","story_id":"…"}`) — flat keys, no `attributes_` prefix, no nested `attributes` object.

4. **LogQL semantics.** In LogQL, `| json` parses the log *line* as JSON and extracts label filters from it; against a plain-string body it yields nothing. Structured-metadata fields are queried with the label-filter pipe `| field = "value"`, are usable directly in `by (field)` aggregations, and in `| unwrap field` for metric extraction — which is exactly the corrected form. This matches the issue author's empirical three-syntax table, where only the `| field = "value"` metadata form returned data.

5. **JSON validity.** `jq empty <file>` exits 0 for all five modified dashboards.

6. **Zero regressions of the broken pattern.** After the change, `grep -c attributes_` across the five files = 0 (was 39 in query/label positions), and `grep '| json'` across the five files = 0.

**Live-stack verification (for the maintainer).** End-to-end confirmation needs a running stack plus an actively-emitting Claude session — which can't run here. To verify locally, from a project root containing `.factory/`:

```bash
"${CLAUDE_PLUGIN_ROOT}/bin/factory-obs" up      # brings up loki+grafana+prometheus+otel-collector via docker-compose
"${CLAUDE_PLUGIN_ROOT}/bin/factory-obs" dashboard
# open Claude Overview / Factory Today / PRs / ROI / Subagents — panels that were
# empty should now populate. Spot-check via the Loki API that the metadata form returns data:
curl -s "http://localhost:3100/loki/api/v1/query_range" --get \
  --data-urlencode 'query=sum by (event_name) (count_over_time({service_name="claude-code"}[5m]))' \
  --data-urlencode "start=$(($(date +%s)-300))000000000" --data-urlencode "end=$(date +%s)000000000" | jq '.data.result'
```

**Two honest caveats the maintainer should know:**

- **`last_step` and `open_to_merge_seconds` (factory-prs.json) have no emit site in this checkout.** I grepped the whole tree and inspected `hook-plugins/capture-pr-activity.wasm` (`strings`) — it emits `pr_url`, `pr_number`, `pr_repo`, `merge_strategy`, `title`, but not `open_to_merge_seconds` or `last_step`. Those two panels' *syntax* is now correct (they'll populate once the fields are emitted) but they won't show data until the emit side ships those keys. That is a separate defect from this LogQL-syntax bug; flagging rather than silently "fixing."
- There is **no test exercising Grafana panel `expr`** (`factory-dashboard.bats` covers the terminal renderer, not these panels) — nothing runs a panel query against live Loki, which is exactly why all three dashboard-vs-data-shape bugs (this, #244, #245) pass CI. Following review, this PR now adds the cheap static ratchet: `tests/grafana-dashboards.bats` asserts no `json | attributes_` body-parse stage and no `attributes_`-prefixed label reference survives in `grafana-dashboards/*.json` (verified red against develop, green here). The live-Loki harness remains the durable follow-up.

No factory-artifact implications — Class 0, touches only develop-tracked files.

Closes: #243

