### PR TITLE
fix(observability): include cacheCreation in cache-hit-ratio denominator

### DIFF
--- a/plugins/vsdd-factory/tools/observability/grafana-dashboards/claude-cost.json
+++ b/plugins/vsdd-factory/tools/observability/grafana-dashboards/claude-cost.json
@@ -182,7 +182,7 @@
     {
       "id": 5,
       "title": "Cache hit ratio",
-      "description": "cacheRead / (input + cacheRead). High is good — cache reads are much cheaper than fresh input. Low numbers suggest prompt caching isn't benefiting your workflow much (often fixable by restructuring prompts or system instructions).",
+      "description": "Share of input-side tokens served from cache: cacheRead / (input + cacheRead + cacheCreation). High is good — cache reads are much cheaper than fresh input. cacheCreation (cache-write) tokens are included in the denominator because they are billed at a premium and are not cache hits; omitting them inflates the ratio toward a false 100%. Low numbers suggest prompt caching isn't benefiting your workflow much (often fixable by restructuring prompts or system instructions).",
       "type": "gauge",
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "gridPos": { "h": 4, "w": 4, "x": 20, "y": 0 },
@@ -217,7 +217,7 @@
         {
           "refId": "A",
           "datasource": { "type": "prometheus", "uid": "prometheus" },
-          "expr": "sum(increase(claude_code_token_usage_tokens_total{type=\"cacheRead\"}[$__range])) / (sum(increase(claude_code_token_usage_tokens_total{type=\"input\"}[$__range])) + sum(increase(claude_code_token_usage_tokens_total{type=\"cacheRead\"}[$__range])))"
+          "expr": "sum(increase(claude_code_token_usage_tokens_total{type=\"cacheRead\"}[$__range])) / (sum(increase(claude_code_token_usage_tokens_total{type=\"input\"}[$__range])) + sum(increase(claude_code_token_usage_tokens_total{type=\"cacheRead\"}[$__range])) + sum(increase(claude_code_token_usage_tokens_total{type=\"cacheCreation\"}[$__range])))"
         }
       ]
     },


### PR DESCRIPTION
## Why

The "Cache hit ratio" panel in `claude-cost.json` computes
`cacheRead / (input + cacheRead)`, omitting `cacheCreation` — the cache-*write*
tokens billed at a premium and which are not cache hits. Any session that
writes new cache prefixes therefore reads as ~100% cache-hit even when a
substantial fraction of its input-side tokens are the expensive cache-creation
kind. Because operators make budget and prompt-structure decisions off this
gauge, a false 100% actively misleads. Adding `cacheCreation` to the
denominator makes the ratio mean "share of input-side tokens served from
cache," which is what the panel title implies.

## What changed

`plugins/vsdd-factory/tools/observability/grafana-dashboards/claude-cost.json`,
"Cache hit ratio" panel (single occurrence):

- `expr`: added `+ sum(increase(claude_code_token_usage_tokens_total{type="cacheCreation"}[$__range]))` to the denominator, giving `cacheRead / (input + cacheRead + cacheCreation)`.
- `description`: restated the formula and the explicit metric definition — **"share of input-side tokens served from cache"** — and noted why cacheCreation belongs in the denominator (premium-billed, not a hit; omitting it inflates toward a false 100%). Stating the definition explicitly so you can veto it if you intend something different.

I did **not** add the optional sibling "Cache write ratio" panel the issue
mentioned ("if desired") — kept the diff to the two lines that fix the actual
defect. Easy to add as a follow-up if you want it. Two-line change, no
structural JSON edits.

## Test evidence

1. **The metric type exists.** `cacheCreation` is one of the four
   `claude_code_token_usage_tokens_total{type=...}` buckets — the same
   dashboard's "Token usage by type" panel description (`claude-cost.json:303`)
   enumerates `input, output, cacheRead, cacheCreation`, and the issue's
   Prometheus query confirms all four are emitted. So the added term resolves.

2. **Executed arithmetic on the issue's realistic magnitudes:**
   ```
   $ python3 -c 'i=122; r=8126790; c=1000449
   print("dashboard:", r/(i+r)*100)
   print("correct:  ", r/(i+r+c)*100)'
   dashboard: 99.99849891906103
   correct:   89.03767474519744
   ```
   Broken formula displays **100%**; corrected displays **89%** — an ~11
   percentage-point overstatement, and the omitted ~11% is composed of the
   premium-billed cache-write tokens.

   *Ground-truth note:* the issue body states the correct value as `89.04108%`.
   My executed arithmetic on the stated inputs (input=122, cacheRead=8126790,
   cacheCreation=1000449) gives `89.03767%`. The two differ in the third
   decimal (the issue's figure corresponds to cacheCreation≈999950, not the
   1000449 it lists). Both round to 89% and the ~11-point skew is identical, so
   the fix and its impact are unchanged — flagging the arithmetic slip in the
   issue for the record rather than papering over it.

3. **JSON validity.** `jq empty claude-cost.json` exits 0.

4. **Live verification (for the maintainer).** With the stack up
   (`"${CLAUDE_PLUGIN_ROOT}/bin/factory-obs" up`), on any session where
   `cacheCreation > 0` the gauge should now render < 100%. Cross-check against
   Prometheus:
   ```bash
   for t in input cacheRead cacheCreation; do
     v=$(curl -s "http://localhost:9090/api/v1/query?query=sum(claude_code_token_usage_tokens_total{type=\"$t\"})" | jq -r '.data.result[0].value[1] // "0"')
     echo "$t: $v"
   done
   # ratio = cacheRead / (input + cacheRead + cacheCreation)
   ```
   The issue's acceptance criterion also asks for a math test asserting the
   formula; there is no dashboard-validation harness in the tree today, so this
   PR relies on the static + executed-arithmetic evidence above and leaves the
   test harness (shared with #243/#245) as a follow-up.

No factory-artifact implications — Class 0, touches only develop-tracked files.

Using `Refs` rather than `Closes`: the issue's math-test acceptance criterion is deferred to a follow-up, so the merge should not auto-close it.

Refs: #244

