### PR TITLE
fix(skills): create factory-artifacts orphan branch via plumbing — no checkout dance, signed commit

### DIFF
--- a/plugins/vsdd-factory/skills/factory-health/SKILL.md
+++ b/plugins/vsdd-factory/skills/factory-health/SKILL.md
@@ -17,12 +17,14 @@ Validate that the `.factory/` worktree is properly mounted and healthy. Auto-rep
 git branch --list factory-artifacts
 ```
 
-- **If missing**: Create it.
+- **If missing**: Create it. Build the empty root commit with plumbing and
+  point the branch ref at it directly — this never moves `HEAD`, never touches
+  the working tree, and signs the commit (`-S`). No checkout dance, so there is
+  no failed-return case that could strand the session on `factory-artifacts`.
   ```bash
-  git checkout --orphan factory-artifacts
-  git rm -rf --cached . 2>/dev/null || true
-  git commit --allow-empty -m "chore: initialize factory-artifacts orphan branch"
-  git checkout -  # return to previous branch
+  git branch factory-artifacts \
+    "$(git commit-tree -S "$(git mktree </dev/null)" \
+       -m "chore: initialize factory-artifacts orphan branch")"
   ```
 
 ### 2. Worktree is mounted

--- a/plugins/vsdd-factory/skills/factory-health/SKILL.md
+++ b/plugins/vsdd-factory/skills/factory-health/SKILL.md
@@ -18,13 +18,19 @@ git branch --list factory-artifacts
 ```
 
 - **If missing**: Create it. Build the empty root commit with plumbing and
-  point the branch ref at it directly — this never moves `HEAD`, never touches
-  the working tree, and signs the commit (`-S`). No checkout dance, so there is
-  no failed-return case that could strand the session on `factory-artifacts`.
+  point the branch ref at it directly — this never moves `HEAD` and never
+  touches the working tree. No checkout dance, so there is no failed-return
+  case that could strand the session on `factory-artifacts`. The init marker
+  commit is deliberately unsigned: `git commit-tree` does not honor
+  `commit.gpgsign`, and a hard `-S` would fail outright in environments with
+  no signing key configured (fresh CI runners, agent containers, plugin
+  consumers). Real content commits on the branch are signed later by
+  state-manager under the repo's normal commit config.
   ```bash
-  git branch factory-artifacts \
-    "$(git commit-tree -S "$(git mktree </dev/null)" \
-       -m "chore: initialize factory-artifacts orphan branch")"
+  commit=$(git commit-tree "$(git mktree </dev/null)" \
+    -m "chore: initialize factory-artifacts orphan branch") \
+    || { echo "failed to create factory-artifacts init commit" >&2; exit 1; }
+  git branch factory-artifacts "$commit"
   ```
 
 ### 2. Worktree is mounted

--- a/plugins/vsdd-factory/skills/factory-worktree-health/SKILL.md
+++ b/plugins/vsdd-factory/skills/factory-worktree-health/SKILL.md
@@ -81,13 +81,16 @@ git ls-remote --heads origin ${BRANCH_NAME}
 ```
 
 - **Branch exists:** Proceed to Step 2
-- **Branch does NOT exist:** Create it:
+- **Branch does NOT exist:** Create it. Build the empty root commit with
+  plumbing and point the branch ref at it directly, then push. `HEAD` never
+  moves and the working tree is never disturbed — so there is no `git checkout`
+  step whose failure could strand the session on `${BRANCH_NAME}` (nor any
+  hardcoded return target to guess wrong). The commit is signed (`-S`).
   ```bash
-  git checkout --orphan ${BRANCH_NAME}
-  git rm -rf .
-  git commit --allow-empty -m "chore: initialize ${BRANCH_NAME} branch"
+  git branch ${BRANCH_NAME} \
+    "$(git commit-tree -S "$(git mktree </dev/null)" \
+       -m "chore: initialize ${BRANCH_NAME} branch")"
   git push origin ${BRANCH_NAME}
-  git checkout develop
   ```
   Then proceed to Step 2.
 

--- a/plugins/vsdd-factory/skills/factory-worktree-health/SKILL.md
+++ b/plugins/vsdd-factory/skills/factory-worktree-health/SKILL.md
@@ -85,12 +85,21 @@ git ls-remote --heads origin ${BRANCH_NAME}
   plumbing and point the branch ref at it directly, then push. `HEAD` never
   moves and the working tree is never disturbed — so there is no `git checkout`
   step whose failure could strand the session on `${BRANCH_NAME}` (nor any
-  hardcoded return target to guess wrong). The commit is signed (`-S`).
+  hardcoded return target to guess wrong). The local-existence guard covers
+  the re-run case where the branch already exists locally but was never
+  pushed — the Step 1 check above is remote-only. The init marker commit is
+  deliberately unsigned: `git commit-tree` does not honor `commit.gpgsign`,
+  and a hard `-S` would fail outright in environments with no signing key
+  configured; content commits are signed later by state-manager under the
+  repo's normal commit config.
   ```bash
-  git branch ${BRANCH_NAME} \
-    "$(git commit-tree -S "$(git mktree </dev/null)" \
-       -m "chore: initialize ${BRANCH_NAME} branch")"
-  git push origin ${BRANCH_NAME}
+  if ! git show-ref --verify --quiet "refs/heads/${BRANCH_NAME}"; then
+    commit=$(git commit-tree "$(git mktree </dev/null)" \
+      -m "chore: initialize ${BRANCH_NAME} branch") \
+      || { echo "failed to create ${BRANCH_NAME} init commit" >&2; exit 1; }
+    git branch "${BRANCH_NAME}" "$commit"
+  fi
+  git push origin "${BRANCH_NAME}"
   ```
   Then proceed to Step 2.
 

--- a/plugins/vsdd-factory/tests/orphan-branch-plumbing.bats
+++ b/plugins/vsdd-factory/tests/orphan-branch-plumbing.bats
@@ -1,0 +1,290 @@
+#!/usr/bin/env bats
+# orphan-branch-plumbing.bats — behavioral + contract tests for issue #204:
+# the factory-artifacts orphan branch must be created with plumbing
+# (git commit-tree + git mktree + git branch), never with a checkout dance.
+#
+# THE BUG (#204): both factory-health and factory-worktree-health created the
+# orphan branch by switching HEAD onto it (git checkout --orphan), clearing the
+# index, committing, then switching back (git checkout - / git checkout develop).
+# The return step is unchecked. When it fails — e.g. `git checkout -` cannot
+# resolve the previous ref, or the working-tree files that became untracked
+# under the orphan would be overwritten — HEAD is silently STRANDED on
+# factory-artifacts and subsequent pipeline work commits to the wrong branch.
+# The commits were also unsigned.
+#
+# THE FIX (issue's Option B, plumbing-only):
+#   git branch <name> "$(git commit-tree -S "$(git mktree </dev/null)" -m "...")"
+# HEAD never moves, the working tree is never touched, the commit is signed.
+#
+# TEST STRATEGY
+#   - Behavioral (GREEN): run the new recipe in a scratch repo with tracked +
+#     untracked files and assert the invariants: current branch unchanged,
+#     factory-artifacts resolves, it is a parentless (orphan) empty-tree commit,
+#     and `git status --porcelain` is byte-identical before and after.
+#   - Behavioral (RED): run each OLD recipe in the same scratch fixture and
+#     assert it CAN strand HEAD on factory-artifacts — this is the defect the
+#     fix removes. These tests PASS by demonstrating the old behavior is broken.
+#   - Signing: run the recipe verbatim WITH -S under an ephemeral SSH signing
+#     key and assert the commit verifies. Skipped if SSH commit signing is
+#     unavailable in the environment (ssh-keygen missing or git too old).
+#   - Contract: the shipped SKILL.md files contain the plumbing recipe and no
+#     longer contain the fragile checkout-dance in the branch-creation block.
+#
+#   The behavioral tests strip -S from the recipe so they run on any host with
+#   no signing key configured (as CI runs). The -S delta is covered separately
+#   by the gated signing test and by the contract test that asserts -S is
+#   present in the shipped recipe text.
+#
+# Run:
+#   bats plugins/vsdd-factory/tests/orphan-branch-plumbing.bats
+
+setup() {
+  PLUGIN_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  FACTORY_HEALTH="$PLUGIN_ROOT/skills/factory-health/SKILL.md"
+  WORKTREE_HEALTH="$PLUGIN_ROOT/skills/factory-worktree-health/SKILL.md"
+
+  WORK="$(mktemp -d)"
+  # Resolve symlinks (macOS /var -> /private/var) for stable path comparisons.
+  WORK="$(cd "$WORK" && pwd -P)"
+}
+
+teardown() {
+  rm -rf "$WORK"
+}
+
+# ---------------------------------------------------------------------------
+# Build a scratch repo on branch `develop` with one seed commit, a tracked
+# file, and an untracked file. Commit signing is DISABLED so the fixture is
+# CI-portable (no key required). Sets REPO and STARTING_BRANCH.
+# ---------------------------------------------------------------------------
+_setup_repo() {
+  REPO="$WORK/repo"
+  git init -q -b develop "$REPO"
+  git -C "$REPO" config user.email "test@orphan-plumbing.test"
+  git -C "$REPO" config user.name "Orphan Plumbing Test"
+  git -C "$REPO" config commit.gpgsign false
+
+  mkdir -p "$REPO/src"
+  echo "fn main() {}" > "$REPO/src/main.rs"
+  echo "# project"     > "$REPO/README.md"
+  git -C "$REPO" add -A
+  git -C "$REPO" commit -q -m "seed develop with tracked files"
+
+  # An untracked file present at recipe time — the class of working-tree state
+  # that the old checkout-dance could clobber or refuse to restore over.
+  echo "scratch notes" > "$REPO/untracked.txt"
+
+  STARTING_BRANCH="$(git -C "$REPO" branch --show-current)"
+}
+
+# The empty tree object hash is a git constant.
+EMPTY_TREE="4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+
+# ===========================================================================
+# BEHAVIORAL — GREEN: the plumbing recipe holds every invariant
+# ===========================================================================
+
+@test "new recipe: HEAD/current branch unchanged after creation" {
+  _setup_repo
+  local before_head before_branch
+  before_head="$(git -C "$REPO" rev-parse HEAD)"
+  before_branch="$(git -C "$REPO" branch --show-current)"
+
+  # New recipe (issue #204 Option B), -S stripped for CI portability.
+  git -C "$REPO" branch factory-artifacts \
+    "$(git -C "$REPO" commit-tree "$(git -C "$REPO" mktree </dev/null)" \
+       -m "chore: initialize factory-artifacts orphan branch")"
+
+  [ "$(git -C "$REPO" rev-parse HEAD)" = "$before_head" ]
+  [ "$(git -C "$REPO" branch --show-current)" = "$before_branch" ]
+  [ "$(git -C "$REPO" branch --show-current)" = "develop" ]
+}
+
+@test "new recipe: factory-artifacts ref resolves to a commit" {
+  _setup_repo
+  git -C "$REPO" branch factory-artifacts \
+    "$(git -C "$REPO" commit-tree "$(git -C "$REPO" mktree </dev/null)" \
+       -m "chore: initialize factory-artifacts orphan branch")"
+
+  run git -C "$REPO" rev-parse --verify --quiet factory-artifacts
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
+}
+
+@test "new recipe: factory-artifacts is a parentless (orphan) empty-tree commit" {
+  _setup_repo
+  git -C "$REPO" branch factory-artifacts \
+    "$(git -C "$REPO" commit-tree "$(git -C "$REPO" mktree </dev/null)" \
+       -m "chore: initialize factory-artifacts orphan branch")"
+
+  # Orphan: `git rev-list --parents -n1` prints only the commit SHA (1 token)
+  # when there are no parents; a parent would add a second token.
+  local parents
+  parents="$(git -C "$REPO" rev-list --parents -n 1 factory-artifacts)"
+  [ "$(printf '%s' "$parents" | wc -w | tr -d ' ')" -eq 1 ]
+
+  # Empty content: the branch's tree is the canonical empty tree.
+  [ "$(git -C "$REPO" rev-parse 'factory-artifacts^{tree}')" = "$EMPTY_TREE" ]
+}
+
+@test "new recipe: working tree is byte-for-byte untouched" {
+  _setup_repo
+  local before after
+  before="$(git -C "$REPO" status --porcelain)"
+  local before_main before_readme before_untracked
+  before_main="$(cat "$REPO/src/main.rs")"
+  before_readme="$(cat "$REPO/README.md")"
+  before_untracked="$(cat "$REPO/untracked.txt")"
+
+  git -C "$REPO" branch factory-artifacts \
+    "$(git -C "$REPO" commit-tree "$(git -C "$REPO" mktree </dev/null)" \
+       -m "chore: initialize factory-artifacts orphan branch")"
+
+  after="$(git -C "$REPO" status --porcelain)"
+  # Same working-tree/index state as before (the one untracked file, nothing else).
+  [ "$before" = "$after" ]
+  # Tracked files intact.
+  [ "$(cat "$REPO/src/main.rs")" = "$before_main" ]
+  [ "$(cat "$REPO/README.md")" = "$before_readme" ]
+  # Untracked file intact (the old `git rm -rf .` variant would have deleted it).
+  [ "$(cat "$REPO/untracked.txt")" = "$before_untracked" ]
+}
+
+# ===========================================================================
+# BEHAVIORAL — RED: the OLD recipes CAN strand HEAD. These tests document the
+# defect the fix removes; they PASS by proving the old behavior is broken.
+# ===========================================================================
+
+@test "old factory-health recipe strands HEAD (git checkout - cannot resolve)" {
+  _setup_repo
+  # Reproduce the pre-fix factory-health recipe verbatim (SKILL.md:22-25).
+  # `git checkout -` resolves the previous branch from the reflog's @{-1};
+  # after `git checkout --orphan` there is no such entry to return to, so the
+  # return fails and HEAD is left on factory-artifacts.
+  git -C "$REPO" checkout -q --orphan factory-artifacts
+  git -C "$REPO" rm -rf --cached . >/dev/null 2>&1 || true
+  git -C "$REPO" commit -q --allow-empty \
+    -m "chore: initialize factory-artifacts orphan branch"
+  run git -C "$REPO" checkout -    # unchecked return — the defect
+  # The return failed...
+  [ "$status" -ne 0 ]
+  # ...and HEAD is STRANDED on factory-artifacts, not back on develop.
+  [ "$(git -C "$REPO" branch --show-current)" = "factory-artifacts" ]
+  [ "$(git -C "$REPO" branch --show-current)" != "$STARTING_BRANCH" ]
+}
+
+@test "old factory-worktree-health recipe destroys untracked working-tree files" {
+  _setup_repo
+  # Reproduce the pre-fix factory-worktree-health recipe (SKILL.md:86-90),
+  # minus the network push. `git rm -rf .` (no --cached) deletes the working
+  # copy of every tracked path from disk on the orphan branch. The hardcoded
+  # `git checkout develop` restores the tracked files, but any work that ran
+  # against the working tree between the two checkouts saw them gone — and an
+  # untracked file is simply lost to the rm.
+  [ -f "$REPO/src/main.rs" ]
+  git -C "$REPO" checkout -q --orphan factory-artifacts
+  git -C "$REPO" rm -rf . >/dev/null 2>&1 || true
+  # Tracked files are gone from disk at this point (mid-recipe window).
+  [ ! -f "$REPO/src/main.rs" ]
+  [ ! -f "$REPO/README.md" ]
+}
+
+@test "old factory-worktree-health recipe: hardcoded return lands on develop, not the actual start branch" {
+  _setup_repo
+  # Start on a FEATURE branch, not develop. The old recipe's hardcoded
+  # `git checkout develop` silently moves the session to develop regardless of
+  # where it began — a wrong-branch return even when it doesn't outright fail.
+  git -C "$REPO" checkout -q -b feature/my-work
+  local start="feature/my-work"
+  [ "$(git -C "$REPO" branch --show-current)" = "$start" ]
+
+  git -C "$REPO" checkout -q --orphan factory-artifacts
+  git -C "$REPO" rm -rf . >/dev/null 2>&1 || true
+  git -C "$REPO" commit -q --allow-empty -m "chore: initialize factory-artifacts branch"
+  git -C "$REPO" checkout -q develop   # hardcoded return target
+
+  [ "$(git -C "$REPO" branch --show-current)" = "develop" ]
+  [ "$(git -C "$REPO" branch --show-current)" != "$start" ]
+}
+
+@test "new recipe does NOT strand: same fixture, HEAD stays put" {
+  _setup_repo
+  # Contrast to the RED cases above: identical starting fixture, new recipe,
+  # HEAD is exactly where it started.
+  local before_branch
+  before_branch="$(git -C "$REPO" branch --show-current)"
+  git -C "$REPO" branch factory-artifacts \
+    "$(git -C "$REPO" commit-tree "$(git -C "$REPO" mktree </dev/null)" \
+       -m "chore: initialize factory-artifacts orphan branch")"
+  [ "$(git -C "$REPO" branch --show-current)" = "$before_branch" ]
+}
+
+# ===========================================================================
+# SIGNING — verbatim recipe with -S, gated on SSH-signing availability
+# ===========================================================================
+
+@test "new recipe with -S produces a verifiable signature" {
+  command -v ssh-keygen >/dev/null 2>&1 || skip "ssh-keygen not available"
+
+  _setup_repo
+  local key="$WORK/sign_key"
+  # Generate an ephemeral SSH key for signing (no passphrase).
+  ssh-keygen -q -t ed25519 -f "$key" -N "" -C "orphan-plumbing-test" \
+    </dev/null >/dev/null 2>&1 || skip "ssh-keygen failed"
+
+  git -C "$REPO" config gpg.format ssh
+  git -C "$REPO" config user.signingkey "$key.pub"
+
+  # Run the recipe VERBATIM, including -S, as shipped in SKILL.md.
+  run git -C "$REPO" branch factory-artifacts \
+    "$(git -C "$REPO" commit-tree -S "$(git -C "$REPO" mktree </dev/null)" \
+       -m "chore: initialize factory-artifacts orphan branch")"
+  # If this git build lacks SSH signing support, skip rather than fail.
+  if [ "$status" -ne 0 ]; then
+    skip "SSH commit signing unavailable in this git build"
+  fi
+
+  # An allowed-signers file lets verify-commit confirm the signature.
+  local signers="$WORK/allowed_signers"
+  echo "orphan-plumbing-test $(cat "$key.pub")" > "$signers"
+  git -C "$REPO" config gpg.ssh.allowedSignersFile "$signers"
+
+  run git -C "$REPO" verify-commit factory-artifacts
+  [ "$status" -eq 0 ]
+  # HEAD still didn't move even with signing on.
+  [ "$(git -C "$REPO" branch --show-current)" = "develop" ]
+}
+
+# ===========================================================================
+# CONTRACT — the shipped SKILL.md files carry the fix, not the fragile recipe
+# ===========================================================================
+
+@test "factory-health SKILL.md uses the plumbing recipe" {
+  grep -qF "git commit-tree -S" "$FACTORY_HEALTH"
+  grep -qF "git mktree </dev/null" "$FACTORY_HEALTH"
+  grep -qF "git branch factory-artifacts" "$FACTORY_HEALTH"
+}
+
+@test "factory-health SKILL.md no longer contains the checkout dance in branch creation" {
+  # The fragile primitives must be gone from the file.
+  run grep -F "git checkout --orphan factory-artifacts" "$FACTORY_HEALTH"
+  [ "$status" -ne 0 ]
+  run grep -F "git checkout -  # return to previous branch" "$FACTORY_HEALTH"
+  [ "$status" -ne 0 ]
+}
+
+@test "factory-worktree-health SKILL.md uses the plumbing recipe" {
+  grep -qF 'git commit-tree -S' "$WORKTREE_HEALTH"
+  grep -qF 'git mktree </dev/null' "$WORKTREE_HEALTH"
+  grep -qF 'git branch ${BRANCH_NAME}' "$WORKTREE_HEALTH"
+  # The remote branch still gets pushed.
+  grep -qF 'git push origin ${BRANCH_NAME}' "$WORKTREE_HEALTH"
+}
+
+@test "factory-worktree-health SKILL.md no longer contains the checkout dance in branch creation" {
+  run grep -F 'git checkout --orphan ${BRANCH_NAME}' "$WORKTREE_HEALTH"
+  [ "$status" -ne 0 ]
+  # The hardcoded return target is gone.
+  run grep -nF 'git checkout develop' "$WORKTREE_HEALTH"
+  [ "$status" -ne 0 ]
+}

--- a/plugins/vsdd-factory/tests/orphan-branch-plumbing.bats
+++ b/plugins/vsdd-factory/tests/orphan-branch-plumbing.bats
@@ -10,30 +10,38 @@
 # resolve the previous ref, or the working-tree files that became untracked
 # under the orphan would be overwritten — HEAD is silently STRANDED on
 # factory-artifacts and subsequent pipeline work commits to the wrong branch.
-# The commits were also unsigned.
 #
 # THE FIX (issue's Option B, plumbing-only):
-#   git branch <name> "$(git commit-tree -S "$(git mktree </dev/null)" -m "...")"
-# HEAD never moves, the working tree is never touched, the commit is signed.
+#   commit=$(git commit-tree "$(git mktree </dev/null)" -m "...") || { ...; exit 1; }
+#   git branch <name> "$commit"
+# HEAD never moves and the working tree is never touched. The init marker
+# commit is deliberately UNSIGNED: `git commit-tree` does not honor
+# `commit.gpgsign`, so a hard -S would turn the auto-repair path into a hard
+# failure on any host without a signing key (fresh CI runner, agent container,
+# downstream plugin consumer). Content commits are signed later by
+# state-manager under the repo's normal commit config.
 #
 # TEST STRATEGY
-#   - Behavioral (GREEN): run the new recipe in a scratch repo with tracked +
-#     untracked files and assert the invariants: current branch unchanged,
-#     factory-artifacts resolves, it is a parentless (orphan) empty-tree commit,
-#     and `git status --porcelain` is byte-identical before and after.
+#   - The behavioral tests EXTRACT the fenced ```bash recipe from the shipped
+#     SKILL.md files and execute that exact text — a typo introduced into
+#     either SKILL.md fails the behavioral tests, not just a substring check.
+#   - Behavioral (GREEN): run the extracted recipe in a scratch repo with
+#     tracked + untracked files and assert the invariants: current branch
+#     unchanged, factory-artifacts resolves, it is a parentless (orphan)
+#     empty-tree commit, and `git status --porcelain` is byte-identical
+#     before and after.
 #   - Behavioral (RED): run each OLD recipe in the same scratch fixture and
 #     assert it CAN strand HEAD on factory-artifacts — this is the defect the
 #     fix removes. These tests PASS by demonstrating the old behavior is broken.
-#   - Signing: run the recipe verbatim WITH -S under an ephemeral SSH signing
-#     key and assert the commit verifies. Skipped if SSH commit signing is
-#     unavailable in the environment (ssh-keygen missing or git too old).
-#   - Contract: the shipped SKILL.md files contain the plumbing recipe and no
-#     longer contain the fragile checkout-dance in the branch-creation block.
-#
-#   The behavioral tests strip -S from the recipe so they run on any host with
-#   no signing key configured (as CI runs). The -S delta is covered separately
-#   by the gated signing test and by the contract test that asserts -S is
-#   present in the shipped recipe text.
+#   - Keyless environment: run the extracted recipe with global/system git
+#     config masked (no signing key reachable) and assert the branch is still
+#     created, unsigned — the repair path must not require a key.
+#   - Error path: run the extracted recipe in a repo where commit-tree cannot
+#     succeed (no committer identity) and assert it fails cleanly with the
+#     recipe's own message and creates NO branch (no `git branch <name> ""`).
+#   - Contract: the shipped SKILL.md files contain the plumbing recipe (no -S),
+#     the worktree variant carries the local-existence guard and quoted
+#     ${BRANCH_NAME}, and neither file retains the fragile checkout dance.
 #
 # Run:
 #   bats plugins/vsdd-factory/tests/orphan-branch-plumbing.bats
@@ -50,6 +58,40 @@ setup() {
 
 teardown() {
   rm -rf "$WORK"
+}
+
+# ---------------------------------------------------------------------------
+# Extract the branch-creation recipe from a SKILL.md: the first fenced ```bash
+# block that contains `commit-tree`, with the bullet's 2-space indent stripped.
+# Binding the behavioral tests to this extracted text means the tests exercise
+# the exact recipe the plugin ships.
+# ---------------------------------------------------------------------------
+_extract_recipe() {
+  local file="$1"
+  awk '
+    /^[[:space:]]*```/ {
+      if (inblock) {
+        if (buf ~ /commit-tree/) { printf "%s", buf; exit }
+        inblock = 0; buf = ""
+      } else {
+        inblock = 1
+      }
+      next
+    }
+    inblock { line = $0; sub(/^  /, "", line); buf = buf line "\n" }
+  ' "$file"
+}
+
+# Run an extracted recipe inside a repo (subshell; recipe `exit 1` is contained).
+_run_recipe() {
+  local repo="$1" recipe="$2"
+  ( cd "$repo" && eval "$recipe" )
+}
+
+# Same, with BRANCH_NAME bound (factory-worktree-health parameterizes on it).
+_run_recipe_named() {
+  local repo="$1" recipe="$2" name="$3"
+  ( cd "$repo" && BRANCH_NAME="$name" && eval "$recipe" )
 }
 
 # ---------------------------------------------------------------------------
@@ -77,45 +119,67 @@ _setup_repo() {
   STARTING_BRANCH="$(git -C "$REPO" branch --show-current)"
 }
 
+# Bare origin for the factory-worktree-health recipe's push step.
+_setup_remote() {
+  ORIGIN="$WORK/origin.git"
+  git init -q --bare "$ORIGIN"
+  git -C "$REPO" remote add origin "$ORIGIN"
+}
+
 # The empty tree object hash is a git constant.
 EMPTY_TREE="4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 
 # ===========================================================================
-# BEHAVIORAL — GREEN: the plumbing recipe holds every invariant
+# EXTRACTION SANITY — the recipes are actually present to extract
 # ===========================================================================
 
-@test "new recipe: HEAD/current branch unchanged after creation" {
+@test "factory-health SKILL.md yields an extractable branch-creation recipe" {
+  recipe="$(_extract_recipe "$FACTORY_HEALTH")"
+  [ -n "$recipe" ]
+  [[ "$recipe" == *"commit-tree"* ]]
+  [[ "$recipe" == *"git branch factory-artifacts"* ]]
+}
+
+@test "factory-worktree-health SKILL.md yields an extractable branch-creation recipe" {
+  recipe="$(_extract_recipe "$WORKTREE_HEALTH")"
+  [ -n "$recipe" ]
+  [[ "$recipe" == *"commit-tree"* ]]
+  [[ "$recipe" == *'git push origin "${BRANCH_NAME}"'* ]]
+}
+
+# ===========================================================================
+# BEHAVIORAL — GREEN: the SHIPPED recipe holds every invariant
+# ===========================================================================
+
+@test "shipped recipe: HEAD/current branch unchanged after creation" {
   _setup_repo
-  local before_head before_branch
+  local before_head before_branch recipe
   before_head="$(git -C "$REPO" rev-parse HEAD)"
   before_branch="$(git -C "$REPO" branch --show-current)"
+  recipe="$(_extract_recipe "$FACTORY_HEALTH")"
 
-  # New recipe (issue #204 Option B), -S stripped for CI portability.
-  git -C "$REPO" branch factory-artifacts \
-    "$(git -C "$REPO" commit-tree "$(git -C "$REPO" mktree </dev/null)" \
-       -m "chore: initialize factory-artifacts orphan branch")"
+  run _run_recipe "$REPO" "$recipe"
+  [ "$status" -eq 0 ]
 
   [ "$(git -C "$REPO" rev-parse HEAD)" = "$before_head" ]
   [ "$(git -C "$REPO" branch --show-current)" = "$before_branch" ]
   [ "$(git -C "$REPO" branch --show-current)" = "develop" ]
 }
 
-@test "new recipe: factory-artifacts ref resolves to a commit" {
+@test "shipped recipe: factory-artifacts ref resolves to a commit" {
   _setup_repo
-  git -C "$REPO" branch factory-artifacts \
-    "$(git -C "$REPO" commit-tree "$(git -C "$REPO" mktree </dev/null)" \
-       -m "chore: initialize factory-artifacts orphan branch")"
+  run _run_recipe "$REPO" "$(_extract_recipe "$FACTORY_HEALTH")"
+  [ "$status" -eq 0 ]
 
   run git -C "$REPO" rev-parse --verify --quiet factory-artifacts
   [ "$status" -eq 0 ]
   [ -n "$output" ]
 }
 
-@test "new recipe: factory-artifacts is a parentless (orphan) empty-tree commit" {
+@test "shipped recipe: factory-artifacts is a parentless (orphan) empty-tree commit" {
   _setup_repo
-  git -C "$REPO" branch factory-artifacts \
-    "$(git -C "$REPO" commit-tree "$(git -C "$REPO" mktree </dev/null)" \
-       -m "chore: initialize factory-artifacts orphan branch")"
+  run _run_recipe "$REPO" "$(_extract_recipe "$FACTORY_HEALTH")"
+  [ "$status" -eq 0 ]
 
   # Orphan: `git rev-list --parents -n1` prints only the commit SHA (1 token)
   # when there are no parents; a parent would add a second token.
@@ -127,7 +191,7 @@ EMPTY_TREE="4b825dc642cb6eb9a060e54bf8d69288fbee4904"
   [ "$(git -C "$REPO" rev-parse 'factory-artifacts^{tree}')" = "$EMPTY_TREE" ]
 }
 
-@test "new recipe: working tree is byte-for-byte untouched" {
+@test "shipped recipe: working tree is byte-for-byte untouched" {
   _setup_repo
   local before after
   before="$(git -C "$REPO" status --porcelain)"
@@ -136,9 +200,8 @@ EMPTY_TREE="4b825dc642cb6eb9a060e54bf8d69288fbee4904"
   before_readme="$(cat "$REPO/README.md")"
   before_untracked="$(cat "$REPO/untracked.txt")"
 
-  git -C "$REPO" branch factory-artifacts \
-    "$(git -C "$REPO" commit-tree "$(git -C "$REPO" mktree </dev/null)" \
-       -m "chore: initialize factory-artifacts orphan branch")"
+  run _run_recipe "$REPO" "$(_extract_recipe "$FACTORY_HEALTH")"
+  [ "$status" -eq 0 ]
 
   after="$(git -C "$REPO" status --porcelain)"
   # Same working-tree/index state as before (the one untracked file, nothing else).
@@ -148,6 +211,50 @@ EMPTY_TREE="4b825dc642cb6eb9a060e54bf8d69288fbee4904"
   [ "$(cat "$REPO/README.md")" = "$before_readme" ]
   # Untracked file intact (the old `git rm -rf .` variant would have deleted it).
   [ "$(cat "$REPO/untracked.txt")" = "$before_untracked" ]
+}
+
+@test "shipped worktree-health recipe: creates the branch locally and pushes it" {
+  _setup_repo
+  _setup_remote
+  local before_branch recipe
+  before_branch="$(git -C "$REPO" branch --show-current)"
+  recipe="$(_extract_recipe "$WORKTREE_HEALTH")"
+
+  run _run_recipe_named "$REPO" "$recipe" "factory-artifacts"
+  [ "$status" -eq 0 ]
+
+  # Local branch created; HEAD untouched.
+  run git -C "$REPO" rev-parse --verify --quiet factory-artifacts
+  [ "$status" -eq 0 ]
+  [ "$(git -C "$REPO" branch --show-current)" = "$before_branch" ]
+  # Pushed: the bare origin now has the ref.
+  run git -C "$ORIGIN" show-ref --verify --quiet refs/heads/factory-artifacts
+  [ "$status" -eq 0 ]
+}
+
+@test "shipped worktree-health recipe: re-run with existing local branch succeeds (local-existence guard)" {
+  _setup_repo
+  _setup_remote
+  local recipe
+  recipe="$(_extract_recipe "$WORKTREE_HEALTH")"
+
+  # First run creates local + remote. Simulate the review's re-run case by
+  # deleting only the REMOTE ref (Step 1's ls-remote check is remote-only,
+  # so the skill re-enters this recipe while the local branch still exists).
+  run _run_recipe_named "$REPO" "$recipe" "factory-artifacts"
+  [ "$status" -eq 0 ]
+  git -C "$ORIGIN" update-ref -d refs/heads/factory-artifacts
+  local existing
+  existing="$(git -C "$REPO" rev-parse factory-artifacts)"
+
+  # Re-run: without the guard this died with "branch already exists".
+  run _run_recipe_named "$REPO" "$recipe" "factory-artifacts"
+  [ "$status" -eq 0 ]
+  # The existing local branch was reused, not recreated...
+  [ "$(git -C "$REPO" rev-parse factory-artifacts)" = "$existing" ]
+  # ...and the push restored the remote ref.
+  run git -C "$ORIGIN" show-ref --verify --quiet refs/heads/factory-artifacts
+  [ "$status" -eq 0 ]
 }
 
 # ===========================================================================
@@ -207,62 +314,73 @@ EMPTY_TREE="4b825dc642cb6eb9a060e54bf8d69288fbee4904"
   [ "$(git -C "$REPO" branch --show-current)" != "$start" ]
 }
 
-@test "new recipe does NOT strand: same fixture, HEAD stays put" {
+@test "shipped recipe does NOT strand: same fixture, HEAD stays put" {
   _setup_repo
-  # Contrast to the RED cases above: identical starting fixture, new recipe,
-  # HEAD is exactly where it started.
+  # Contrast to the RED cases above: identical starting fixture, shipped
+  # recipe, HEAD is exactly where it started.
   local before_branch
   before_branch="$(git -C "$REPO" branch --show-current)"
-  git -C "$REPO" branch factory-artifacts \
-    "$(git -C "$REPO" commit-tree "$(git -C "$REPO" mktree </dev/null)" \
-       -m "chore: initialize factory-artifacts orphan branch")"
+  run _run_recipe "$REPO" "$(_extract_recipe "$FACTORY_HEALTH")"
+  [ "$status" -eq 0 ]
   [ "$(git -C "$REPO" branch --show-current)" = "$before_branch" ]
 }
 
 # ===========================================================================
-# SIGNING — verbatim recipe with -S, gated on SSH-signing availability
+# ENVIRONMENT NEUTRALITY — the repair path must not require a signing key
 # ===========================================================================
 
-@test "new recipe with -S produces a verifiable signature" {
-  command -v ssh-keygen >/dev/null 2>&1 || skip "ssh-keygen not available"
-
+@test "shipped recipe succeeds in a keyless environment (no signing config reachable)" {
   _setup_repo
-  local key="$WORK/sign_key"
-  # Generate an ephemeral SSH key for signing (no passphrase).
-  ssh-keygen -q -t ed25519 -f "$key" -N "" -C "orphan-plumbing-test" \
-    </dev/null >/dev/null 2>&1 || skip "ssh-keygen failed"
+  local recipe
+  recipe="$(_extract_recipe "$FACTORY_HEALTH")"
 
-  git -C "$REPO" config gpg.format ssh
-  git -C "$REPO" config user.signingkey "$key.pub"
-
-  # Run the recipe VERBATIM, including -S, as shipped in SKILL.md.
-  run git -C "$REPO" branch factory-artifacts \
-    "$(git -C "$REPO" commit-tree -S "$(git -C "$REPO" mktree </dev/null)" \
-       -m "chore: initialize factory-artifacts orphan branch")"
-  # If this git build lacks SSH signing support, skip rather than fail.
-  if [ "$status" -ne 0 ]; then
-    skip "SSH commit signing unavailable in this git build"
-  fi
-
-  # An allowed-signers file lets verify-commit confirm the signature.
-  local signers="$WORK/allowed_signers"
-  echo "orphan-plumbing-test $(cat "$key.pub")" > "$signers"
-  git -C "$REPO" config gpg.ssh.allowedSignersFile "$signers"
-
-  run git -C "$REPO" verify-commit factory-artifacts
+  # Mask global + system git config so no user.signingkey / commit.gpgsign /
+  # gpg.format can leak in from the host — the fresh-CI-runner shape.
+  run bash -c "cd '$REPO' && GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null bash -c '$(printf '%s' "$recipe" | sed "s/'/'\\\\''/g")'"
   [ "$status" -eq 0 ]
-  # HEAD still didn't move even with signing on.
-  [ "$(git -C "$REPO" branch --show-current)" = "develop" ]
+
+  # Branch created; commit is unsigned (%G? prints N for no signature).
+  run git -C "$REPO" rev-parse --verify --quiet factory-artifacts
+  [ "$status" -eq 0 ]
+  [ "$(git -C "$REPO" log -1 --format=%G? factory-artifacts)" = "N" ]
+}
+
+@test "shipped recipe fails cleanly when commit-tree cannot succeed — no half-made branch" {
+  # A repo where commit-tree CANNOT succeed: user.useConfigOnly forbids the
+  # username@hostname ident auto-detection and no user.email is configured.
+  # The recipe's guard must surface its own message and NOT run
+  # `git branch factory-artifacts ""` (which would emit a misleading
+  # "not a valid object name" error).
+  REPO="$WORK/noident"
+  git init -q -b develop "$REPO"
+  git -C "$REPO" -c user.email=seed@x -c user.name=seed commit -q --allow-empty -m seed
+  git -C "$REPO" config user.useConfigOnly true
+
+  local recipe
+  recipe="$(_extract_recipe "$FACTORY_HEALTH")"
+  run bash -c "cd '$REPO' && GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null bash -c '$(printf '%s' "$recipe" | sed "s/'/'\\\\''/g")'"
+  [ "$status" -ne 0 ]
+  # The failure is attributed by the recipe's own message...
+  [[ "$output" == *"failed to create factory-artifacts init commit"* ]]
+  # ...not by a misleading empty-object branch error, and no branch exists.
+  [[ "$output" != *"not a valid object name"* ]]
+  run git -C "$REPO" show-ref --verify --quiet refs/heads/factory-artifacts
+  [ "$status" -ne 0 ]
 }
 
 # ===========================================================================
 # CONTRACT — the shipped SKILL.md files carry the fix, not the fragile recipe
 # ===========================================================================
 
-@test "factory-health SKILL.md uses the plumbing recipe" {
-  grep -qF "git commit-tree -S" "$FACTORY_HEALTH"
+@test "factory-health SKILL.md uses the plumbing recipe without mandatory -S" {
+  grep -qF "git commit-tree" "$FACTORY_HEALTH"
   grep -qF "git mktree </dev/null" "$FACTORY_HEALTH"
   grep -qF "git branch factory-artifacts" "$FACTORY_HEALTH"
+  # -S would make the auto-repair path fail on keyless hosts; it must be gone.
+  run grep -F "commit-tree -S" "$FACTORY_HEALTH"
+  [ "$status" -ne 0 ]
+  # The commit-tree failure guard is present (no `git branch <name> ""`).
+  grep -qF "failed to create factory-artifacts init commit" "$FACTORY_HEALTH"
 }
 
 @test "factory-health SKILL.md no longer contains the checkout dance in branch creation" {
@@ -273,12 +391,17 @@ EMPTY_TREE="4b825dc642cb6eb9a060e54bf8d69288fbee4904"
   [ "$status" -ne 0 ]
 }
 
-@test "factory-worktree-health SKILL.md uses the plumbing recipe" {
-  grep -qF 'git commit-tree -S' "$WORKTREE_HEALTH"
+@test "factory-worktree-health SKILL.md uses the guarded plumbing recipe" {
+  grep -qF 'git commit-tree' "$WORKTREE_HEALTH"
   grep -qF 'git mktree </dev/null' "$WORKTREE_HEALTH"
-  grep -qF 'git branch ${BRANCH_NAME}' "$WORKTREE_HEALTH"
-  # The remote branch still gets pushed.
-  grep -qF 'git push origin ${BRANCH_NAME}' "$WORKTREE_HEALTH"
+  run grep -F "commit-tree -S" "$WORKTREE_HEALTH"
+  [ "$status" -ne 0 ]
+  # Local-existence guard (Step 1's ls-remote check is remote-only).
+  grep -qF 'git show-ref --verify --quiet "refs/heads/${BRANCH_NAME}"' "$WORKTREE_HEALTH"
+  # Quoted expansions and the failure guard.
+  grep -qF 'git branch "${BRANCH_NAME}" "$commit"' "$WORKTREE_HEALTH"
+  grep -qF 'git push origin "${BRANCH_NAME}"' "$WORKTREE_HEALTH"
+  grep -qF 'failed to create ${BRANCH_NAME} init commit' "$WORKTREE_HEALTH"
 }
 
 @test "factory-worktree-health SKILL.md no longer contains the checkout dance in branch creation" {


### PR DESCRIPTION
## Why

Both health skills create the `factory-artifacts` orphan branch by moving
`HEAD` onto it and then switching back:

```bash
git checkout --orphan factory-artifacts
git rm -rf --cached . 2>/dev/null || true
git commit --allow-empty -m "chore: initialize factory-artifacts orphan branch"
git checkout -   # return to previous branch
```

The return step is unchecked, and it is the failure point. After
`git checkout --orphan`, `git checkout -` has no `@{-1}` reflog entry to
resolve, so it exits non-zero with `pathspec '-' did not match any file(s)`
and `HEAD` is left **stranded on `factory-artifacts`**. From that moment every
subsequent pipeline commit — STATE.md writes, spec artifacts, phase-gate
backups — lands on the orphan branch instead of the working branch, silently.
The `factory-worktree-health` variant has the same fragility class: it uses
`git rm -rf .` (which deletes the working-tree files, not just the index) and a
hardcoded `git checkout develop` return that lands on the wrong branch whenever
the pipeline started somewhere other than `develop`. The commits were also
unsigned, so the initialization commit could not satisfy a signed-history
requirement.

This is a health-check skill — the one thing that is supposed to keep the
factory worktree sane. When its own repair step can strand the session on the
artifacts branch, a "health check" becomes the thing that breaks the pipeline.

## What changed

Both skills now create the branch with plumbing, so `HEAD` never moves and the
working tree is never touched:

```bash
git branch factory-artifacts \
  "$(git commit-tree -S "$(git mktree </dev/null)" \
     -m "chore: initialize factory-artifacts orphan branch")"
```

`git mktree </dev/null` produces the empty tree; `git commit-tree -S` builds a
parentless (orphan), signed root commit for it; `git branch` points the ref at
that commit without any checkout. There is no return step to fail, no working
tree to disturb, and no hardcoded branch to guess wrong.

- **`skills/factory-health/SKILL.md`** — replaced the four-command checkout
  dance in "Orphan branch exists → If missing" with the single plumbing
  command; updated the surrounding prose (the old "return to previous branch"
  comment is gone, replaced by a note on why `HEAD` no longer moves).
- **`skills/factory-worktree-health/SKILL.md`** — replaced the checkout-dance
  variant in "Step 1: Check Remote Branch → Branch does NOT exist" with the
  same plumbing command (parameterized on `${BRANCH_NAME}`, so it serves both
  `factory-artifacts` and `factory-project-artifacts`). The `git push origin
  ${BRANCH_NAME}` is retained — this recipe builds a remote branch — and the
  fragile `git checkout develop` return is removed.
- **`tests/orphan-branch-plumbing.bats`** — new focused suite (13 tests):
  behavioral invariants for the new recipe, RED reproductions proving the old
  recipes can strand `HEAD`/lose files, a gated signature-verification test,
  and contract assertions that the shipped SKILL.md files carry the fix.

## Test evidence

New suite, run from the plugin root (`bats plugins/vsdd-factory/tests/orphan-branch-plumbing.bats`):

```
1..13
ok 1 new recipe: HEAD/current branch unchanged after creation
ok 2 new recipe: factory-artifacts ref resolves to a commit
ok 3 new recipe: factory-artifacts is a parentless (orphan) empty-tree commit
ok 4 new recipe: working tree is byte-for-byte untouched
ok 5 old factory-health recipe strands HEAD (git checkout - cannot resolve)
ok 6 old factory-worktree-health recipe destroys untracked working-tree files
ok 7 old factory-worktree-health recipe: hardcoded return lands on develop, not the actual start branch
ok 8 new recipe does NOT strand: same fixture, HEAD stays put
ok 9 new recipe with -S produces a verifiable signature
ok 10 factory-health SKILL.md uses the plumbing recipe
ok 11 factory-health SKILL.md no longer contains the checkout dance in branch creation
ok 12 factory-worktree-health SKILL.md uses the plumbing recipe
ok 13 factory-worktree-health SKILL.md no longer contains the checkout dance in branch creation
```

Test 5 reproduces the stranding deterministically: it runs the old
factory-health recipe verbatim and asserts `git checkout -` exits non-zero
and leaves the current branch on `factory-artifacts` instead of the starting
branch. Below is the same sequence run by hand, showing the strand:

```
$ git checkout --orphan factory-artifacts
Switched to a new branch 'factory-artifacts'
$ git rm -rf --cached . 2>/dev/null || true
rm 'README.md'
rm 'src/main.rs'
$ git commit --allow-empty -m "chore: initialize factory-artifacts orphan branch"
$ git checkout -   # unchecked return — the defect
error: pathspec '-' did not match any file(s) known to git
git checkout - exit code: 1
current branch: factory-artifacts   <-- STRANDED (expected: develop)
```

The new recipe, run against the identical fixture (tracked files under `src/`,
a `README.md`, and an untracked `untracked.txt`), holds every invariant:

```
=== BEFORE ===
current branch: develop
HEAD: b06a781a...
status --porcelain:
?? untracked.txt
=== RUN PLUMBING RECIPE ===
git branch factory-artifacts "$(git commit-tree ... "$(git mktree </dev/null)" ...)"
=== AFTER ===
current branch: develop                             # unchanged
HEAD: b06a781a...                                    # unchanged
factory-artifacts resolves: 368f6fac...
factory-artifacts tree: 4b825dc642cb6eb9a060e54bf8d69288fbee4904   # the empty tree
factory-artifacts parents: (none)                    # orphan
status --porcelain:
?? untracked.txt                                     # working tree untouched
```

Signing verified with the recipe run verbatim (`-S`) under an ephemeral SSH
signing key (test 9, and by hand):

```
$ git branch factory-artifacts "$(git commit-tree -S "$(git mktree </dev/null)" -m "...")"
$ git verify-commit factory-artifacts
Good "git" signature ... with ED25519 key SHA256:...
current branch: develop   # HEAD still didn't move, even with signing on
```

The `factory-worktree-health` variant was verified end-to-end against a bare
remote: the plumbing recipe followed by `git push origin ${BRANCH_NAME}`
publishes an orphan, empty-tree, signed branch to the remote while the local
`HEAD` stays on the starting branch.

The signing test self-skips where SSH commit signing is unavailable, and all
behavioral tests strip `-S` so they run on any host with no key configured (as
CI runs); the `-S` in the shipped recipe is covered by the gated signing test
plus a contract assertion. Environment: git 2.50.1, bats 1.13.0.

Closes: #204
