### PR TITLE
fix(skills): STATE.md bootstrap derives product name — remove leaked author literal

### DIFF
--- a/plugins/vsdd-factory/skills/factory-health/SKILL.md
+++ b/plugins/vsdd-factory/skills/factory-health/SKILL.md
@@ -56,12 +56,19 @@ cd .factory && git branch --show-current
 test -f .factory/STATE.md
 ```
 
-- **If missing**: Create initial STATE.md.
+- **If missing**: Create initial STATE.md. Derive `product` from the
+  repository — use the repo directory name verbatim (do NOT strip any
+  `-blue`/`-green` or other suffix; the name on disk is the name):
+  ```bash
+  git rev-parse --show-toplevel | xargs basename
+  ```
+  If that name is ambiguous or clearly not the product (e.g. a generic
+  checkout dir), ask the human for the product name instead. Then write:
   ```yaml
   ---
   pipeline: INITIALIZED
   phase: pre-1
-  product: corverax
+  product: <repo name from git, or human-supplied>
   mode: greenfield
   timestamp: <current ISO8601>
   ---

--- a/plugins/vsdd-factory/skills/state-update/SKILL.md
+++ b/plugins/vsdd-factory/skills/state-update/SKILL.md
@@ -35,13 +35,16 @@ Parse the YAML frontmatter for current `phase` and `pipeline` status.
 
 ### 2. Update frontmatter
 
-Update the YAML frontmatter fields:
+Update the YAML frontmatter fields. Preserve the existing `product` value read
+in step 1 — never overwrite it. If it is somehow absent, derive it from the
+repository (`git rev-parse --show-toplevel | xargs basename`, using the name
+verbatim with no suffix stripping) or ask the human:
 
 ```yaml
 ---
 pipeline: <RUNNING|PAUSED|COMPLETED|BLOCKED>
 phase: <new phase>
-product: corverax
+product: <existing product name — preserved unchanged>
 mode: <greenfield|brownfield|feature>
 timestamp: <current ISO8601>
 previous_phase: <old phase>

--- a/plugins/vsdd-factory/tests/skills-content.bats
+++ b/plugins/vsdd-factory/tests/skills-content.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+# skills-content.bats — content guards against author-environment leaks in
+# skill prose.
+#
+# Issue #229: the STATE.md bootstrap in factory-health/SKILL.md and the
+# frontmatter update in state-update/SKILL.md both emitted a hardcoded
+# `product: corverax` — corverax is the author's project, not the user's.
+# On a fresh install this writes a stranger's product name into the user's
+# STATE.md. The canonical templates already use a placeholder
+# (templates/state-template.md → `project: "[project-name]"`,
+# templates/factory-project-state-template.md → `${project_name}`); the skill
+# emissions must too.
+#
+# These guards catch the whole leak CLASS — any bare literal value on a
+# `product:` frontmatter emission line — not just the one reported string.
+
+setup() {
+  SKILLS="${BATS_TEST_DIRNAME}/../skills"
+}
+
+@test "no skill emits the leaked author product literal 'corverax' (issue #229)" {
+  # The exact reported instances: factory-health step 4 + state-update step 2.
+  run grep -rn 'product: corverax' "$SKILLS"
+  [ "$status" -ne 0 ]
+}
+
+@test "every skill product: frontmatter emission uses a placeholder, not a literal" {
+  # A `product:` YAML line in skill prose is a STATE.md emission template. Its
+  # value must be a placeholder — square-bracket [...] (the canonical
+  # templates' idiom) or angle-bracket <...> (this repo's inline-yaml idiom) —
+  # never a bare identifier, which is by definition a leaked author name.
+  #
+  # Match every `product:` emission line (leading whitespace allowed, so prose
+  # like `... or per-product:` is excluded), then drop the ones whose value
+  # begins with `[` or `<`. Whatever remains is a hardcoded literal.
+  local offenders
+  offenders="$(grep -rnE '^[[:space:]]*product:[[:space:]]' "$SKILLS" \
+                 | grep -vE 'product:[[:space:]]+[<[]' || true)"
+  if [ -n "$offenders" ]; then
+    echo "hardcoded product literal(s) — must be a [placeholder] or <placeholder>:" >&2
+    echo "$offenders" >&2
+    return 1
+  fi
+}


### PR DESCRIPTION
## Why

Two skills that write `.factory/STATE.md` frontmatter hardcoded `product: corverax` — the author's own project name. On any other install the factory-health auto-repair (step 4) and every state-update phase transition stamp a stranger's product into the user's STATE.md. The canonical templates already got this right (`templates/state-template.md` uses `project: "[project-name]"`, `templates/factory-project-state-template.md` uses `${project_name}`); the two skill emissions drifted from them. This closes that gap so a fresh factory names its own product.

## What changed

- **`skills/factory-health/SKILL.md`** (step 4, STATE.md bootstrap): the initial-STATE.md block no longer emits `product: corverax`. It now instructs the executing agent to derive the product from the repository — `git rev-parse --show-toplevel | xargs basename`, used verbatim — and to ask the human if that name is ambiguous. The frontmatter value becomes `product: <repo name from git, or human-supplied>`.
- **`skills/state-update/SKILL.md`** (step 2, frontmatter update): this skill *reads* current state first, so the correct behavior is to preserve the existing `product` value rather than re-derive it. The emission block is now `product: <existing product name — preserved unchanged>`, with a fallback (derive-or-ask) only if it is somehow absent.
- **No name normalization.** Per the issue thread, neither edit strips `-blue`/`-green` or any other suffix — the directory name on disk is used as-is. Suffix-stripping would reintroduce the same author-environment-assumption class the fix removes.
- **New guard suite `tests/skills-content.bats`** (2 tests): asserts `grep -rn 'product: corverax' skills/` returns nothing, and — catching the whole leak class, not just the one string — that every `product:` frontmatter emission line in any skill uses a `[placeholder]` or `<placeholder>` value rather than a bare literal.

## Test evidence

New suite `tests/skills-content.bats`, run against this worktree (bats 1.x, git 2.50.1):

RED (before the skill edits, both tests fail — the grep found the two instances):
```
not ok 1 no skill emits the leaked author product literal 'corverax' (issue #229)
not ok 2 every skill product: frontmatter emission uses a placeholder, not a literal
#   skills/factory-health/SKILL.md:64:  product: corverax
#   skills/state-update/SKILL.md:44:product: corverax
```

GREEN (after the skill edits):
```
ok 1 no skill emits the leaked author product literal 'corverax' (issue #229)
ok 2 every skill product: frontmatter emission uses a placeholder, not a literal
```

No regressions: `tests/skills.bats` (58 tests) and `tests/factory-lock-status.bats` (which greps `factory-health/SKILL.md`) both still pass; `tests/check-bats-orphans.sh` passes.

## Reviewer note — scope

This fix targets only the `product:` STATE.md-emission leak class named in #229. A grep for `corverax` across `skills/` also surfaces a *separate* leak class — author-absolute paths (`/Users/jmagady/Dev/corverax/.reference/...`) and baked artifact filenames (`*-pass-9-corverax-disposition.md`) in `skills/brownfield-ingest/`, `skills/disposition-pass/`, and `agents/codebase-analyzer.md`. Those are intentionally out of scope here (different fix shape, different files) and are left untouched. The `product: corverax` guard is deliberately scoped to the emission class so it goes GREEN with this change; the path-leak class is filed separately as #734.

Closes: #229
