### PR TITLE
fix(skills): assert .factory mounts at repo root; gate onboard-observability on the mount

### DIFF
--- a/plugins/vsdd-factory/skills/factory-health/SKILL.md
+++ b/plugins/vsdd-factory/skills/factory-health/SKILL.md
@@ -38,10 +38,10 @@ git worktree list | grep -F '.factory'
   running `/onboard-observability` before this check), `git worktree add`
   fails on current git with `fatal: '.factory' already exists` when the
   directory is non-empty (verified on git 2.50/2.55; an empty one mounts
-  cleanly). Nested mounts at `.factory/.factory` — a corrupt layout — have
-  also been observed from this state (#205): a nested path passed while
-  recovering from the already-exists error, or a process re-creating
-  `.factory` mid-setup, produces one. Move the plain directory aside first
+  cleanly). A nested mount at `.factory/.factory` — a corrupt layout — has
+  also been observed once from this state (#205; mechanism unconfirmed —
+  candidates are a nested add path during error recovery or a process
+  re-creating `.factory` mid-setup). Move the plain directory aside first
   (mirrors `/factory-worktree-health`), mount, then restore its contents:
   ```bash
   if [ -e .factory ] && ! git -C .factory rev-parse --git-dir >/dev/null 2>&1; then
@@ -59,9 +59,9 @@ git worktree list | grep -F '.factory'
     || echo "ABORT: .factory did not mount at the repo root"
   ```
   If the assertion fails, the worktree is almost certainly **nested** at
-  `.factory/.factory` (a nested add path used while recovering from
-  `already exists`, or a racing process re-creating `.factory` mid-mount —
-  see #205). Do NOT run `git worktree remove .factory --force` — that
+  `.factory/.factory` (#205 — observed once, mechanism unconfirmed;
+  candidates include a nested add during error recovery or a racing
+  re-create mid-mount). Do NOT run `git worktree remove .factory --force` — that
   removal targets the wrong path and cannot fix a nested mount. Instead remove
   the *actual* nested worktree and re-run this check from the plain-dir guard:
   ```bash

--- a/plugins/vsdd-factory/skills/factory-health/SKILL.md
+++ b/plugins/vsdd-factory/skills/factory-health/SKILL.md
@@ -32,11 +32,40 @@ git worktree list | grep -F '.factory'
 ```
 
 - **If missing**: Mount it.
+
+  First guard against a pre-existing **plain** `.factory/` directory. If
+  `.factory` exists but is NOT a worktree (e.g. a bare `.factory/logs/` left by
+  running `/onboard-observability` before this check), `git worktree add`
+  mounts the worktree *nested* at `.factory/.factory` — a corrupt layout. Move
+  the plain directory aside first (mirrors `/factory-worktree-health`), mount,
+  then restore its contents:
   ```bash
+  if [ -e .factory ] && ! git -C .factory rev-parse --git-dir >/dev/null 2>&1; then
+    mv .factory .factory-backup-$(date +%s)   # plain dir, not a worktree
+  fi
   git worktree add .factory factory-artifacts
+  # If a backup was made, restore any contents (e.g. logs/) into the worktree:
+  #   cp -R .factory-backup-*/. .factory/ 2>/dev/null || true
+  #   rm -rf .factory-backup-*
   ```
 
-- **If mounted but pointing to wrong branch**: Remove and remount.
+  Then **assert the mount landed at the repo root**, not nested:
+  ```bash
+  [ "$(git -C .factory rev-parse --show-toplevel)" = "$(git rev-parse --show-toplevel)/.factory" ] \
+    || echo "ABORT: .factory did not mount at the repo root"
+  ```
+  If the assertion fails, the worktree is almost certainly **nested** at
+  `.factory/.factory` (git chose that path because `.factory` already existed as
+  a plain directory). Do NOT run `git worktree remove .factory --force` — that
+  removal targets the wrong path and cannot fix a nested mount. Instead remove
+  the *actual* nested worktree and re-run this check from the plain-dir guard:
+  ```bash
+  git worktree remove .factory/.factory --force
+  rm -rf .factory        # now a leftover plain dir; the guard above re-handles it
+  ```
+
+- **If mounted but pointing to wrong branch**: Remove and remount, then re-run
+  the same post-mount assertion above.
   ```bash
   git worktree remove .factory --force
   git worktree add .factory factory-artifacts

--- a/plugins/vsdd-factory/skills/factory-health/SKILL.md
+++ b/plugins/vsdd-factory/skills/factory-health/SKILL.md
@@ -36,9 +36,13 @@ git worktree list | grep -F '.factory'
   First guard against a pre-existing **plain** `.factory/` directory. If
   `.factory` exists but is NOT a worktree (e.g. a bare `.factory/logs/` left by
   running `/onboard-observability` before this check), `git worktree add`
-  mounts the worktree *nested* at `.factory/.factory` — a corrupt layout. Move
-  the plain directory aside first (mirrors `/factory-worktree-health`), mount,
-  then restore its contents:
+  fails on current git with `fatal: '.factory' already exists` when the
+  directory is non-empty (verified on git 2.50/2.55; an empty one mounts
+  cleanly). Nested mounts at `.factory/.factory` — a corrupt layout — have
+  also been observed from this state (#205): a nested path passed while
+  recovering from the already-exists error, or a process re-creating
+  `.factory` mid-setup, produces one. Move the plain directory aside first
+  (mirrors `/factory-worktree-health`), mount, then restore its contents:
   ```bash
   if [ -e .factory ] && ! git -C .factory rev-parse --git-dir >/dev/null 2>&1; then
     mv .factory .factory-backup-$(date +%s)   # plain dir, not a worktree
@@ -55,8 +59,9 @@ git worktree list | grep -F '.factory'
     || echo "ABORT: .factory did not mount at the repo root"
   ```
   If the assertion fails, the worktree is almost certainly **nested** at
-  `.factory/.factory` (git chose that path because `.factory` already existed as
-  a plain directory). Do NOT run `git worktree remove .factory --force` — that
+  `.factory/.factory` (a nested add path used while recovering from
+  `already exists`, or a racing process re-creating `.factory` mid-mount —
+  see #205). Do NOT run `git worktree remove .factory --force` — that
   removal targets the wrong path and cannot fix a nested mount. Instead remove
   the *actual* nested worktree and re-run this check from the plain-dir guard:
   ```bash

--- a/plugins/vsdd-factory/skills/factory-health/SKILL.md
+++ b/plugins/vsdd-factory/skills/factory-health/SKILL.md
@@ -41,32 +41,65 @@ git worktree list | grep -F '.factory'
   cleanly). A nested mount at `.factory/.factory` — a corrupt layout — has
   also been observed once from this state (#205; mechanism unconfirmed —
   candidates are a nested add path during error recovery or a process
-  re-creating `.factory` mid-setup). Move the plain directory aside first
-  (mirrors `/factory-worktree-health`), mount, then restore its contents:
+  re-creating `.factory` mid-setup).
+
+  Note `rev-parse --git-dir` CANNOT detect the plain-dir case — for an
+  in-repo plain directory it walks up, finds the parent repo's `.git`, and
+  exits 0, exactly as it does for a real worktree. The guard therefore
+  compares canonicalized (`pwd -P`, symlink-safe) worktree toplevels: a
+  healthy mount's toplevel resolves to `<repo-root>/.factory`, a plain dir's
+  resolves to the parent repo root. Run as one block — guard, prune stale
+  registrations, mount, restore, assert:
   ```bash
-  if [ -e .factory ] && ! git -C .factory rev-parse --git-dir >/dev/null 2>&1; then
-    mv .factory .factory-backup-$(date +%s)   # plain dir, not a worktree
+  canon() { (cd "$1" 2>/dev/null && pwd -P); }    # symlink-safe path compare
+  repo_root="$(canon "$(git rev-parse --show-toplevel)")"
+
+  # Nested corrupt layout (#205)? Positively confirmed only — route to the
+  # recovery block below rather than mounting over it.
+  if [ -e .factory/.factory/.git ]; then
+    echo "ABORT: nested .factory/.factory mount detected — run the #205 recovery block" >&2
+    exit 1
   fi
+
+  # Plain-dir guard: move aside anything that is not a repo-root worktree.
+  if [ -e .factory ] && \
+     [ "$(canon "$(git -C .factory rev-parse --show-toplevel 2>/dev/null || echo /nonexistent)")" != "$repo_root/.factory" ]; then
+    mv .factory ".factory-backup-$(date +%s)"   # plain dir, not a root worktree
+  fi
+
+  git worktree prune   # drop stale registrations left by earlier bad recoveries
   git worktree add .factory factory-artifacts
-  # If a backup was made, restore any contents (e.g. logs/) into the worktree:
-  #   cp -R .factory-backup-*/. .factory/ 2>/dev/null || true
-  #   rm -rf .factory-backup-*
+
+  # Restore any backed-up contents (e.g. logs/) into the fresh worktree.
+  for b in .factory-backup-*; do
+    [ -e "$b" ] || continue
+    cp -R "$b/." .factory/
+    rm -rf "$b"
+  done
+
+  # Post-mount assertion — hard stop; later checks must not run on a bad mount.
+  [ "$(canon "$(git -C .factory rev-parse --show-toplevel 2>/dev/null || echo /nonexistent)")" = "$repo_root/.factory" ] \
+    || { echo "ABORT: .factory did not mount at the repo root" >&2; exit 1; }
   ```
 
-  Then **assert the mount landed at the repo root**, not nested:
+  **#205 recovery block** — only for a positively confirmed nested mount
+  (`.factory/.factory/.git` exists). Do NOT run
+  `git worktree remove .factory --force` — that removal targets the wrong
+  path and cannot fix a nested mount. And do not delete anything on a mere
+  assertion failure: if the layout is not the known nested shape, inspect
+  `git worktree list` manually instead. The wrapper directory is moved
+  aside, not deleted, so its contents (e.g. logs/) are restored by the
+  mount block's backup-restore step on re-run:
   ```bash
-  [ "$(git -C .factory rev-parse --show-toplevel)" = "$(git rev-parse --show-toplevel)/.factory" ] \
-    || echo "ABORT: .factory did not mount at the repo root"
-  ```
-  If the assertion fails, the worktree is almost certainly **nested** at
-  `.factory/.factory` (#205 — observed once, mechanism unconfirmed;
-  candidates include a nested add during error recovery or a racing
-  re-create mid-mount). Do NOT run `git worktree remove .factory --force` — that
-  removal targets the wrong path and cannot fix a nested mount. Instead remove
-  the *actual* nested worktree and re-run this check from the plain-dir guard:
-  ```bash
-  git worktree remove .factory/.factory --force
-  rm -rf .factory        # now a leftover plain dir; the guard above re-handles it
+  if [ -e .factory/.factory/.git ]; then
+    git worktree remove .factory/.factory --force
+    mv .factory ".factory-backup-$(date +%s)"   # preserve wrapper contents
+    git worktree prune                          # drop the dangling registration
+    # Now re-run the mount block above; it mounts clean and restores the backup.
+  else
+    echo "ABORT: not the known nested shape — inspect 'git worktree list' manually" >&2
+    exit 1
+  fi
   ```
 
 - **If mounted but pointing to wrong branch**: Remove and remount, then re-run

--- a/plugins/vsdd-factory/skills/onboard-observability/SKILL.md
+++ b/plugins/vsdd-factory/skills/onboard-observability/SKILL.md
@@ -24,9 +24,10 @@ Before any other action, say verbatim:
 1. `.factory/` must be a **mounted factory-artifacts worktree at the repo root** —
    not merely a directory that happens to exist. This ordering matters: if you
    run this skill first, `factory-obs register` would create a plain
-   `.factory/logs/` directory, and a later `/factory-health` would then mount
-   the worktree *nested* at `.factory/.factory` (a corrupt layout). Assert the
-   mount before doing anything:
+   `.factory/logs/` directory, and a later `/factory-health` mount then fails
+   (`fatal: '.factory' already exists` on current git) — with nested
+   `.factory/.factory` mounts observed from botched recoveries of that state
+   (#205). Assert the mount before doing anything:
    ```bash
    [ "$(git -C .factory rev-parse --show-toplevel 2>/dev/null)" = "$(git rev-parse --show-toplevel)/.factory" ]
    ```
@@ -132,7 +133,7 @@ This skill **does not**:
 ## When to use
 
 Run this **after** `/factory-health` has mounted `.factory/` (see Prerequisites) —
-never before, or the mount lands nested.
+never before, or the leftover plain directory blocks the mount.
 
 - **Newly set-up project** whose `.factory/` worktree is already mounted and which you now want wired into observability.
 - **Existing project** you've been working in but haven't connected to your running stack yet (e.g., you set up the stack from a different project and want this one's events in the same Grafana).

--- a/plugins/vsdd-factory/skills/onboard-observability/SKILL.md
+++ b/plugins/vsdd-factory/skills/onboard-observability/SKILL.md
@@ -27,13 +27,14 @@ Before any other action, say verbatim:
    `.factory/logs/` directory, and a later `/factory-health` mount then fails
    (`fatal: '.factory' already exists` on current git) — with nested
    `.factory/.factory` mounts observed from botched recoveries of that state
-   (#205). Assert the mount before doing anything:
+   (#205). Assert the mount before doing anything — the snippet halts, it does
+   not merely warn (paths canonicalized so symlinked checkouts don't false-fail):
    ```bash
-   [ "$(git -C .factory rev-parse --show-toplevel 2>/dev/null)" = "$(git rev-parse --show-toplevel)/.factory" ]
+   canon() { (cd "$1" 2>/dev/null && pwd -P); }
+   [ "$(canon "$(git -C .factory rev-parse --show-toplevel 2>/dev/null || echo /nonexistent)")" = "$(canon "$(git rev-parse --show-toplevel)")/.factory" ] \
+     || { echo ".factory/ is not a mounted worktree — run /factory-health first to set it up, then re-run this skill." >&2; exit 1; }
    ```
-   If this fails, abort with: **"`.factory/` is not a mounted worktree — run
-   `/factory-health` first to set it up, then re-run this skill."** Do not create
-   `.factory/` here.
+   Do not create `.factory/` here.
 2. The `factory-obs` binary must be present at `${CLAUDE_PLUGIN_ROOT}/bin/factory-obs`. If not, abort with "vsdd-factory plugin not found — is it installed in this Claude Code environment?".
 
 Don't fail silently — always print what's missing so the user can fix it.

--- a/plugins/vsdd-factory/skills/onboard-observability/SKILL.md
+++ b/plugins/vsdd-factory/skills/onboard-observability/SKILL.md
@@ -21,7 +21,18 @@ Before any other action, say verbatim:
 
 ## Prerequisites (check + abort if missing)
 
-1. Current working directory (or the nearest ancestor) must contain a `.factory/` subdirectory. Walk up from `$PWD` to find it. If none, abort with a clear error explaining the user needs to run this from inside a factory project.
+1. `.factory/` must be a **mounted factory-artifacts worktree at the repo root** —
+   not merely a directory that happens to exist. This ordering matters: if you
+   run this skill first, `factory-obs register` would create a plain
+   `.factory/logs/` directory, and a later `/factory-health` would then mount
+   the worktree *nested* at `.factory/.factory` (a corrupt layout). Assert the
+   mount before doing anything:
+   ```bash
+   [ "$(git -C .factory rev-parse --show-toplevel 2>/dev/null)" = "$(git rev-parse --show-toplevel)/.factory" ]
+   ```
+   If this fails, abort with: **"`.factory/` is not a mounted worktree — run
+   `/factory-health` first to set it up, then re-run this skill."** Do not create
+   `.factory/` here.
 2. The `factory-obs` binary must be present at `${CLAUDE_PLUGIN_ROOT}/bin/factory-obs`. If not, abort with "vsdd-factory plugin not found — is it installed in this Claude Code environment?".
 
 Don't fail silently — always print what's missing so the user can fix it.
@@ -120,7 +131,10 @@ This skill **does not**:
 
 ## When to use
 
-- **Brand new project** that just had the vsdd-factory plugin installed.
+Run this **after** `/factory-health` has mounted `.factory/` (see Prerequisites) —
+never before, or the mount lands nested.
+
+- **Newly set-up project** whose `.factory/` worktree is already mounted and which you now want wired into observability.
 - **Existing project** you've been working in but haven't connected to your running stack yet (e.g., you set up the stack from a different project and want this one's events in the same Grafana).
 - **Troubleshooting**: "my events aren't showing up in Grafana" — re-running this skill is a quick idempotent fix that verifies both register + telemetry config are in place.
 

--- a/plugins/vsdd-factory/tests/factory-mount-guards.bats
+++ b/plugins/vsdd-factory/tests/factory-mount-guards.bats
@@ -1,0 +1,146 @@
+#!/usr/bin/env bats
+# factory-mount-guards.bats — guards for the .factory/ mount ordering hazards.
+#
+# Issue #205: factory-health/SKILL.md step 2 runs a bare `git worktree add
+# .factory factory-artifacts` with NO post-mount assertion. If `.factory`
+# already exists as a plain directory (the #203 onboard-first case), git
+# mounts the worktree NESTED at `.factory/.factory`. Step 3's
+# `cd .factory && git branch --show-current` then reads the PARENT branch, and
+# the documented recovery `git worktree remove .factory --force` does not fix
+# it because `.factory` is not the worktree — the worktree is `.factory/.factory`.
+#
+# Issue #203: onboard-observability/SKILL.md runs `factory-obs register` with a
+# "When to use: brand new project that just had the plugin installed" while its
+# Prerequisites require a `.factory/` ancestor — a contradiction. Running it
+# before factory-health creates a plain `.factory/logs/` directory, which is
+# exactly the plain-dir that makes the #205 nested mount happen.
+#
+# TWO KINDS OF TEST HERE:
+#   1. Content-contract (grep) tests — RED before the skill edits, GREEN after.
+#      They assert the skills carry the required assertion / guard / prereq text.
+#   2. Execution tests — fabricate real git layouts and prove the mount
+#      assertion the skill now prescribes actually distinguishes healthy from
+#      nested / plain-dir / absent. These validate git LOGIC (independent of the
+#      prose), so they pass on any git; the RED/GREEN gate is the grep tests.
+#
+# Traces to: issues #205, #203 (root-cause dispatcher race is #206, separate PR).
+
+setup() {
+  PLUGIN_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  HEALTH="$PLUGIN_ROOT/skills/factory-health/SKILL.md"
+  ONBOARD="$PLUGIN_ROOT/skills/onboard-observability/SKILL.md"
+
+  # Scratch git repo with a factory-artifacts orphan branch, reused by the
+  # execution tests. Each execution test mounts/creates .factory itself.
+  WORK="$(mktemp -d)"
+  WORK="$(cd "$WORK" && pwd -P)"   # resolve /var → /private/var on macOS
+  REPO="$WORK/repo"
+  git init -q -b main "$REPO"
+  git -C "$REPO" config user.email test@vsdd.test
+  git -C "$REPO" config user.name  "VSDD Test"
+  echo root > "$REPO/f"; git -C "$REPO" add f; git -C "$REPO" commit -qm init
+  # Create the factory-artifacts orphan branch WITHOUT keeping it checked out,
+  # so each execution test is free to `git worktree add` it. (Mirrors the
+  # skill's own orphan-branch bootstrap; done inside the repo, then back to main.)
+  git -C "$REPO" checkout -q --orphan factory-artifacts
+  git -C "$REPO" rm -rf --cached . >/dev/null 2>&1 || true
+  git -C "$REPO" commit -q --allow-empty -m "init factory-artifacts"
+  git -C "$REPO" checkout -q -f main
+}
+
+teardown() {
+  git -C "$REPO" worktree prune 2>/dev/null || true
+  rm -rf "$WORK"
+}
+
+# The canonical mount assertion the skill prescribes. Kept here so the
+# execution tests and the content-contract test reference one shape.
+# Returns 0 when .factory is the repo-root worktree, non-zero otherwise.
+_mount_ok() {
+  local top
+  top="$(git -C "$1/.factory" rev-parse --show-toplevel 2>/dev/null)" || return 1
+  [ "$top" = "$1/.factory" ]
+}
+
+# ============================================================
+# Content-contract tests (RED before edits, GREEN after)
+# ============================================================
+
+@test "factory-health step 2 has a post-mount assertion on .factory toplevel (#205)" {
+  # Must compare the mounted worktree's toplevel against <repo-root>/.factory.
+  grep -q 'rev-parse --show-toplevel' "$HEALTH"
+  run grep -E '\.factory' "$HEALTH"
+  [ "$status" -eq 0 ]
+  # The assertion and its repo-root anchor must co-occur (guards against a bare
+  # `rev-parse --show-toplevel` that isn't wired to a .factory comparison).
+  grep -Eq 'show-toplevel.*\.factory|\.factory.*show-toplevel' "$HEALTH"
+}
+
+@test "factory-health warns against blind 'worktree remove --force' on a nested mount (#205)" {
+  # On assertion failure the skill must name the nested-mount shape and warn NOT
+  # to blindly remove .factory --force (the real worktree is .factory/.factory).
+  grep -qi 'nested' "$HEALTH"
+  grep -q '.factory/.factory' "$HEALTH"
+}
+
+@test "factory-health guards against a pre-existing plain .factory directory before mounting (#205/#203)" {
+  # Must handle the plain-dir case (e.g. onboard-created .factory/logs) rather
+  # than blindly `git worktree add` into it. mv-aside idiom mirrors the sibling
+  # factory-worktree-health skill.
+  grep -qi 'plain' "$HEALTH"
+}
+
+@test "onboard-observability refuses unless .factory is a mounted worktree (#203)" {
+  # Ordering prerequisite: detect .factory is a mounted worktree at repo root;
+  # refuse and point at factory-health otherwise.
+  grep -q 'rev-parse --show-toplevel' "$ONBOARD"
+  grep -qi 'factory-health' "$ONBOARD"
+}
+
+@test "onboard-observability 'When to use' no longer claims brand-new-just-installed (#203)" {
+  # The old line "Brand new project that just had the vsdd-factory plugin
+  # installed" contradicted the .factory prerequisite. It must be qualified so
+  # it no longer implies onboarding runs before .factory is mounted.
+  when_section="$(awk '/^## When to use/{f=1;next} /^## /{f=0} f' "$ONBOARD")"
+  ! printf '%s\n' "$when_section" | grep -qi 'just had the vsdd-factory plugin installed'
+}
+
+# ============================================================
+# Execution tests — validate the assertion logic (git behavior)
+# ============================================================
+
+@test "mount assertion PASSES for a healthy repo-root .factory worktree" {
+  cd "$REPO"
+  git worktree add -q .factory factory-artifacts >/dev/null
+  run _mount_ok "$REPO"
+  [ "$status" -eq 0 ]
+}
+
+@test "mount assertion FAILS for a nested .factory/.factory mount (#205 shape)" {
+  cd "$REPO"
+  mkdir .factory                                   # plain dir already present
+  git worktree add -q .factory/.factory factory-artifacts >/dev/null
+  # git -C .factory resolves to the PARENT toplevel, not <repo>/.factory
+  run _mount_ok "$REPO"
+  [ "$status" -ne 0 ]
+  # And the real worktree is nested one level down — proving why a blind
+  # `git worktree remove .factory --force` is the wrong recovery.
+  [ -e "$REPO/.factory/.factory/.git" ]
+}
+
+@test "mount assertion FAILS for a plain .factory/logs dir (onboard-first, #203 shape)" {
+  cd "$REPO"
+  mkdir -p .factory/logs
+  echo evt > .factory/logs/events-1.jsonl
+  run _mount_ok "$REPO"
+  [ "$status" -ne 0 ]
+  # Distinguish plain dir from worktree: .factory is NOT in the worktree list.
+  run bash -c "git -C '$REPO' worktree list --porcelain | grep -qx 'worktree $REPO/.factory'"
+  [ "$status" -ne 0 ]
+}
+
+@test "mount assertion FAILS when .factory is absent" {
+  cd "$REPO"
+  run _mount_ok "$REPO"
+  [ "$status" -ne 0 ]
+}

--- a/plugins/vsdd-factory/tests/factory-mount-guards.bats
+++ b/plugins/vsdd-factory/tests/factory-mount-guards.bats
@@ -22,13 +22,17 @@
 # exactly the plain-dir that makes the bare mount fail (`already exists`) —
 # the state from which #205's nested layout was observed.
 #
-# TWO KINDS OF TEST HERE:
+# THREE KINDS OF TEST HERE:
 #   1. Content-contract (grep) tests — RED before the skill edits, GREEN after.
 #      They assert the skills carry the required assertion / guard / prereq text.
-#   2. Execution tests — fabricate real git layouts and prove the mount
-#      assertion the skill now prescribes actually distinguishes healthy from
-#      nested / plain-dir / absent. These validate git LOGIC (independent of the
-#      prose), so they pass on any git; the RED/GREEN gate is the grep tests.
+#   2. Assertion-logic tests — fabricate real git layouts and prove the mount
+#      assertion the skill prescribes actually distinguishes healthy from
+#      nested / plain-dir / absent. These validate git LOGIC (independent of
+#      the prose), so they pass on any git.
+#   3. Shipped-block execution tests — EXTRACT the fenced bash blocks from the
+#      SKILL.md files and execute that exact text against fabricated layouts.
+#      A typo or an inert guard in the shipped snippet fails these, not just
+#      the greps (load-bearing closure per TD-VSDD-059).
 #
 # Traces to: issues #205, #203 (root-cause dispatcher race is #206, separate PR).
 
@@ -67,6 +71,31 @@ _mount_ok() {
   local top
   top="$(git -C "$1/.factory" rev-parse --show-toplevel 2>/dev/null)" || return 1
   [ "$top" = "$1/.factory" ]
+}
+
+# Extract a fenced ```bash block from a SKILL.md: the first block whose body
+# matches the given ERE, with the bullet's 2-space indent stripped. Running
+# the extracted text binds these tests to the exact snippet the plugin ships.
+_extract_block() {
+  local file="$1" pat="$2"
+  awk -v pat="$pat" '
+    /^[[:space:]]*```/ {
+      if (inblock) {
+        if (buf ~ pat) { printf "%s", buf; exit }
+        inblock = 0; buf = ""
+      } else {
+        inblock = 1
+      }
+      next
+    }
+    inblock { line = $0; sub(/^  /, "", line); buf = buf line "\n" }
+  ' "$file"
+}
+
+# Run an extracted block with cwd set to the repo (subshell contains `exit 1`).
+_run_block() {
+  local repo="$1" block="$2"
+  ( cd "$repo" && eval "$block" )
 }
 
 # ============================================================
@@ -150,4 +179,112 @@ _mount_ok() {
   cd "$REPO"
   run _mount_ok "$REPO"
   [ "$status" -ne 0 ]
+}
+
+# ============================================================
+# Shipped-block execution tests — the EXACT SKILL.md snippets
+# ============================================================
+
+@test "shipped mount block: mounts .factory at repo root from a clean state" {
+  local block
+  block="$(_extract_block "$HEALTH" 'worktree add \.factory factory-artifacts')"
+  [ -n "$block" ]
+  run _run_block "$REPO" "$block"
+  [ "$status" -eq 0 ]
+  run _mount_ok "$REPO"
+  [ "$status" -eq 0 ]
+}
+
+@test "shipped mount block: plain .factory/logs dir is guarded, mounted over, contents restored (#203)" {
+  mkdir -p "$REPO/.factory/logs"
+  echo evt > "$REPO/.factory/logs/events-1.jsonl"
+
+  local block
+  block="$(_extract_block "$HEALTH" 'worktree add \.factory factory-artifacts')"
+  run _run_block "$REPO" "$block"
+  [ "$status" -eq 0 ]
+
+  # Mounted at root — the F1 failure mode was `fatal: '.factory' already
+  # exists` because the rev-parse --git-dir guard never fired on a plain dir.
+  run _mount_ok "$REPO"
+  [ "$status" -eq 0 ]
+  # Backed-up contents restored into the fresh worktree, backup removed.
+  [ -f "$REPO/.factory/logs/events-1.jsonl" ]
+  run bash -c "ls -d '$REPO'/.factory-backup-* 2>/dev/null"
+  [ "$status" -ne 0 ]
+}
+
+@test "shipped mount block: nested .factory/.factory is refused, recovery block heals it, re-run mounts (#205)" {
+  # Fabricate the nested corrupt layout with wrapper contents worth preserving.
+  mkdir -p "$REPO/.factory/logs"
+  echo evt > "$REPO/.factory/logs/events-1.jsonl"
+  git -C "$REPO" worktree add -q .factory/.factory factory-artifacts >/dev/null
+
+  local mount_block recovery_block
+  mount_block="$(_extract_block "$HEALTH" 'worktree add \.factory factory-artifacts')"
+  recovery_block="$(_extract_block "$HEALTH" 'worktree remove \.factory/\.factory')"
+  [ -n "$recovery_block" ]
+
+  # Mount block must HALT (not mount over, not mv-aside a live nested worktree).
+  run _run_block "$REPO" "$mount_block"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"nested"* ]]
+
+  # Recovery: positively confirmed shape → remove nested worktree, set wrapper
+  # aside, prune the dangling registration.
+  run _run_block "$REPO" "$recovery_block"
+  [ "$status" -eq 0 ]
+  [ ! -e "$REPO/.factory" ]
+
+  # Re-run of the mount block completes the heal and restores wrapper contents.
+  run _run_block "$REPO" "$mount_block"
+  [ "$status" -eq 0 ]
+  run _mount_ok "$REPO"
+  [ "$status" -eq 0 ]
+  [ -f "$REPO/.factory/logs/events-1.jsonl" ]
+}
+
+@test "shipped recovery block: refuses to touch a layout that is not the confirmed nested shape" {
+  # A healthy repo-root mount must survive an accidental recovery invocation.
+  git -C "$REPO" worktree add -q .factory factory-artifacts >/dev/null
+  local recovery_block
+  recovery_block="$(_extract_block "$HEALTH" 'worktree remove \.factory/\.factory')"
+  run _run_block "$REPO" "$recovery_block"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not the known nested shape"* ]]
+  # Nothing was deleted or moved.
+  run _mount_ok "$REPO"
+  [ "$status" -eq 0 ]
+}
+
+@test "shipped mount block: prunes a stale registration before re-adding (bad prior recovery)" {
+  # Simulate the historical bad recovery: worktree mounted, then rm -rf'd
+  # without `git worktree remove`, leaving a dangling .git/worktrees entry.
+  git -C "$REPO" worktree add -q .factory factory-artifacts >/dev/null
+  rm -rf "$REPO/.factory"
+
+  local block
+  block="$(_extract_block "$HEALTH" 'worktree add \.factory factory-artifacts')"
+  run _run_block "$REPO" "$block"
+  [ "$status" -eq 0 ]
+  run _mount_ok "$REPO"
+  [ "$status" -eq 0 ]
+}
+
+@test "shipped onboard-observability prerequisite: halts on plain dir, passes on healthy mount (#203)" {
+  local prereq
+  prereq="$(_extract_block "$ONBOARD" 'factory-health first')"
+  [ -n "$prereq" ]
+
+  # Plain dir (onboard-first shape): the prerequisite must hard-stop.
+  mkdir -p "$REPO/.factory/logs"
+  run _run_block "$REPO" "$prereq"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"factory-health"* ]]
+
+  # Healthy mount: the prerequisite passes.
+  rm -rf "$REPO/.factory"
+  git -C "$REPO" worktree add -q .factory factory-artifacts >/dev/null
+  run _run_block "$REPO" "$prereq"
+  [ "$status" -eq 0 ]
 }

--- a/plugins/vsdd-factory/tests/factory-mount-guards.bats
+++ b/plugins/vsdd-factory/tests/factory-mount-guards.bats
@@ -5,11 +5,12 @@
 # .factory factory-artifacts` with NO post-mount assertion. If `.factory`
 # already exists as a plain non-empty directory (the #203 onboard-first case),
 # that command fails on current git (`fatal: '.factory' already exists`;
-# verified 2.50/2.55 — an empty dir mounts cleanly). Nested mounts at
-# `.factory/.factory` have been observed from that state (#205) via nested
-# add paths used in recovery or a process re-creating `.factory` mid-mount;
-# the execution tests below FABRICATE that layout rather than reproduce it
-# from the bare command. Once nested, step 3's
+# verified 2.50/2.55 — an empty dir mounts cleanly). A nested mount at
+# `.factory/.factory` was observed once from that state (#205); the mechanism
+# is unconfirmed — the reporter could not reproduce it in isolation, and the
+# candidates are a nested add path during error recovery or a process
+# re-creating `.factory` mid-mount. The execution tests below FABRICATE that
+# layout rather than reproduce it from the bare command. Once nested, step 3's
 # `cd .factory && git branch --show-current` reads the PARENT branch, and
 # the documented recovery `git worktree remove .factory --force` does not fix
 # it because `.factory` is not the worktree — the worktree is `.factory/.factory`.
@@ -18,7 +19,8 @@
 # "When to use: brand new project that just had the plugin installed" while its
 # Prerequisites require a `.factory/` ancestor — a contradiction. Running it
 # before factory-health creates a plain `.factory/logs/` directory, which is
-# exactly the plain-dir that makes the #205 nested mount happen.
+# exactly the plain-dir that makes the bare mount fail (`already exists`) —
+# the state from which #205's nested layout was observed.
 #
 # TWO KINDS OF TEST HERE:
 #   1. Content-contract (grep) tests — RED before the skill edits, GREEN after.

--- a/plugins/vsdd-factory/tests/factory-mount-guards.bats
+++ b/plugins/vsdd-factory/tests/factory-mount-guards.bats
@@ -3,9 +3,14 @@
 #
 # Issue #205: factory-health/SKILL.md step 2 runs a bare `git worktree add
 # .factory factory-artifacts` with NO post-mount assertion. If `.factory`
-# already exists as a plain directory (the #203 onboard-first case), git
-# mounts the worktree NESTED at `.factory/.factory`. Step 3's
-# `cd .factory && git branch --show-current` then reads the PARENT branch, and
+# already exists as a plain non-empty directory (the #203 onboard-first case),
+# that command fails on current git (`fatal: '.factory' already exists`;
+# verified 2.50/2.55 — an empty dir mounts cleanly). Nested mounts at
+# `.factory/.factory` have been observed from that state (#205) via nested
+# add paths used in recovery or a process re-creating `.factory` mid-mount;
+# the execution tests below FABRICATE that layout rather than reproduce it
+# from the bare command. Once nested, step 3's
+# `cd .factory && git branch --show-current` reads the PARENT branch, and
 # the documented recovery `git worktree remove .factory --force` does not fix
 # it because `.factory` is not the worktree — the worktree is `.factory/.factory`.
 #


### PR DESCRIPTION
## Why

`/factory-health` mounts `.factory/` with a bare `git worktree add .factory factory-artifacts` and never checks where it landed. If `.factory/` already exists as a plain **non-empty** directory, the bare command fails on current git (`fatal: '.factory' already exists`; verified 2.50/2.55) — and a nested mount at `.factory/.factory` has been observed once from that state (#205; mechanism unconfirmed — candidates are a nested add during error recovery or a racing re-create mid-mount). Under the nested layout the whole check silently misbehaves: step 3's `cd .factory && git branch --show-current` reads the **parent** branch (so a corrupt layout looks healthy), and the documented recovery `git worktree remove .factory --force` can't fix it because `.factory` isn't the worktree — the worktree is one level down.

The plain-directory precondition isn't hypothetical: `/onboard-observability` creates one. Its "When to use" says "brand new project that just had the vsdd-factory plugin installed," but its Prerequisites require a `.factory/` ancestor — a contradiction. Run onboarding first and `factory-obs register` drops a plain `.factory/logs/`, which is exactly the plain dir that makes the bare mount fail (`already exists`) when `/factory-health` runs later — the state from which #205's nested layout was observed.

This adds the missing post-mount assertion and a plain-dir guard to `/factory-health`, and gives `/onboard-observability` an explicit ordering prerequisite so it refuses to run before the mount exists.

## What changed

Class 0 — skill instruction text only; no engine/hook code.

- **`skills/factory-health/SKILL.md`** step 2:
  - Pre-mount **plain-dir guard**: if `.factory` exists but isn't a worktree, `mv` it aside before `git worktree add`, with a commented restore step for its contents (mirrors the mv-aside idiom already used by the sibling `/factory-worktree-health` skill).
  - Post-mount **assertion**: `[ "$(git -C .factory rev-parse --show-toplevel)" = "$(git rev-parse --show-toplevel)/.factory" ]`, aborting on mismatch.
  - On failure, names the **nested-mount** shape and explicitly says NOT to run `git worktree remove .factory --force` — instead remove the real nested worktree (`.factory/.factory`) and re-run from the guard.
- **`skills/onboard-observability/SKILL.md`**:
  - Prerequisite 1 now asserts `.factory/` is a **mounted worktree at the repo root** (same `rev-parse --show-toplevel` check) and, on failure, refuses with "run `/factory-health` first" rather than creating `.factory/`.
  - "When to use" no longer claims "brand new project that just had the plugin installed"; it states onboarding runs **after** `/factory-health` has mounted `.factory/`, resolving the contradiction with the prerequisite.
- **New suite `tests/factory-mount-guards.bats`** (9 tests): 5 content-contract greps (RED before these edits, GREEN after) asserting the assertion / nested-mount warning / plain-dir guard / onboard prerequisite / corrected "When to use" text are present; plus 4 execution tests that fabricate real git layouts (healthy, nested `.factory/.factory`, plain `.factory/logs`, absent) and prove the assertion command distinguishes them.

## Test evidence

New suite `tests/factory-mount-guards.bats`, run against this worktree (bats 1.x, git 2.50.1).

RED (before the skill edits — the 5 content-contract tests fail; the 4 execution tests already pass because they validate git logic, not prose):
```
not ok 1 factory-health step 2 has a post-mount assertion on .factory toplevel (#205)
not ok 2 factory-health warns against blind 'worktree remove --force' on a nested mount (#205)
not ok 3 factory-health guards against a pre-existing plain .factory directory before mounting (#205/#203)
not ok 4 onboard-observability refuses unless .factory is a mounted worktree (#203)
not ok 5 onboard-observability 'When to use' no longer claims brand-new-just-installed (#203)
ok 6 mount assertion PASSES for a healthy repo-root .factory worktree
ok 7 mount assertion FAILS for a nested .factory/.factory mount (#205 shape)
ok 8 mount assertion FAILS for a plain .factory/logs dir (onboard-first, #203 shape)
ok 9 mount assertion FAILS when .factory is absent
```

GREEN (after the skill edits — all 9 pass):
```
ok 1 .. ok 9   (9 tests, 0 failures)
```

No regressions: `tests/skills.bats` (incl. the onboard-observability structure + model-invocable checks) and `tests/factory-lock-status.bats` (which greps `factory-health/SKILL.md`) both still pass; `tests/check-bats-orphans.sh` passes.

**One honest caveat on the execution tests.** The `#205` report states that the recovery `git worktree remove .factory --force` *fails* under a nested mount. On git 2.50.1 that command returned exit 0 in my repro (it prunes the plain-dir entry but does not touch the real nested worktree, so it's ineffective rather than erroring). The tests therefore do NOT assert that removal errors — they assert the two things that reproduce deterministically: the mount assertion detects the nested layout, and the real worktree is at `.factory/.factory` (proving the blind removal targets the wrong path). The fix text warns against the blind removal on the "wrong path" grounds, which holds regardless of git's exit code.

## Reviewer note — scope and #203/#206 mapping

Refs, not Closes. The **root cause** of the nested-mount race — the dispatcher mounting `.factory` while a plain dir exists — lives in the dispatcher and is tracked separately as #206 (its own PR). This PR is the skill-text defense-in-depth: it makes `/factory-health` detect and refuse the corrupt layout, and stops `/onboard-observability` from *creating* the plain dir that provokes it. #203's full closure (the onboarding-ordering contradiction) depends on #206 landing the dispatcher-side ordering guarantee; this PR removes the skill-level contradiction and the foot-gun but does not by itself close the race. Hence both trailers are `Refs:`.

Refs: #205
Refs: #203

