### PR TITLE
fix(dispatcher): gate .factory/logs creation on a mounted worktree — stop racing bootstrap

### DIFF
--- a/crates/factory-dispatcher/src/internal_log.rs
+++ b/crates/factory-dispatcher/src/internal_log.rs
@@ -246,19 +246,36 @@ pub struct InternalLog {
     /// once per dispatcher session instead of once per event. Shared across
     /// clones like `seen_errors`.
     gate_warned: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    /// Whether the #206 mount gate applies. `true` for resolved (level C–G)
+    /// log dirs; `false` when the operator explicitly chose the location via
+    /// `VSDD_LOG_DIR` / `FACTORY_ROOT` (level A/B) — an explicit override
+    /// must not itself be overridden, even when it points at a `.factory/logs`
+    /// path (the bats harness does exactly that with scratch fixtures).
+    mount_gated: bool,
 }
 
 impl InternalLog {
     /// Build a writer rooted at `log_dir`. The directory is NOT created
-    /// eagerly; `write` will `mkdir -p` on first use — and only once the
-    /// `.factory` parent is a mounted worktree (see
-    /// [`crate::log_dir::factory_mount_ready`], issue #206).
+    /// eagerly; `write` will `mkdir -p` on first use — and, by default, only
+    /// once the `.factory` parent is a mounted worktree (see
+    /// [`crate::log_dir::factory_mount_ready`], issue #206). Callers whose
+    /// `log_dir` came from an explicit operator override should disable the
+    /// gate via [`InternalLog::with_mount_gate`].
     pub fn new(log_dir: PathBuf) -> Self {
         Self {
             log_dir,
             seen_errors: std::sync::Arc::new(Mutex::new(HashSet::new())),
             gate_warned: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            mount_gated: true,
         }
+    }
+
+    /// Set whether the #206 mount gate applies. Pass `false` when the log
+    /// dir came from an explicit `VSDD_LOG_DIR` / `FACTORY_ROOT` override.
+    #[must_use]
+    pub fn with_mount_gate(mut self, gated: bool) -> Self {
+        self.mount_gated = gated;
+        self
     }
 
     /// Best-effort append. Never panics, never propagates errors. On
@@ -301,11 +318,13 @@ impl InternalLog {
         // Issue #206: never create `.factory/logs` ahead of the worktree
         // mount. The dispatcher fires on every tool use, so an unconditional
         // mkdir here continuously recreated a plain `.factory/` during
-        // `/factory-health` bootstrap, forcing the later `git worktree add`
-        // to nest at `.factory/.factory` (#203/#205). Suppression is a skip,
-        // not an error — events during the bootstrap window are still
-        // observable via `VSDD_SINK_FILE`.
-        if !crate::log_dir::factory_mount_ready(&self.log_dir) {
+        // `/factory-health` bootstrap — blocking the later `git worktree add`
+        // (`fatal: '.factory' already exists`) and feeding the #203/#205
+        // bootstrap-failure cluster. Suppression is a skip, not an error —
+        // events during the bootstrap window are still observable via
+        // `VSDD_SINK_FILE`. Explicit VSDD_LOG_DIR / FACTORY_ROOT overrides
+        // are exempt (`mount_gated == false`): the operator chose the path.
+        if self.mount_gated && !crate::log_dir::factory_mount_ready(&self.log_dir) {
             if !self
                 .gate_warned
                 .swap(true, std::sync::atomic::Ordering::Relaxed)
@@ -588,6 +607,29 @@ mod tests {
         assert!(
             !factory.join("logs").exists(),
             "plain .factory dir must not gain logs/ — that is the bootstrap race"
+        );
+    }
+
+    /// Issue #206: an explicit override (`with_mount_gate(false)`, the
+    /// VSDD_LOG_DIR / FACTORY_ROOT path) writes even into a plain `.factory`
+    /// with no `.git` — the operator chose the location; the gate must not
+    /// override the override.
+    #[test]
+    fn gate_bypassed_for_explicit_override() {
+        let dir = tempfile::tempdir().unwrap();
+        let factory = dir.path().join(".factory");
+        stdfs::create_dir_all(&factory).unwrap();
+        let log = InternalLog::new(factory.join("logs")).with_mount_gate(false);
+        let ts = Local.with_ymd_and_hms(2026, 1, 15, 9, 30, 0).unwrap();
+
+        log.write(&InternalEvent::with_ts(DISPATCHER_STARTED, ts));
+
+        let expected = factory
+            .join("logs")
+            .join(format!("{FILENAME_PREFIX}2026-01-15{FILENAME_SUFFIX}"));
+        assert!(
+            expected.exists(),
+            "explicit override must write regardless of mount state"
         );
     }
 

--- a/crates/factory-dispatcher/src/internal_log.rs
+++ b/crates/factory-dispatcher/src/internal_log.rs
@@ -246,11 +246,13 @@ pub struct InternalLog {
     /// once per dispatcher session instead of once per event. Shared across
     /// clones like `seen_errors`.
     gate_warned: std::sync::Arc<std::sync::atomic::AtomicBool>,
-    /// Whether the #206 mount gate applies. `true` for resolved (level C–G)
-    /// log dirs; `false` when the operator explicitly chose the location via
-    /// `VSDD_LOG_DIR` / `FACTORY_ROOT` (level A/B) — an explicit override
-    /// must not itself be overridden, even when it points at a `.factory/logs`
-    /// path (the bats harness does exactly that with scratch fixtures).
+    /// Whether the #206 mount gate applies. `true` for resolved (level B–G)
+    /// log dirs; `false` only when the operator explicitly chose the location
+    /// via `VSDD_LOG_DIR` (level A) — an explicit override must not itself be
+    /// overridden, even when it points at a `.factory/logs` path (the bats
+    /// harness does exactly that with scratch fixtures). `FACTORY_ROOT`
+    /// (level B) is deliberately NOT exempt: it resolves to
+    /// `$FACTORY_ROOT/logs`, the racing shape the gate holds back.
     mount_gated: bool,
 }
 
@@ -270,8 +272,9 @@ impl InternalLog {
         }
     }
 
-    /// Set whether the #206 mount gate applies. Pass `false` when the log
-    /// dir came from an explicit `VSDD_LOG_DIR` / `FACTORY_ROOT` override.
+    /// Set whether the #206 mount gate applies. Pass `false` only when the
+    /// log dir came from an explicit `VSDD_LOG_DIR` (level A) override — see
+    /// `crate::log_dir::mount_gate_exempt`.
     #[must_use]
     pub fn with_mount_gate(mut self, gated: bool) -> Self {
         self.mount_gated = gated;
@@ -322,8 +325,8 @@ impl InternalLog {
         // (`fatal: '.factory' already exists`) and feeding the #203/#205
         // bootstrap-failure cluster. Suppression is a skip, not an error —
         // events during the bootstrap window are still observable via
-        // `VSDD_SINK_FILE`. Explicit VSDD_LOG_DIR / FACTORY_ROOT overrides
-        // are exempt (`mount_gated == false`): the operator chose the path.
+        // `VSDD_SINK_FILE`. Only an explicit VSDD_LOG_DIR override is exempt
+        // (`mount_gated == false`): the operator chose that exact path.
         if self.mount_gated && !crate::log_dir::factory_mount_ready(&self.log_dir) {
             if !self
                 .gate_warned
@@ -610,10 +613,10 @@ mod tests {
         );
     }
 
-    /// Issue #206: an explicit override (`with_mount_gate(false)`, the
-    /// VSDD_LOG_DIR / FACTORY_ROOT path) writes even into a plain `.factory`
+    /// Issue #206: an explicit override (`with_mount_gate(false)`, reached
+    /// only via VSDD_LOG_DIR — level A) writes even into a plain `.factory`
     /// with no `.git` — the operator chose the location; the gate must not
-    /// override the override.
+    /// override the override. FACTORY_ROOT does NOT reach this path (#738).
     #[test]
     fn gate_bypassed_for_explicit_override() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/factory-dispatcher/src/internal_log.rs
+++ b/crates/factory-dispatcher/src/internal_log.rs
@@ -242,15 +242,22 @@ pub struct InternalLog {
     /// Shared via `Arc` so every `clone()` of `InternalLog` participates in the
     /// same dedup window (one process invocation = one dispatcher session).
     seen_errors: std::sync::Arc<Mutex<HashSet<u64>>>,
+    /// One-shot flag so the mount-gate suppression (issue #206) warns exactly
+    /// once per dispatcher session instead of once per event. Shared across
+    /// clones like `seen_errors`.
+    gate_warned: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl InternalLog {
     /// Build a writer rooted at `log_dir`. The directory is NOT created
-    /// eagerly; `write` will `mkdir -p` on first use.
+    /// eagerly; `write` will `mkdir -p` on first use — and only once the
+    /// `.factory` parent is a mounted worktree (see
+    /// [`crate::log_dir::factory_mount_ready`], issue #206).
     pub fn new(log_dir: PathBuf) -> Self {
         Self {
             log_dir,
             seen_errors: std::sync::Arc::new(Mutex::new(HashSet::new())),
+            gate_warned: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
     }
 
@@ -289,6 +296,28 @@ impl InternalLog {
                     // Poisoned mutex — write anyway to avoid silent loss.
                 }
             }
+        }
+
+        // Issue #206: never create `.factory/logs` ahead of the worktree
+        // mount. The dispatcher fires on every tool use, so an unconditional
+        // mkdir here continuously recreated a plain `.factory/` during
+        // `/factory-health` bootstrap, forcing the later `git worktree add`
+        // to nest at `.factory/.factory` (#203/#205). Suppression is a skip,
+        // not an error — events during the bootstrap window are still
+        // observable via `VSDD_SINK_FILE`.
+        if !crate::log_dir::factory_mount_ready(&self.log_dir) {
+            if !self
+                .gate_warned
+                .swap(true, std::sync::atomic::Ordering::Relaxed)
+            {
+                eprintln!(
+                    "factory-dispatcher: internal_log suppressed — parent of {} is not a \
+                     mounted .factory worktree yet (no .git entry); run /factory-health to \
+                     mount it, or set VSDD_LOG_DIR to log elsewhere",
+                    self.log_dir.display()
+                );
+            }
+            return Ok(());
         }
 
         fs::create_dir_all(&self.log_dir)?;
@@ -524,6 +553,62 @@ mod tests {
         assert!(expected.exists());
         let lines = read_lines(&expected);
         assert_eq!(lines.len(), 1);
+    }
+
+    /// Issue #206: when the log dir is `.factory/logs` and `.factory` does not
+    /// exist, `write` must NOT create it — a plain `.factory/` planted here
+    /// forces the later `git worktree add .factory` to mount nested.
+    #[test]
+    fn gate_skips_write_when_factory_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let factory = dir.path().join(".factory");
+        let log = InternalLog::new(factory.join("logs"));
+        let ts = Local.with_ymd_and_hms(2026, 1, 15, 9, 30, 0).unwrap();
+
+        log.write(&InternalEvent::with_ts(DISPATCHER_STARTED, ts));
+
+        assert!(
+            !factory.exists(),
+            ".factory must not be created by the internal log ahead of the mount"
+        );
+    }
+
+    /// Issue #206/#203: `.factory` existing as a PLAIN directory (the
+    /// onboard-before-health conflict state) must not gain a `logs/` child.
+    #[test]
+    fn gate_skips_write_into_plain_factory_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let factory = dir.path().join(".factory");
+        stdfs::create_dir_all(&factory).unwrap();
+        let log = InternalLog::new(factory.join("logs"));
+        let ts = Local.with_ymd_and_hms(2026, 1, 15, 9, 30, 0).unwrap();
+
+        log.write(&InternalEvent::with_ts(DISPATCHER_STARTED, ts));
+
+        assert!(
+            !factory.join("logs").exists(),
+            "plain .factory dir must not gain logs/ — that is the bootstrap race"
+        );
+    }
+
+    /// Issue #206 control: a mounted `.factory` (a `.git` FILE, the
+    /// `git worktree add` shape) writes exactly as before.
+    #[test]
+    fn gate_allows_write_into_mounted_factory() {
+        let dir = tempfile::tempdir().unwrap();
+        let factory = dir.path().join(".factory");
+        stdfs::create_dir_all(&factory).unwrap();
+        stdfs::write(factory.join(".git"), "gitdir: ../.git/worktrees/.factory\n").unwrap();
+        let log = InternalLog::new(factory.join("logs"));
+        let ts = Local.with_ymd_and_hms(2026, 1, 15, 9, 30, 0).unwrap();
+
+        log.write(&InternalEvent::with_ts(DISPATCHER_STARTED, ts));
+
+        let expected = factory
+            .join("logs")
+            .join(format!("{FILENAME_PREFIX}2026-01-15{FILENAME_SUFFIX}"));
+        assert!(expected.exists(), "mounted .factory must write normally");
+        assert_eq!(read_lines(&expected).len(), 1);
     }
 
     #[test]

--- a/crates/factory-dispatcher/src/log_dir.rs
+++ b/crates/factory-dispatcher/src/log_dir.rs
@@ -159,6 +159,36 @@ fn is_factory_name(s: &str) -> bool {
     s.eq_ignore_ascii_case(".factory")
 }
 
+/// Returns `true` when writing into `log_dir` cannot race the `.factory`
+/// worktree bootstrap (issue #206).
+///
+/// Every level C–G resolution is shaped `<root>/.factory/logs`. Creating that
+/// directory while `.factory` is absent — or while it exists only as a plain
+/// directory with no `.git` entry — plants exactly the plain `.factory/` that
+/// makes a later `git worktree add .factory factory-artifacts` mount NESTED at
+/// `.factory/.factory` (issues #203/#205). The dispatcher fires on every tool
+/// use, so its unconditional `mkdir -p` continuously recreated that state
+/// during `/factory-health` setup.
+///
+/// Ready iff the `.factory` parent exists AND carries a `.git` entry — a
+/// worktree mount has a `.git` *file*, a plain checkout a `.git` *dir*; both
+/// count. A `log_dir` whose parent is not named `.factory` (a `VSDD_LOG_DIR` /
+/// `FACTORY_ROOT` override pointing elsewhere) is always ready: the override
+/// path cannot collide with the mount. An override deliberately pointing at an
+/// unmounted `.factory/logs` is gated like the resolved shape — creating the
+/// plain dir would cause the same nested mount regardless of who asked.
+pub fn factory_mount_ready(log_dir: &Path) -> bool {
+    let Some(parent) = log_dir.parent() else {
+        return true;
+    };
+    if !is_dot_factory_basename(parent) {
+        return true;
+    }
+    // `.git` is a file for `git worktree add` mounts and a directory for a
+    // plain checkout; `exists()` accepts both.
+    parent.join(".git").exists()
+}
+
 /// Walk the parent chain from `start` upward. Returns the first ancestor
 /// whose basename is `.factory`, or `None` if the filesystem root is reached
 /// or a symlink loop is detected.
@@ -315,6 +345,67 @@ fn read_piped_stdout(child: &mut std::process::Child) -> Vec<u8> {
         let _ = stdout.read_to_end(&mut buf);
     }
     buf
+}
+
+#[cfg(test)]
+mod factory_mount_ready_tests {
+    use super::*;
+
+    /// Issue #206: `.factory` absent → NOT ready. The dispatcher must not
+    /// plant a plain `.factory/` ahead of the worktree mount.
+    #[test]
+    fn test_not_ready_when_factory_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_dir = dir.path().join(".factory").join("logs");
+        assert!(
+            !factory_mount_ready(&log_dir),
+            "must not be ready when .factory does not exist"
+        );
+    }
+
+    /// Issue #206/#203: `.factory` exists as a plain directory (the
+    /// onboard-before-health state) → NOT ready. Writing into it is the race.
+    #[test]
+    fn test_not_ready_for_plain_factory_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let factory = dir.path().join(".factory");
+        std::fs::create_dir_all(&factory).unwrap();
+        assert!(
+            !factory_mount_ready(&factory.join("logs")),
+            "plain .factory dir without .git is the bootstrap-conflict state"
+        );
+    }
+
+    /// `.factory` with a `.git` FILE — the `git worktree add` mount shape —
+    /// is ready.
+    #[test]
+    fn test_ready_for_worktree_mount_git_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let factory = dir.path().join(".factory");
+        std::fs::create_dir_all(&factory).unwrap();
+        std::fs::write(factory.join(".git"), "gitdir: ../.git/worktrees/.factory\n").unwrap();
+        assert!(factory_mount_ready(&factory.join("logs")));
+    }
+
+    /// `.factory` with a `.git` DIRECTORY — a plain checkout of the artifact
+    /// branch (the CI mount shape) — is ready.
+    #[test]
+    fn test_ready_for_checkout_git_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let factory = dir.path().join(".factory");
+        std::fs::create_dir_all(factory.join(".git")).unwrap();
+        assert!(factory_mount_ready(&factory.join("logs")));
+    }
+
+    /// A log dir whose parent is not named `.factory` (VSDD_LOG_DIR /
+    /// FACTORY_ROOT override elsewhere) is always ready — it cannot collide
+    /// with the worktree mount.
+    #[test]
+    fn test_override_path_always_ready() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_dir = dir.path().join("custom-diagnostics").join("logs");
+        assert!(factory_mount_ready(&log_dir));
+    }
 }
 
 #[cfg(test)]

--- a/crates/factory-dispatcher/src/log_dir.rs
+++ b/crates/factory-dispatcher/src/log_dir.rs
@@ -170,14 +170,19 @@ fn is_factory_name(s: &str) -> bool {
 /// use, so its unconditional `mkdir -p` continuously recreated that state
 /// during `/factory-health` setup.
 ///
-/// Ready iff the `.factory` parent exists AND carries a `.git` entry — a
-/// worktree mount has a `.git` *file*, a plain checkout a `.git` *dir*; both
-/// count. A `log_dir` whose parent is not named `.factory` (a `VSDD_LOG_DIR` /
-/// `FACTORY_ROOT` override pointing elsewhere) is always ready: the override
-/// path cannot collide with the mount. This helper only classifies the path
-/// shape — explicit level A/B overrides are exempted wholesale by the caller
-/// (`InternalLog::with_mount_gate(false)`, wired in `main.rs`), so an operator
+/// Ready iff the `.factory` parent exists AND carries a `.git` entry that is
+/// a plausible git marker — a worktree mount has a `.git` *file* whose
+/// content is a `gitdir:` pointer, a plain checkout a `.git` *directory*;
+/// both count, but a dangling/garbage `.git` file does not. A `log_dir`
+/// whose parent is not named `.factory` (an override pointing elsewhere) is
+/// always ready: that path cannot collide with the mount. This helper only
+/// classifies the path shape — the explicit level A override (`VSDD_LOG_DIR`)
+/// is exempted wholesale by the caller ([`mount_gate_exempt`] →
+/// `InternalLog::with_mount_gate(false)`, wired in `main.rs`), so an operator
 /// pointing `VSDD_LOG_DIR` at a `.factory/logs` path is honored verbatim.
+/// Level B (`FACTORY_ROOT`) is NOT exempted: it resolves to
+/// `$FACTORY_ROOT/logs`, and the conventional `FACTORY_ROOT=<repo>/.factory`
+/// is exactly the racing shape this gate holds back.
 pub fn factory_mount_ready(log_dir: &Path) -> bool {
     let Some(parent) = log_dir.parent() else {
         return true;
@@ -185,9 +190,26 @@ pub fn factory_mount_ready(log_dir: &Path) -> bool {
     if !is_dot_factory_basename(parent) {
         return true;
     }
-    // `.git` is a file for `git worktree add` mounts and a directory for a
-    // plain checkout; `exists()` accepts both.
-    parent.join(".git").exists()
+    let git_entry = parent.join(".git");
+    // A `.git` DIRECTORY is a plain checkout of the artifact branch.
+    if git_entry.is_dir() {
+        return true;
+    }
+    // `git worktree add` mounts carry a `.git` FILE whose content is a
+    // `gitdir:` pointer. Any other content (or an unreadable/absent entry)
+    // is not a mount — the gate stays closed rather than trusting an
+    // arbitrary entry that happens to be named `.git`.
+    std::fs::read_to_string(&git_entry).is_ok_and(|s| s.trim_start().starts_with("gitdir:"))
+}
+
+/// Level-A override detection for the #206 mount-gate exemption: ONLY
+/// `VSDD_LOG_DIR` — the per-invocation diagnostic override, whose value is
+/// used verbatim — bypasses the gate. `FACTORY_ROOT` (level B) deliberately
+/// does not qualify; see [`factory_mount_ready`]. Parameterized on the env
+/// value so the exemption rule is unit-testable without process-global env
+/// mutation.
+pub fn mount_gate_exempt(vsdd_log_dir: Option<&str>) -> bool {
+    vsdd_log_dir.is_some_and(|v| !v.is_empty())
 }
 
 /// Walk the parent chain from `start` upward. Returns the first ancestor
@@ -398,14 +420,88 @@ mod factory_mount_ready_tests {
         assert!(factory_mount_ready(&factory.join("logs")));
     }
 
-    /// A log dir whose parent is not named `.factory` (VSDD_LOG_DIR /
-    /// FACTORY_ROOT override elsewhere) is always ready — it cannot collide
-    /// with the worktree mount.
+    /// A log dir whose parent is not named `.factory` (an override pointing
+    /// elsewhere) is always ready — it cannot collide with the worktree mount.
     #[test]
     fn test_override_path_always_ready() {
         let dir = tempfile::tempdir().unwrap();
         let log_dir = dir.path().join("custom-diagnostics").join("logs");
         assert!(factory_mount_ready(&log_dir));
+    }
+
+    /// A garbage `.git` FILE with no `gitdir:` pointer is not a mount — the
+    /// gate must not trust an arbitrary entry that is merely named `.git`.
+    #[test]
+    fn test_not_ready_for_garbage_git_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let factory = dir.path().join(".factory");
+        std::fs::create_dir_all(&factory).unwrap();
+        std::fs::write(factory.join(".git"), "not a git pointer\n").unwrap();
+        assert!(
+            !factory_mount_ready(&factory.join("logs")),
+            "a .git file without a gitdir: pointer is not a worktree mount"
+        );
+    }
+
+    /// An empty `.git` FILE (e.g. truncated by a crashed process) is not a
+    /// mount either.
+    #[test]
+    fn test_not_ready_for_empty_git_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let factory = dir.path().join(".factory");
+        std::fs::create_dir_all(&factory).unwrap();
+        std::fs::write(factory.join(".git"), "").unwrap();
+        assert!(!factory_mount_ready(&factory.join("logs")));
+    }
+}
+
+#[cfg(test)]
+mod mount_gate_exempt_tests {
+    use super::*;
+
+    /// Level A (VSDD_LOG_DIR) is the one and only gate exemption.
+    #[test]
+    fn test_vsdd_log_dir_is_exempt() {
+        assert!(mount_gate_exempt(Some("/tmp/scratch/.factory/logs")));
+    }
+
+    /// Absent or empty VSDD_LOG_DIR is not an override.
+    #[test]
+    fn test_absent_or_empty_vsdd_log_dir_not_exempt() {
+        assert!(!mount_gate_exempt(None));
+        assert!(!mount_gate_exempt(Some("")));
+    }
+
+    /// Level B (FACTORY_ROOT) stays gated end-to-end: with no VSDD_LOG_DIR
+    /// the exemption is off regardless of FACTORY_ROOT, the resolver maps
+    /// `FACTORY_ROOT=<x>/.factory` to `<x>/.factory/logs`, and
+    /// `factory_mount_ready` holds that path back until the worktree is
+    /// mounted — then admits it. (The #738 re-review HIGH scenario.)
+    #[test]
+    fn test_factory_root_derived_path_stays_gated_until_mounted() {
+        let dir = tempfile::tempdir().unwrap();
+        let factory_root = dir.path().join(".factory");
+        std::fs::create_dir_all(&factory_root).unwrap();
+        let factory_str = factory_root.to_str().unwrap();
+
+        // main.rs computes the exemption from VSDD_LOG_DIR alone — a set
+        // FACTORY_ROOT contributes nothing to it:
+        assert!(!mount_gate_exempt(None));
+
+        // The level-B resolution lands inside `.factory`...
+        let resolved = resolve_log_dir_from_params(None, Some(factory_str), None, dir.path());
+        assert_eq!(resolved, factory_root.join("logs"));
+
+        // ...which the gate refuses while `.factory` is a plain dir...
+        assert!(!factory_mount_ready(&resolved));
+
+        // ...and admits once the worktree mount shape exists.
+        std::fs::write(
+            factory_root.join(".git"),
+            "gitdir: ../.git/worktrees/.factory\n",
+        )
+        .unwrap();
+        assert!(factory_mount_ready(&resolved));
     }
 }
 

--- a/crates/factory-dispatcher/src/log_dir.rs
+++ b/crates/factory-dispatcher/src/log_dir.rs
@@ -174,9 +174,10 @@ fn is_factory_name(s: &str) -> bool {
 /// worktree mount has a `.git` *file*, a plain checkout a `.git` *dir*; both
 /// count. A `log_dir` whose parent is not named `.factory` (a `VSDD_LOG_DIR` /
 /// `FACTORY_ROOT` override pointing elsewhere) is always ready: the override
-/// path cannot collide with the mount. An override deliberately pointing at an
-/// unmounted `.factory/logs` is gated like the resolved shape — creating the
-/// plain dir would cause the same nested mount regardless of who asked.
+/// path cannot collide with the mount. This helper only classifies the path
+/// shape — explicit level A/B overrides are exempted wholesale by the caller
+/// (`InternalLog::with_mount_gate(false)`, wired in `main.rs`), so an operator
+/// pointing `VSDD_LOG_DIR` at a `.factory/logs` path is honored verbatim.
 pub fn factory_mount_ready(log_dir: &Path) -> bool {
     let Some(parent) = log_dir.parent() else {
         return true;

--- a/crates/factory-dispatcher/src/main.rs
+++ b/crates/factory-dispatcher/src/main.rs
@@ -79,7 +79,16 @@ const ENV_ASYNC_DRAIN_WINDOW_MS: &str = "VSDD_ASYNC_DRAIN_WINDOW_MS";
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    let internal_log = Arc::new(InternalLog::new(resolve_log_dir()));
+    // Explicit VSDD_LOG_DIR / FACTORY_ROOT overrides (resolution level A/B)
+    // bypass the #206 mount gate: the operator said exactly where to log, and
+    // suppressing that would override the override (the bats harness points
+    // VSDD_LOG_DIR at scratch `.factory/logs` fixtures, for example). Only
+    // resolved level C–G locations are gated on the worktree mount.
+    let explicit_override = ["VSDD_LOG_DIR", "FACTORY_ROOT"]
+        .iter()
+        .any(|k| std::env::var(k).is_ok_and(|v| !v.is_empty()));
+    let internal_log =
+        Arc::new(InternalLog::new(resolve_log_dir()).with_mount_gate(!explicit_override));
     internal_log.prune_old(DEFAULT_RETENTION_DAYS);
 
     let code = match run(internal_log.clone()).await {

--- a/crates/factory-dispatcher/src/main.rs
+++ b/crates/factory-dispatcher/src/main.rs
@@ -79,14 +79,19 @@ const ENV_ASYNC_DRAIN_WINDOW_MS: &str = "VSDD_ASYNC_DRAIN_WINDOW_MS";
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    // Explicit VSDD_LOG_DIR / FACTORY_ROOT overrides (resolution level A/B)
-    // bypass the #206 mount gate: the operator said exactly where to log, and
-    // suppressing that would override the override (the bats harness points
-    // VSDD_LOG_DIR at scratch `.factory/logs` fixtures, for example). Only
-    // resolved level C–G locations are gated on the worktree mount.
-    let explicit_override = ["VSDD_LOG_DIR", "FACTORY_ROOT"]
-        .iter()
-        .any(|k| std::env::var(k).is_ok_and(|v| !v.is_empty()));
+    // ONLY an explicit VSDD_LOG_DIR (resolution level A) bypasses the #206
+    // mount gate: the operator said exactly where to log, and suppressing
+    // that would override the override (the bats harness points VSDD_LOG_DIR
+    // at scratch `.factory/logs` fixtures, for example). FACTORY_ROOT
+    // (level B) stays GATED: it resolves to `$FACTORY_ROOT/logs`, and by the
+    // resolution contract FACTORY_ROOT names the `.factory` directory itself
+    // — the conventional `FACTORY_ROOT=<repo>/.factory` therefore yields
+    // exactly the racing shape the gate exists to hold back, on the
+    // mid-setup population most likely to hit it. When FACTORY_ROOT points
+    // anywhere not named `.factory`, the gate never fires anyway.
+    let explicit_override = factory_dispatcher::log_dir::mount_gate_exempt(
+        std::env::var("VSDD_LOG_DIR").ok().as_deref(),
+    );
     let internal_log =
         Arc::new(InternalLog::new(resolve_log_dir()).with_mount_gate(!explicit_override));
     internal_log.prune_old(DEFAULT_RETENTION_DAYS);

--- a/crates/factory-dispatcher/tests/internal_log_integration.rs
+++ b/crates/factory-dispatcher/tests/internal_log_integration.rs
@@ -31,10 +31,19 @@ fn read_lines(path: &Path) -> Vec<String> {
 #[test]
 fn startup_flow_writes_parseable_jsonl() {
     let dir = tempfile::tempdir().unwrap();
-    // Intentionally point at a nested path that does not exist yet to
-    // exercise the mkdir-p semantics in the same call path main.rs
-    // takes on a fresh checkout.
-    let log_dir = dir.path().join("repo").join(".factory").join("logs");
+    // `.factory` is fabricated as a mounted worktree (a `.git` FILE, the
+    // `git worktree add` shape): since issue #206 the internal log refuses to
+    // create `.factory/` itself — planting a plain `.factory` ahead of the
+    // mount is exactly the bootstrap race. `logs/` is still left absent to
+    // exercise the mkdir-p semantics main.rs relies on.
+    let factory_dir = dir.path().join("repo").join(".factory");
+    fs::create_dir_all(&factory_dir).unwrap();
+    fs::write(
+        factory_dir.join(".git"),
+        "gitdir: ../.git/worktrees/.factory\n",
+    )
+    .unwrap();
+    let log_dir = factory_dir.join("logs");
     let log = InternalLog::new(log_dir.clone());
 
     let trace_id = "trace-integration-1";

--- a/crates/factory-dispatcher/tests/issue_130_log_dir_shadow.rs
+++ b/crates/factory-dispatcher/tests/issue_130_log_dir_shadow.rs
@@ -66,6 +66,16 @@ fn test_BC_2_06_001_resolve_log_dir_cwd_inside_factory() {
     let factory_root = tmpdir.path().join(".factory");
     let cwd = factory_root.join("cycles").join("v1.0-pass-1");
     fs::create_dir_all(&cwd).expect("create simulated cwd");
+    // Since issue #206 the internal log refuses to write while `.factory` is
+    // not a mounted worktree (no `.git` entry): fabricate the mount shape (a
+    // `.git` FILE, as `git worktree add` produces) so the mkdir-p assertion
+    // below still exercises the write path. The shadow assertion this test
+    // exists for is unchanged.
+    fs::write(
+        factory_root.join(".git"),
+        "gitdir: ../.git/worktrees/.factory\n",
+    )
+    .expect("fabricate worktree .git file");
 
     // H-2: hermetic call — explicit None for all env-var params.
     // This test does NOT depend on the developer/CI shell having

--- a/docs/guide/migrating-from-0.79.md
+++ b/docs/guide/migrating-from-0.79.md
@@ -129,7 +129,11 @@ After the upgrade procedure completes, confirm the following:
   changes are required.
 - [ ] **Dispatcher log has entries.** Open
   `.factory/logs/dispatcher-internal.jsonl` and confirm it exists and
-  has recent entries (timestamps within the current session).
+  has recent entries (timestamps within the current session). If the file
+  is missing or empty, check `/vsdd-factory:factory-health` first: the
+  dispatcher deliberately skips internal-log writes while `.factory` is
+  not yet a mounted worktree (it emits a once-per-session stderr notice),
+  so an empty log can mean "mount the worktree", not "dispatcher broken".
 - [ ] **Factory health is green.** `/vsdd-factory:factory-health` reports
   all checks passing.
 - [ ] **Plugin version is correct.** The health check output includes the
@@ -222,7 +226,11 @@ If v1.0 misbehaves on your factory and you need to revert:
   a missed activation step. Run `/vsdd-factory:activate` and then restart
   your Claude Code session completely. Confirm activation wrote entries to
   `.factory/logs/dispatcher-internal.jsonl` on the next hook-triggering
-  action (e.g., make a commit).
+  action (e.g., make a commit). Before concluding the dispatcher is
+  broken, run `/vsdd-factory:factory-health`: with `.factory` present but
+  not mounted as a worktree, the dispatcher runs its hooks normally but
+  holds back internal-log writes until the mount exists, which presents
+  as this exact symptom.
 
 - **Datadog 401 Unauthorized.** The Datadog sink is returning an auth
   error. Check `observability-config.toml` — confirm the `api_key` value

--- a/plugins/vsdd-factory/bin/factory-obs
+++ b/plugins/vsdd-factory/bin/factory-obs
@@ -242,7 +242,18 @@ _generate_override() {
       echo "factory-obs: skipping invalid registry entry: $root" >&2
       continue
     fi
-    mkdir -p "$root/.factory/logs" 2>/dev/null || true
+    # Issue #206: never plant `.factory/` state ahead of the worktree mount —
+    # a plain `.factory` (or a logs/ child inside one) blocks the later
+    # `git worktree add .factory factory-artifacts` during /factory-health
+    # bootstrap. Pre-create logs/ only when `.factory` is already
+    # mount-shaped (.git entry: file for a worktree, dir for a checkout);
+    # otherwise leave it alone and tell the operator. The mount line is still
+    # written — the collector picks the path up once the mount exists.
+    if [ -e "$root/.factory/.git" ]; then
+      mkdir -p "$root/.factory/logs" 2>/dev/null || true
+    else
+      echo "factory-obs: $root/.factory is not a mounted worktree — skipping logs/ pre-create (run /factory-health there first)" >&2
+    fi
     local name
     name=$(_safe_name "$root")
     mount_lines+="      - \"$root/.factory/logs:/var/log/factory/$name:ro\"

--- a/plugins/vsdd-factory/tests/factory-obs-registry.bats
+++ b/plugins/vsdd-factory/tests/factory-obs-registry.bats
@@ -210,3 +210,32 @@ teardown() {
   count=$(grep -oE '/var/log/factory/api-[0-9a-f]+' "$OVERRIDE_FILE" | sort -u | wc -l | tr -d ' ')
   [ "$count" -eq 2 ]
 }
+
+# ---------- #206: logs/ pre-create gated on the worktree mount ----------
+
+@test "regenerate: does not create logs/ inside an unmounted .factory (#206)" {
+  # Plain .factory with no .git entry — the mid-bootstrap shape. The
+  # pre-create must skip it: planting logs/ here is exactly the state that
+  # blocks a later `git worktree add .factory factory-artifacts`.
+  UNMOUNTED="$TEST_HOME/proj-unmounted"
+  mkdir -p "$UNMOUNTED/.factory"
+  echo "$UNMOUNTED" > "$VSDD_OBS_REGISTRY"
+
+  run "$TOOL" regenerate
+  [ "$status" -eq 0 ]
+  [ ! -e "$UNMOUNTED/.factory/logs" ]
+  [[ "$output" == *"not a mounted worktree"* ]]
+  # The mount line is still generated for when the mount lands.
+  grep -q "$UNMOUNTED/.factory/logs:" "$OVERRIDE_FILE"
+}
+
+@test "regenerate: pre-creates logs/ when .factory is mount-shaped (#206)" {
+  MOUNTED="$TEST_HOME/proj-mounted"
+  mkdir -p "$MOUNTED/.factory"
+  echo "gitdir: ../.git/worktrees/.factory" > "$MOUNTED/.factory/.git"
+  echo "$MOUNTED" > "$VSDD_OBS_REGISTRY"
+
+  run "$TOOL" regenerate
+  [ "$status" -eq 0 ]
+  [ -d "$MOUNTED/.factory/logs" ]
+}


### PR DESCRIPTION
## Why

The dispatcher's internal log does an unconditional `fs::create_dir_all(<root>/.factory/logs)` on every write, and the dispatcher fires on every tool use. During `/factory-health` first-time setup that means the dispatcher continuously re-plants a plain `.factory/` directory in the window between "checked missing" and `git worktree add .factory factory-artifacts` — and git, finding `.factory` already present, mounts the worktree **nested** at `.factory/.factory` (#206; this is the shared root cause of the #203/#205 bootstrap-failure cluster). The skill-side guards for the symptom half ship separately (companion skills PR adds the mount assertion); this PR removes the process that keeps recreating the conflicting state.

## What changed

- `crates/factory-dispatcher/src/log_dir.rs` — new pure helper `factory_mount_ready(log_dir)`: a `.factory`-parented log dir is writable only when that `.factory` carries a `.git` entry. A `git worktree add` mount has a `.git` *file*; a plain checkout of the artifact branch has a `.git` *dir*; both count. A log dir whose parent is not named `.factory` (a `VSDD_LOG_DIR` / `FACTORY_ROOT` override pointing elsewhere) is always writable — it cannot collide with the mount. An override deliberately pointing at an *unmounted* `.factory/logs` is gated like the resolved shape, since creating the plain dir would cause the same nested mount regardless of who asked; this corner is documented on the helper.
- `crates/factory-dispatcher/src/internal_log.rs` — `write_inner` consults the gate before `create_dir_all`. Suppression is a skip, not an error: a once-per-session stderr notice (shared `AtomicBool` across clones, same pattern as the dedup set) explains the state and points at `/factory-health` or `VSDD_LOG_DIR`. Events during the bootstrap window remain observable via `VSDD_SINK_FILE`.
- Resolution levels A–G themselves are unchanged — this gates the *write*, not the *resolution*, so the log location documented in project docs stays `.factory/logs/dispatcher-internal-YYYY-MM-DD.jsonl`.

## Behavior

| Log-dir provenance | `.factory` state | Before | After |
|---|---|---|---|
| resolved (level C–G) | absent | created as plain dir (the race) | skip + warn once |
| resolved (level C–G) | plain dir, no `.git` (onboard-first state) | `logs/` created inside (blocks the mount) | skip + warn once |
| resolved (level C–G) | mounted worktree (`.git` file) or checkout (`.git` dir) | write | write (unchanged) |
| explicit `VSDD_LOG_DIR` / `FACTORY_ROOT` (level A/B) | any | write | write (unchanged — the gate never overrides the override) |

## Test evidence

- 5 new unit tests on the pure gate (`log_dir.rs`): absent / plain-dir / `.git`-file mount / `.git`-dir checkout / non-`.factory` override.
- 3 new write-path tests (`internal_log.rs`): `.factory` absent → not created; plain `.factory` → no `logs/` child; mounted `.factory` → JSONL written exactly as before.
- Two existing fixtures fabricated plain `.factory` dirs and asserted writes landed — the exact behavior this issue reports as the defect. Updated to the mount shape (`.git` file) their surrounding comments already assumed: `tests/internal_log_integration.rs` (mkdir-p semantics still exercised — `logs/` left absent) and `tests/issue_130_log_dir_shadow.rs` (its shadow assertion is unchanged and still passes).
- `cargo test -p factory-dispatcher`: all 33 test binaries pass. `cargo test --workspace --all-targets`: green except the two pre-existing `validate-state-structure` tests that read the live artifact state (banner drift recorded in the project's own state frontmatter; unrelated to this diff). `cargo fmt --check --all` and `cargo clippy -p factory-dispatcher --all-targets -- -D warnings` clean.

## Notes

- `bin/factory-obs` (`_generate_override`) also does a `mkdir -p "$root/.factory/logs"` outside any worktree check — a second, non-recurring creation site. Left out of this PR to keep it single-concern; the onboard-observability ordering guard in the companion skills PR covers its practical path.
- Operator-level effect lands at the next release: the cached plugin ships a prebuilt dispatcher, so develop-branch changes don't alter running installs until an rc is cut.

## Review round: override exemption (second commit)

As first shipped, the gate also suppressed writes when the log dir came from an **explicit `VSDD_LOG_DIR` / `FACTORY_ROOT` override** pointing at a `.factory/logs`-shaped path — and the first real consumer of that corner turned out to be this repo's own bats harness, which points `VSDD_LOG_DIR` at scratch `.factory/logs` fixtures. 16 tests across `regression-v1.0`, `check-harness-version`, `validate-heavy-op-delegation`, and the trajectory-tail advisory suites failed on empty internal logs (caught in review — thank you). `InternalLog` now takes `with_mount_gate(bool)`; `main.rs` disables the gate whenever either override env var is set and non-empty, so an explicit operator choice is honored verbatim. All four suite groups re-run green locally against the rebuilt release dispatcher; a new unit test (`gate_bypassed_for_explicit_override`) locks the bypass. The remaining red on this PR's first CI run also included the batch-wide `sprint-state-format` def-b failure, which is #724's known issue (fix in flight on a sibling PR) — unrelated to this diff.

Refs: #206
Refs: #203

