### PR TITLE
fix(agents): orchestrator loads task-tracking tools at startup — no mid-pipeline discovery

### DIFF
--- a/plugins/vsdd-factory/agents/orchestrator/orchestrator.md
+++ b/plugins/vsdd-factory/agents/orchestrator/orchestrator.md
@@ -230,7 +230,7 @@ These skills are available at any point in the pipeline:
 
 ## Operating Loop
 
-0. Call `agents_list` to discover registered agents
+0. Call `agents_list` to discover registered agents, and load the session-scoped task-tracking tools up front (see Task Tracking below)
 1. Read `.factory/STATE.md` to understand current pipeline state
 2. Determine which phase is active and what work remains
 3. Spawn the right agent from the routing table with a clear task description
@@ -239,6 +239,14 @@ These skills are available at any point in the pipeline:
 6. If gate passes: advance to next phase, spawn state-manager to update STATE.md
 7. If gate fails: spawn the appropriate agent again with feedback
 8. Report status to the human at each phase transition
+
+### Task Tracking (session-scoped coordination)
+
+A single orchestrator session dispatches many sub-agents in dependency order across phases. Tracking what is dispatched, in flight, blocked, and complete is core to the role, not peripheral. Use the session-scoped task-tracking tools — `TaskCreate`, `TaskUpdate`, `TaskList`, `TaskGet`, `TaskStop` — as your working memory for in-flight coordination.
+
+This is distinct from `.factory/STATE.md`: state-manager owns STATE.md as the durable pipeline record; task tracking is the live dispatch ledger for the current session. These tools are session-coordination primitives, not file writes, so using them does NOT breach the no-write constraint in Constraints above.
+
+**Load them at startup, not on first use.** As step 0 of the Operating Loop, run `ToolSearch query="select:TaskCreate,TaskUpdate,TaskList,TaskGet,TaskStop"` once, alongside `agents_list`. Loading up front means the tools are ready before the first dispatch, and the harness does not repeatedly prompt you to consider task tracking mid-pipeline.
 
 ## Policy Rubric Loading (MANDATORY for adversary dispatch)
 

--- a/plugins/vsdd-factory/tests/permissions.bats
+++ b/plugins/vsdd-factory/tests/permissions.bats
@@ -75,6 +75,22 @@ setup() {
   grep -q 'Denied:.*exec' "$AGENTS/orchestrator/orchestrator.md"
 }
 
+@test "orchestrator documents session-scoped task-tracking tools" {
+  # Coordination is core to the orchestrator; the task-tracking tools must be
+  # named in the operating doc so they are loaded up front, not discovered
+  # mid-pipeline. See issue #221.
+  grep -q 'TaskCreate' "$AGENTS/orchestrator/orchestrator.md"
+  grep -q 'TaskUpdate' "$AGENTS/orchestrator/orchestrator.md"
+  grep -q 'TaskList' "$AGENTS/orchestrator/orchestrator.md"
+}
+
+@test "orchestrator task tools do not breach the no-write coordinator wall" {
+  # Task tracking is session coordination, not file writing. The doc must not
+  # have quietly reintroduced write/exec while adding the task-tracking tools.
+  grep -q 'Denied:.*write' "$AGENTS/orchestrator/orchestrator.md"
+  grep -q 'Denied:.*exec' "$AGENTS/orchestrator/orchestrator.md"
+}
+
 @test "pr-manager has coding profile" {
   grep -q 'Profile: `coding`' "$AGENTS/pr-manager.md"
 }


### PR DESCRIPTION
## Why

An orchestrator session dispatches many sub-agents in dependency order across
phases, and tracking what is dispatched, in flight, blocked, and complete is
core to the role. But the session-scoped task-tracking tools (`TaskCreate`,
`TaskUpdate`, `TaskList`, `TaskGet`, `TaskStop`) arrive deferred: the
orchestrator has to discover them via `ToolSearch` on first use, mid-pipeline,
and the harness repeatedly nudges "consider using TaskCreate" until it does
(issue #221, reproduced in the ftc-blue Phase 1d session). That is exactly the
"skill-required-but-not-equipped" asymmetry the issue describes — the agent
whose job is coordination is not set up to coordinate until it stumbles into
the tools.

This makes the orchestrator load those tools up front (step 0 of its operating
loop, alongside `agents_list`) and documents why they belong there. The result
is one predictable startup action instead of a mid-flow interruption, and
consistent task-tracking practice across sessions.

## What changed

- `agents/orchestrator/orchestrator.md`
  - New "Task Tracking (session-scoped coordination)" subsection under Operating
    Loop. It names the five tools, distinguishes them from `.factory/STATE.md`
    (state-manager owns the durable record; task tracking is the live dispatch
    ledger), states explicitly that they are session-coordination primitives
    rather than file writes (so they do not breach the no-write constraint),
    and instructs loading them at startup via
    `ToolSearch query="select:TaskCreate,TaskUpdate,TaskList,TaskGet,TaskStop"`.
  - Operating-loop step 0 updated to load the task tools alongside `agents_list`.
  - This satisfies the issue's acceptance criterion #3 ("Documented in the
    orchestrator doc why these are loaded for the orchestrator").
- `tests/permissions.bats`
  - Assertion that the orchestrator doc names TaskCreate/TaskUpdate/TaskList.
  - Companion assertion that the change did not quietly reintroduce write/exec
    (the coordinator no-write wall — `Denied: write`/`Denied: exec` — must
    still hold). All 70 tests pass.

## Why a doc + startup instruction, not a `tools:` frontmatter allowlist

The issue proposes adding the tools to the orchestrator's "default tool
profile" frontmatter. Two things make an explicit `tools:` allowlist on this
agent the wrong lever, and I want to be candid about the tradeoff rather than
bury it:

1. **`tools:` is a restriction list, not an addition list.** The sibling agents
   that carry `tools:` (adversary, holdout-evaluator, research-agent) are
   *narrowed* to exactly what they list. The orchestrator's surface is broad
   and spans two vocabularies — the Agent dispatch tool plus engine tools it
   depends on at startup (`agents_list` on line 136, `sessions_*`, `memory_*`,
   `web_*`). An explicit allowlist that omits any one of those load-bearing
   tools would silently break the pipeline. The blast radius of getting the
   list wrong is far larger than the friction the issue is trying to remove.

2. **The orchestrator is a Restricted Coordinator by design.** `FACTORY.md`
   ("Agent Permission Model") and `permissions.bats` structurally assert the
   orchestrator is denied `write` and `exec` — "No shell, delegate everything."
   Task tracking is session coordination, not file writing, so it is compatible
   with that wall; but the safest way to add it is to name the tools in the
   operating doc and load them at startup, not to author a full allowlist that
   risks either omitting a needed engine tool or appearing to reopen the wall.

So this PR takes the issue's own narrower shape — the tools are equipped at
session start via a single up-front `ToolSearch`, and documented — which meets
acceptance criteria #1 (available without a mid-pipeline discovery round-trip)
and #3 (documented) without the allowlist risk.

Note also that the issue lists `TaskOutput` among the tools to add; that tool
does not exist in this harness, so it is deliberately omitted. The five tools
named are the ones actually available.

## Caveat (why the trailer is Refs, not Closes)

Whether an agent doc can *force* the harness to pre-load deferred tools is the
harness's call, not this repo's. This change guarantees the orchestrator is
*instructed* to load them first and documents the rationale, but if the harness
keeps the Task tools deferred regardless of what the agent doc says, the
mid-pipeline `ToolSearch` step is still incurred and this change is inert on
acceptance criterion #2 ("system-reminder about task usage doesn't fire").
That is why this cannot be statically verified in-repo and the trailer is
`Refs`, not `Closes` — the reporter should confirm against a live orchestrator
session whether the up-front load actually suppresses the reminder.

## Test

`tests/permissions.bats` extended with two grep-based assertions in the
existing house style (the orchestrator doc names the Task tools; the no-write
wall still holds). Full suite: 70/70 pass. There is no runtime harness surface
in this repo to assert the deferred-vs-default loading behavior itself — that
is the caveat above.

Refs: #221
