### PR TITLE
docs(agents): state-manager idempotency contract + orchestrator transient-dispatch recovery protocol

### DIFF
--- a/plugins/vsdd-factory/agents/orchestrator/orchestrator.md
+++ b/plugins/vsdd-factory/agents/orchestrator/orchestrator.md
@@ -434,7 +434,10 @@ a hard failure. Diagnose actual state first:
    (e.g. the report file was created; STATE.md shows the phase transition). You
    have read access — use it. This is how you distinguish "died before writing
    anything," "wrote partially," and "wrote everything then the connection
-   dropped on the way back."
+   dropped on the way back." Some tasks have open-ended output sets (a phase
+   transition can touch many files); when you cannot enumerate the full set,
+   inspect what you can and treat the boundary as undeterminable — that case
+   falls through to escalation in step 2.
 2. **Decide from the observed state:**
    - **Nothing landed** → re-dispatch the same task. Agents whose common
      operations are idempotent (state-manager — see its Idempotency section) are
@@ -447,8 +450,10 @@ a hard failure. Diagnose actual state first:
      only the portion that did not land, or escalate if you cannot determine the
      boundary.
 3. **Bound the retries.** Apply the same ceiling as other failures: after the
-   3rd retry without a clean result, escalate to the human per the Human
-   Notification table (Agent timeout — 3rd retry).
+   3rd retry without a clean result, escalate to the human per this file's
+   Failure & Escalation Level 2 ("after 3 retries"). In steady-state mode the
+   escalation row is "Agent timeout (3rd retry)" under `## Human Notification
+   System` in `orchestrator/steady-state.md`.
 
 Prefer diagnosis over blind retry: re-dispatching a task whose work already
 landed wastes tokens and can corrupt append-style state, while assuming success

--- a/plugins/vsdd-factory/agents/orchestrator/orchestrator.md
+++ b/plugins/vsdd-factory/agents/orchestrator/orchestrator.md
@@ -420,6 +420,40 @@ confirmed codifications in `cycles/<cycle>/lessons.md` with `[codified]` tag.
 - **Level 2 (partial output):** If a quality gate fails after 3 retries, present the current state and failure details to human.
 - **Level 3 (escalate):** If a critical prerequisite is missing (no repo, no worktree, model unavailable), stop and report to human immediately.
 
+### Transient Dispatch Failure Recovery
+
+Sometimes a dispatched agent returns a raw transport error rather than a clean
+result — e.g. `API Error: Connection closed mid-response. The response above may
+be incomplete.` This is a transient upstream failure, not an agent logic error,
+and the failed agent may have completed all, some, or none of its work before
+the connection dropped. Do NOT treat the raw error string as either success or
+a hard failure. Diagnose actual state first:
+
+1. **Inspect the expected outputs.** For every file the dispatched task was to
+   produce or modify, check whether it exists and reflects the task
+   (e.g. the report file was created; STATE.md shows the phase transition). You
+   have read access — use it. This is how you distinguish "died before writing
+   anything," "wrote partially," and "wrote everything then the connection
+   dropped on the way back."
+2. **Decide from the observed state:**
+   - **Nothing landed** → re-dispatch the same task. Agents whose common
+     operations are idempotent (state-manager — see its Idempotency section) are
+     safe to re-run verbatim.
+   - **Everything landed** → treat as success; the error was on the return trip
+     only. Do not re-dispatch (a needless re-run risks doubling append-style
+     logs).
+   - **Partial** → for idempotent agents, re-dispatch the whole task (the
+     re-run converges the remaining writes). For non-idempotent work, re-dispatch
+     only the portion that did not land, or escalate if you cannot determine the
+     boundary.
+3. **Bound the retries.** Apply the same ceiling as other failures: after the
+   3rd retry without a clean result, escalate to the human per the Human
+   Notification table (Agent timeout — 3rd retry).
+
+Prefer diagnosis over blind retry: re-dispatching a task whose work already
+landed wastes tokens and can corrupt append-style state, while assuming success
+on a task that died silently loses the work entirely.
+
 ## Remember
 
 **You are a COORDINATOR, not a doer. Every substantive task is delegated via

--- a/plugins/vsdd-factory/agents/state-manager.md
+++ b/plugins/vsdd-factory/agents/state-manager.md
@@ -474,6 +474,32 @@ Do this at every phase gate after writing artifacts. You own the commit — no n
 - **Level 2 (partial output):** If a worktree precondition check fails, report the specific error and recovery command without proceeding.
 - **Level 3 (escalate):** If .factory/ is missing or corrupted and cannot be recovered via worktree commands, stop and report to orchestrator.
 
+## Idempotency
+
+Your common operations are safe to re-run. If the orchestrator re-dispatches you
+after a transient failure (e.g. a dropped connection mid-response left it unsure
+whether your writes landed), re-executing the same task against the same paths
+produces the same end state — it does not duplicate or corrupt what already
+persisted:
+
+- **STATE.md updates** are set-to-value, not append. Phase transitions, file
+  sizes, finding counts, and gate verdicts overwrite the field to the value the
+  task specifies; applying the same transition twice leaves STATE.md identical
+  to applying it once.
+- **Artifact persistence** (writing a report or cycle file to a given absolute
+  path) overwrites that path with the provided content; re-running writes the
+  same bytes.
+- **`.factory/` structure creation** is create-if-absent; re-running skips any
+  directory that already exists.
+- **Git commits** to `factory-artifacts` are safe to re-attempt: if the content
+  is already committed, `git add -A && git commit` reports "nothing to commit"
+  rather than producing a duplicate.
+
+The one non-idempotent class is **append-style logs** — burst-log.md entries and
+convergence-trajectory.md per-pass rows. Re-running a task that appends can
+double the entry. When re-dispatched for an append task, first read the target
+file and skip the append if that entry is already present.
+
 ## Templates
 
 - Pipeline state: `../../templates/state-template.md`

--- a/plugins/vsdd-factory/agents/state-manager.md
+++ b/plugins/vsdd-factory/agents/state-manager.md
@@ -495,10 +495,14 @@ persisted:
   is already committed, `git add -A && git commit` reports "nothing to commit"
   rather than producing a duplicate.
 
-The one non-idempotent class is **append-style logs** — burst-log.md entries and
-convergence-trajectory.md per-pass rows. Re-running a task that appends can
-double the entry. When re-dispatched for an append task, first read the target
-file and skip the append if that entry is already present.
+The one non-idempotent class is **append-style records** — burst-log.md
+entries, convergence-trajectory.md per-pass rows, and the STATE.md **Current
+Phase Steps** row that the Burst-complete protocol above appends on the same
+event that writes burst-log.md (the keep-last-5 window eventually evicts a
+duplicate, but a verbatim re-run doubles the row until it does). Re-running a
+task that appends can double the entry. When re-dispatched for an append task,
+first read the target file (or STATE.md section) and skip the append if that
+entry is already present.
 
 ## Templates
 

--- a/plugins/vsdd-factory/agents/state-manager.md
+++ b/plugins/vsdd-factory/agents/state-manager.md
@@ -482,27 +482,38 @@ whether your writes landed), re-executing the same task against the same paths
 produces the same end state — it does not duplicate or corrupt what already
 persisted:
 
-- **STATE.md updates** are set-to-value, not append. Phase transitions, file
-  sizes, finding counts, and gate verdicts overwrite the field to the value the
-  task specifies; applying the same transition twice leaves STATE.md identical
-  to applying it once.
+- **Most STATE.md fields** are set-to-value, not append. Phase transitions,
+  file sizes, finding counts, and gate verdicts overwrite the field to the
+  value the task specifies; applying the same transition twice leaves those
+  fields identical to applying it once. (The Current Phase Steps row is the
+  documented exception — see the append-style class below.)
 - **Artifact persistence** (writing a report or cycle file to a given absolute
   path) overwrites that path with the provided content; re-running writes the
   same bytes.
 - **`.factory/` structure creation** is create-if-absent; re-running skips any
   directory that already exists.
-- **Git commits** to `factory-artifacts` are safe to re-attempt: if the content
-  is already committed, `git add -A && git commit` reports "nothing to commit"
-  rather than producing a duplicate.
+- **Git commits** to `factory-artifacts` are safe to re-attempt *when the
+  worktree contains only this task's changes*: if the content is already
+  committed, `git add -A && git commit` reports "nothing to commit" rather
+  than producing a duplicate. Note the boundary: `git add -A` stages **every**
+  pending change in the worktree, not just this task's files — after a dropped
+  connection where a dead agent may have written partial or unrelated files, a
+  verbatim re-run can sweep those into the commit. Before re-attempting,
+  verify the tree contains only the expected changes (`git -C .factory status
+  --porcelain`); escalate if it doesn't.
 
-The one non-idempotent class is **append-style records** — burst-log.md
-entries, convergence-trajectory.md per-pass rows, and the STATE.md **Current
-Phase Steps** row that the Burst-complete protocol above appends on the same
-event that writes burst-log.md (the keep-last-5 window eventually evicts a
-duplicate, but a verbatim re-run doubles the row until it does). Re-running a
-task that appends can double the entry. When re-dispatched for an append task,
-first read the target file (or STATE.md section) and skip the append if that
-entry is already present.
+The non-idempotent class is **append-style records** — including but not
+limited to: burst-log.md entries, convergence-trajectory.md per-pass rows,
+`cycles/<cycle>/lessons.md` L-entries, added rows in the 4 INDEX files and
+decision-log.md, and the STATE.md **Current Phase Steps** row that the
+Burst-complete protocol above appends on the same event that writes
+burst-log.md (the keep-last-5 window eventually evicts a duplicate, but a
+verbatim re-run doubles the row until it does). The authoritative enumeration
+is this agent's own update-event list (the "when X happens → append Y"
+triggers above) — treat every append trigger there as non-idempotent.
+Re-running a task that appends can double the entry. When re-dispatched for an
+append task, first read the target file (or STATE.md section) and skip the
+append if that entry is already present.
 
 ## Templates
 


### PR DESCRIPTION
## Why

Issue #212 reports that when a sub-agent dies mid-flight on a transient upstream
error (`Connection closed mid-response`), the orchestrator gets a raw error
string with no structured signal — and has to manually detect whether work
landed, then re-compose and re-dispatch. Its core asks are Claude Code harness
concerns: auto-retry on transient errors inside the Agent tool, and a structured
failure enum (`succeeded | failed_transient | failed_permanent | partial`)
wrapping the agent return value. Neither is fixable in this repo — there is no
Agent-tool internals or dispatch-framework surface here to change, so this PR
does not attempt them and deliberately adds no retry machinery.

What this repo *does* own is the two acceptance criteria that are documentation:
criterion #3 ("common state-manager operations are documented as idempotent")
and the orchestrator-side failure-handling protocol (the issue's own recommended
diagnostic behavior, `agents/orchestrator/`). This PR lands exactly those two,
as prose guidance, and stops there. When the harness-level enum/auto-retry ship,
the diagnostic protocol here is the fallback the orchestrator uses in the
meantime and the behavior it falls back to for any error the harness doesn't
auto-handle.

## What changed

- `agents/state-manager.md` — new "Idempotency" section after Failure &
  Escalation. States that its common operations are safe to re-run: STATE.md
  updates are set-to-value (not append), artifact writes overwrite the same
  path with the same content, `.factory/` structure creation is create-if-absent,
  and `factory-artifacts` commits are safe to re-attempt (already-committed
  content yields "nothing to commit"). Names the one non-idempotent class
  explicitly — append-style logs (burst-log.md, convergence-trajectory.md rows)
  — and tells the agent to read-then-skip on re-dispatch so a retry does not
  double an entry. This is the honest shape: "idempotent" is not blanket-true
  for this agent, and pretending it is would set up exactly the double-append
  the issue worries about.

- `agents/orchestrator/orchestrator.md` — new "Transient Dispatch Failure
  Recovery" subsection under Failure & Escalation. Codifies the diagnostic
  response the issue's reporter performed by hand: do not treat the raw error
  as success or hard failure; inspect the expected output paths to determine
  what actually landed; then decide (nothing → re-dispatch; everything →
  treat as success, don't re-run; partial → re-dispatch idempotent agents
  whole, or the un-landed portion otherwise). Bounds retries at the existing
  3rd-retry escalation ceiling (reusing the Human Notification table's "Agent
  timeout — 3rd retry" rather than inventing a new limit), and cross-references
  state-manager's Idempotency section so "safe to re-run" has a concrete anchor.

Total ~60 lines of markdown across the two files. No code, no workflow changes,
no new hooks.

## Note on testing

This is prose operating guidance for agents; there is no runtime surface in the
repo to exercise it. The existing `tests/permissions.bats` structural checks
(Tool Access / Failure & Escalation / Remember sections must be present; no
shell in coding-profile agents) still pass 68/68 after the edits, but no test
asserts the *content* of a recovery protocol — that is behavioral guidance a
live orchestrator follows, not a statically-verifiable contract. The harness-level
pieces (#212's auto-retry + structured enum) remain the reporter's to build
where the Agent tool lives.

Refs: #212
