### PR TITLE
fix(tests): skip live STATE.md snapshot suite in worktrees without factory-artifacts mount

### DIFF
--- a/plugins/vsdd-factory/tests/validate-state-structure/pass-real-state-md-snapshot.bats
+++ b/plugins/vsdd-factory/tests/validate-state-structure/pass-real-state-md-snapshot.bats
@@ -35,6 +35,14 @@ setup() {
   WORK="$(mktemp -d)"
   mkdir -p "$WORK/hook-plugins"
   mkdir -p "$WORK/.factory/logs"
+  # Guard: skip the entire suite when the factory-artifacts worktree is not mounted.
+  # .factory/STATE.md lives on the factory-artifacts orphan branch, which must be
+  # checked out as a git worktree at REPO_ROOT/.factory. Without that mount the cp
+  # below would abort setup with an error instead of a clean skip. This is the same
+  # local-only design as PR #725 (sprint-state.yaml live-file guards).
+  if [ ! -f "$REPO_ROOT/.factory/STATE.md" ]; then
+    skip ".factory/STATE.md absent — factory-artifacts worktree not mounted; run: git worktree add .factory origin/factory-artifacts"
+  fi
   # F-P3-002: auto-copy LIVE STATE.md at run time — eliminates snapshot-vs-live drift class.
   # The test always exercises current .factory/STATE.md content rather than a frozen fixture.
   cp "$REPO_ROOT/.factory/STATE.md" "$WORK/.factory/STATE.md"


### PR DESCRIPTION
## Fix: pass-real-state-md-snapshot.bats worktree guard

**Finding:** pre-existing test-infra defect — `pass-real-state-md-snapshot.bats` unconditionally copies live `.factory/STATE.md` in `setup()`, failing 3/3 when the `factory-artifacts` orphan-branch worktree is not mounted. Routed from the ADR-032 implementation arc.
**Severity:** LOW (test-infra only; no production code affected)

### What Changed

Added a `setup()`-time skip guard to `pass-real-state-md-snapshot.bats`: detects absence of `$REPO_ROOT/.factory/STATE.md` (the exact file the subsequent `cp` consumes) and skips the entire suite with an explanatory message including the mount remediation command.

Same local-only design class as PR #725.

### Why

The suite unconditionally uses the live `factory-artifacts` worktree mount, which is only present in the main worktree, not in secondary worktrees. The guard makes the suite skip cleanly instead of failing setup.

### Testing

- [x] `run-all.sh` — 245 suites, 2058 ok, 0 failed (full bats suite gate)
- [x] Sibling sweep confirmed — no other suite shares the unguarded live-copy pattern
- [x] No demo required — transparent test-infra fix