### PR TITLE
ci: pin workflow actions to release commit shas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Mount factory artifacts
         run: |
@@ -111,12 +111,13 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust toolchain
         # Pinned in rust-toolchain.toml — keep this version in sync with that file.
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master 2026-08-04
         with:
+          toolchain: 1.95.0
           components: rustfmt, clippy
           targets: wasm32-wasip1
 
@@ -323,7 +324,7 @@ jobs:
     # knows exactly which side to refresh.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install yq + python3-yaml
         run: |
@@ -402,14 +403,15 @@ jobs:
             exe_suffix: ".exe"
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust toolchain
         # Pinned to rust-toolchain.toml (1.95.0). `targets:` here adds
         # both the platform-specific triple AND wasm32-wasip1 in one
         # rustup invocation — the action handles the union internally.
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master 2026-08-04
         with:
+          toolchain: 1.95.0
           components: rustfmt, clippy
           targets: ${{ matrix.target }}, wasm32-wasip1
 
@@ -529,7 +531,7 @@ jobs:
         # for debugging cross-platform build issues). release.yml's build-binaries job
         # produces its own staged artifacts independently via separate build runs;
         # nothing downstream downloads this upload for bundling.
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: factory-dispatcher-${{ matrix.platform }}
           path: artifact-staging/
@@ -547,7 +549,7 @@ jobs:
     name: bats-full-suite (linux)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Mount factory artifacts
         # run-all.sh suites that validate STATE.md / cycle artifacts need .factory/.
@@ -578,8 +580,9 @@ jobs:
       - name: Install Rust toolchain
         # Needed to build factory-dispatcher (release) below.
         # Pinned to rust-toolchain.toml version — keep in sync with cargo-host.
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master 2026-08-04
         with:
+          toolchain: 1.95.0
           targets: wasm32-wasip1
 
       - name: Cache cargo
@@ -683,7 +686,7 @@ jobs:
     name: bats-wave-handoff (macos)
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install tools
         # bats, jq, bash, and PyYAML are the runtime requirements for wave-handoff.bats
@@ -745,7 +748,7 @@ jobs:
     name: bats-darwin-leg (macos, /bin/bash 3.2)
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install bats
         run: brew install bats-core jq

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     name: Pre-release Validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Mount factory artifacts
         run: |
@@ -106,11 +106,12 @@ jobs:
             use_cross: false
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master 2026-08-04
         with:
+          toolchain: 1.95.0
           components: rustfmt, clippy
           targets: ${{ matrix.target }}, wasm32-wasip1
 
@@ -239,7 +240,7 @@ jobs:
           echo "Registry-vs-staged: all ${#declared[@]} hooks-registry plugins present in artifact/. OK"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: factory-dispatcher-${{ matrix.platform }}
           path: artifact/
@@ -264,7 +265,7 @@ jobs:
     needs: build-binaries
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Fetch full history so the commit graph is available for
           # the tag move.
@@ -277,7 +278,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download all platform artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: /tmp/artifacts
           pattern: factory-dispatcher-*
@@ -546,7 +547,7 @@ jobs:
     needs: commit-binaries
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Check out the (possibly retagged) commit so the GH Release
           # is anchored at the binaries-included version.
@@ -602,7 +603,7 @@ jobs:
           mv /tmp/release-notes.final.md /tmp/release-notes.md
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           body_path: /tmp/release-notes.md
           # `contains(ref_name, '-')` flags prerelease (semver §9 hyphen marker).
@@ -650,7 +651,7 @@ jobs:
 
       - name: Check out claude-mp
         if: steps.preflight.outputs.configured == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: drbothen/claude-mp
           token: ${{ secrets.CLAUDE_MP_PAT }}
@@ -740,7 +741,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Full history needed to merge main into develop without
           # spurious unrelated-histories errors.

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -20,7 +20,7 @@ jobs:
     container:
       image: returntocorp/semgrep:1.61.0
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Run Semgrep SAST
         # `semgrep ci` is the CI-aware command: on pull_request triggers it


### PR DESCRIPTION
A tag ref like actions/checkout@v6 is mutable: whoever controls that tag controls code that runs with the workflow's token. Pinning to release commit SHAs removes that surface, and semgrep (config=auto) stops flagging the workflows: a full scan over .github/workflows at this branch reports 0 findings across 82 rules.

This replaces the 22 tag refs across ci.yml, release.yml, and semgrep.yml (counted with `grep -rhoE 'uses:\s*\S+' .github/workflows/*.yml` at develop 948f0fb1). Each pin is the commit SHA of the action's current latest release, resolved via `git ls-remote --tags` (peeled where annotated), with the version in a trailing comment so Renovate/Dependabot can keep tracking it:

| action | was | now |
|---|---|---|
| actions/checkout | v6 | 3d3c42e5 (v7.0.1) |
| actions/upload-artifact | v4 | 043fb46d (v7.0.1) |
| actions/download-artifact | v4 | 3e5f45b2 (v8.0.1) |
| softprops/action-gh-release | v2 | 3d0d9888 (v3.0.2) |
| dtolnay/rust-toolchain | 1.95.0 | 2c7215f1 (master) + explicit `toolchain: 1.95.0` input |

dtolnay/rust-toolchain publishes no releases and normally derives the toolchain from the ref name. At the 1.95.0 branch head its action.yml has no toolchain input, so a bare SHA pin would break selection; at master (2c7215f1) toolchain is a required input. The four sites gain `toolchain: 1.95.0`, so the installed toolchain is unchanged.

One caveat to weigh: checkout v6 to v7, upload-artifact v4 to v7, download-artifact v4 to v8, and gh-release v2 to v3 are major bumps to current releases. ci.yml and semgrep.yml are exercised by this PR's own checks; release.yml only runs on a release, so its upload/download/gh-release sites are untested here. Happy to drop those three to the latest release within their current majors instead (v4.6.2 / v4.3.0 / v2.6.2) if you'd rather separate behavior changes from pinning.

Local gates at develop 948f0fb1: cargo fmt --check, clippy -D warnings, cargo test --workspace (two pre-existing failures in validate-state-structure that read the live .factory/STATE.md banner count; they fail identically on clean develop and your CI is green at the same SHA), hooks.bats + bin.bats, and SEMGREP_BASELINE_REF=upstream/develop semgrep ci with 0 findings.