### PR TITLE
fix(tests): mktemp portability + dispatcher provenance in bats suites

### DIFF
--- a/plugins/vsdd-factory/tests/f2-process-gap-lesson-gates.bats
+++ b/plugins/vsdd-factory/tests/f2-process-gap-lesson-gates.bats
@@ -88,7 +88,13 @@ setup() {
     FACTORY_ROOT="$(dirname "${git_common_dir}")"
   fi
 
-  export FACTORY_ROOT
+  TEST_TMP="$(mktemp -d "${BATS_TMPDIR}/f2-process-gap-XXXXXX")"
+
+  export FACTORY_ROOT TEST_TMP
+}
+
+teardown() {
+  rm -rf "${TEST_TMP}"
 }
 
 # ---------------------------------------------------------------------------
@@ -106,7 +112,7 @@ setup() {
   # Write the script to a temp file to avoid quoting complexity for double-quote patterns.
   # Note: || true on grep calls prevents set -e from aborting on 0-match (grep exits 1).
   local tmpscript
-  tmpscript="$(mktemp /tmp/ac001-gate-XXXXXX.sh)"
+  tmpscript="${TEST_TMP}/gate.sh"
   cat > "$tmpscript" <<SCRIPT
 #!/usr/bin/env bash
 set -euo pipefail

--- a/plugins/vsdd-factory/tests/helpers/dispatcher-provenance.bash
+++ b/plugins/vsdd-factory/tests/helpers/dispatcher-provenance.bash
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# helpers/dispatcher-provenance.bash — emit factory-dispatcher binary provenance.
+#
+# Loaded by setup_file() in suites that invoke factory-dispatcher, so every run
+# produces an auditable record: which binary was exercised, its sha256, and mtime.
+#
+# D-693 / F-S2107-P6-017: a "N/N GREEN" attestation is only meaningful when the
+# specific binary exercised is recorded (path + content hash + mtime).
+#
+# Usage (from setup_file):
+#   load "${BATS_TEST_DIRNAME}/helpers/dispatcher-provenance.bash"
+#   emit_dispatcher_provenance               # auto-resolve: debug → release
+#   emit_dispatcher_provenance "${_my_path}" # explicit path (caller selects)
+#
+# Output goes to >&3 (TAP comment lines — always visible in bats 1.x output).
+# Under CI_REQUIRE_ARTIFACTS=1, returns non-zero when the binary is not found.
+
+emit_dispatcher_provenance() {
+    local _disp="${1:-}"
+
+    if [[ -z "${_disp}" ]]; then
+        # Auto-resolve from the calling test file's repo root (debug preferred over release).
+        local _repo_root
+        _repo_root="$(cd "$(dirname "${BATS_TEST_FILENAME}")/../../.." && pwd)"
+        _disp="${_repo_root}/target/debug/factory-dispatcher"
+        [[ -x "${_disp}" ]] || _disp="${_repo_root}/target/release/factory-dispatcher"
+    fi
+
+    if [[ -x "${_disp}" ]]; then
+        local _sha _mtime
+        _sha="$(shasum -a 256 "${_disp}" | cut -d' ' -f1)"
+        _mtime="$(date -r "${_disp}" +%Y-%m-%dT%H:%M:%S 2>/dev/null \
+                  || stat --format='%y' "${_disp}" 2>/dev/null | sed 's/ /T/; s/\..*//')"
+        echo "# dispatcher-provenance: path=${_disp}" >&3
+        echo "# dispatcher-provenance: sha256=${_sha}  mtime=${_mtime}" >&3
+    else
+        echo "# dispatcher-provenance: UNRESOLVED — binary not found at ${_disp}" >&3
+        if [[ "${CI_REQUIRE_ARTIFACTS:-}" == "1" ]]; then
+            echo "FATAL: CI_REQUIRE_ARTIFACTS=1 — dispatcher must be pre-built at ${_disp}" >&2
+            return 1
+        fi
+    fi
+}

--- a/plugins/vsdd-factory/tests/host-abi-hygiene.bats
+++ b/plugins/vsdd-factory/tests/host-abi-hygiene.bats
@@ -46,6 +46,11 @@ setup() {
   INTERNAL_LOG_RS="$REPO_ROOT/crates/factory-dispatcher/src/internal_log.rs"
   EXECUTOR_RS="$REPO_ROOT/crates/factory-dispatcher/src/executor.rs"
   VSDD_SINK_RS="$REPO_ROOT/crates/factory-dispatcher/src/vsdd_sink.rs"
+  TEST_TMP="$(mktemp -d "${BATS_TMPDIR}/host-abi-hygiene-XXXXXX")"
+}
+
+teardown() {
+  rm -rf "${TEST_TMP}"
 }
 
 # ---------------------------------------------------------------------------
@@ -202,7 +207,7 @@ setup() {
 
   # Mutation-liveness: verify the grep pattern matches the expected declaration form.
   local mut_file
-  mut_file=$(mktemp /tmp/t009_mutant_XXXXXX.rs)
+  mut_file="${TEST_TMP}/mutant.rs"
   printf 'pub const INTERNAL_FILE_NOT_FOUND: &str = "internal.file_not_found";\n' > "$mut_file"
   if ! grep -qE 'pub[[:space:]]+const[[:space:]]+INTERNAL_FILE_NOT_FOUND' "$mut_file"; then
     rm -f "$mut_file"
@@ -242,7 +247,7 @@ setup() {
 
   # Mutation-liveness: verify the grep pattern matches the expected declaration form.
   local mut_file
-  mut_file=$(mktemp /tmp/t010_mutant_XXXXXX.rs)
+  mut_file="${TEST_TMP}/mutant.rs"
   printf 'pub const PLUGIN_ABANDONED: &str = "plugin.abandoned";\n' > "$mut_file"
   if ! grep -qE 'pub[[:space:]]+const[[:space:]]+PLUGIN_ABANDONED' "$mut_file"; then
     rm -f "$mut_file"
@@ -348,7 +353,7 @@ _scan_bare_literals() {
   # Mutation-liveness check: inject a bare literal into a temp copy of
   # read_file.rs's production region and assert the gate fires.
   local mut_file
-  mut_file=$(mktemp /tmp/t011_mutant_XXXXXX.rs)
+  mut_file="${TEST_TMP}/mutant.rs"
   # Insert the mutation line immediately before the #[cfg(test)] boundary.
   awk '{
     if (/^#\[cfg\(test\)\]/) {
@@ -374,7 +379,7 @@ _scan_bare_literals() {
   # Inject "plugin.completed" (one of the two new D22 classes) immediately
   # before the #[cfg(test)] boundary and assert the gate fires on it.
   local mut_file2
-  mut_file2=$(mktemp /tmp/t011_mutant2_XXXXXX.rs)
+  mut_file2="${TEST_TMP}/mutant2.rs"
   awk '{
     if (/^#\[cfg\(test\)\]/) {
       print "    let _ = \"plugin.completed\"; // mutation-liveness injection (D22 extension)"
@@ -400,7 +405,7 @@ _scan_bare_literals() {
   # and assert the 4-stage scan fires — proves the widened perimeter detects
   # a future bare literal in executor.rs production code (F-P2-001).
   local mut_file3
-  mut_file3=$(mktemp /tmp/t011_mutant3_XXXXXX.rs)
+  mut_file3="${TEST_TMP}/mutant3.rs"
   awk '{
     if (/^#\[cfg\(test\)\]/) {
       print "    let _ = \"plugin.completed\"; // mutation-liveness injection (executor.rs extension)"

--- a/plugins/vsdd-factory/tests/pr-manager-hardening.bats
+++ b/plugins/vsdd-factory/tests/pr-manager-hardening.bats
@@ -74,6 +74,10 @@ setup_file() {
         mkdir -p "$wasm_dir"
         cp "${repo_root}/target/wasm32-wasip1/release/pr-manager-completion-guard.wasm" "$wasm"
     fi
+    # Dispatcher provenance: record which binary T-001 and similar tests will use.
+    # D-693 / F-S2107-P6-017: auditable path + sha256 + mtime via TAP comments.
+    load "${BATS_TEST_DIRNAME}/helpers/dispatcher-provenance.bash"
+    emit_dispatcher_provenance
     # Darwin-leg /bin/bash 3.2 preflight — macOS only.
     if [[ "$(uname)" != "Darwin" ]]; then
         return 0
@@ -122,7 +126,7 @@ teardown() {
     fi
 
     local sink_file
-    sink_file="$(mktemp "${BATS_TMPDIR}/T001-sink-XXXXXX.jsonl")"
+    sink_file="${MOCK_BIN}/sink.jsonl"
 
     # SubagentStop payload: pr-manager agent emits READY verdict WITHOUT covered_sha field
     local payload
@@ -562,7 +566,7 @@ GHEOF
     local pr_number="10"
     local release_branch="release/v1.0.0-rc.23"
     local merge_flag_file
-    merge_flag_file="$(mktemp "${BATS_TMPDIR}/merge-flag-T012-XXXXXX.txt")"
+    merge_flag_file="${MOCK_BIN}/merge-flag.txt"
     rm -f "${merge_flag_file}"
 
     cat > "${MOCK_BIN}/gh" <<GHEOF
@@ -1134,7 +1138,7 @@ GHEOF
 @test "T-023: enforce-merge-strategy.sh forwards --delete-branch residual arg to gh (F-P7-001 pass-through)" {
     local pr_number="55"
     local argv_log
-    argv_log="$(mktemp "${BATS_TMPDIR}/gh-argv-T023-XXXXXX.txt")"
+    argv_log="${MOCK_BIN}/gh-argv.txt"
 
     cp "${FIXTURES_DIR}/stub-gh.sh" "${MOCK_BIN}/gh"
     chmod +x "${MOCK_BIN}/gh"
@@ -1260,7 +1264,7 @@ GHEOF
 @test "T-027: enforce-merge-strategy.sh: --merge --delete-branch allowed + forwarded (F-P7-001 deny-list positive)" {
     local pr_number="63"
     local argv_log
-    argv_log="$(mktemp "${BATS_TMPDIR}/gh-argv-T027-XXXXXX.txt")"
+    argv_log="${MOCK_BIN}/gh-argv.txt"
 
     cp "${FIXTURES_DIR}/stub-gh.sh" "${MOCK_BIN}/gh"
     chmod +x "${MOCK_BIN}/gh"
@@ -1301,7 +1305,7 @@ GHEOF
     local pr_number="64"
     local release_branch="release/v1.0.0-rc.23"
     local argv_log
-    argv_log="$(mktemp "${BATS_TMPDIR}/gh-argv-T028-XXXXXX.txt")"
+    argv_log="${MOCK_BIN}/gh-argv.txt"
 
     cp "${FIXTURES_DIR}/stub-gh.sh" "${MOCK_BIN}/gh"
     chmod +x "${MOCK_BIN}/gh"
@@ -1344,7 +1348,7 @@ GHEOF
 @test "T-029: enforce-merge-strategy.sh: --admin as \$2 (primary strategy slot) → exit 1 + non-empty stderr + gh pr merge NOT called (F-P8-003)" {
     local pr_number="10"
     local argv_log
-    argv_log="$(mktemp "${BATS_TMPDIR}/gh-argv-T029-XXXXXX.txt")"
+    argv_log="${MOCK_BIN}/gh-argv.txt"
     # Remove so we can detect whether gh pr merge was called at all.
     rm -f "${argv_log}"
 
@@ -1393,7 +1397,7 @@ GHEOF
 @test "T-030: enforce-merge-strategy.sh: -A as \$2 (short admin flag in strategy slot) → exit 1 + non-empty stderr + gh pr merge NOT called (F-P8-003)" {
     local pr_number="10"
     local argv_log
-    argv_log="$(mktemp "${BATS_TMPDIR}/gh-argv-T030-XXXXXX.txt")"
+    argv_log="${MOCK_BIN}/gh-argv.txt"
     rm -f "${argv_log}"
 
     cp "${FIXTURES_DIR}/stub-gh.sh" "${MOCK_BIN}/gh"

--- a/plugins/vsdd-factory/tests/read-prefix-wasm.bats
+++ b/plugins/vsdd-factory/tests/read-prefix-wasm.bats
@@ -52,6 +52,11 @@ setup() {
   READ_PREFIX_RS="$REPO_ROOT/crates/factory-dispatcher/src/host/read_prefix.rs"
   CI_YML="$REPO_ROOT/.github/workflows/ci.yml"
   RELEASE_YML="$REPO_ROOT/.github/workflows/release.yml"
+  TEST_TMP="$(mktemp -d "${BATS_TMPDIR}/read-prefix-wasm-XXXXXX")"
+}
+
+teardown() {
+  rm -rf "${TEST_TMP}"
 }
 
 # ---------------------------------------------------------------------------
@@ -291,7 +296,7 @@ setup() {
   # production region of a temp copy and assert the gate fires.
   # The injection appears BEFORE // so sed stage 3 does NOT strip it.
   local mut_file
-  mut_file=$(mktemp /tmp/t009g_mutant_XXXXXX.rs)
+  mut_file="${TEST_TMP}/mutant.rs"
 
   # Insert the mutation line immediately before the #[cfg(test)] boundary so
   # stage-1 awk includes it in the production region it processes.
@@ -455,7 +460,7 @@ setup() {
   # After deletion the exclusion count drops below the workspace count, proving
   # the coupled assertion (b) would fire on any --exclude removal.
   local mut_ci_del
-  mut_ci_del=$(mktemp /tmp/t009h_ci_del_XXXXXX.yml)
+  mut_ci_del="${TEST_TMP}/ci-del.yml"
   awk 'seen==0 && /--exclude read-prefix-fixture/{seen=1;next}{print}' \
     "$CI_YML" > "$mut_ci_del"
   local mut_del_excl_count
@@ -474,7 +479,7 @@ setup() {
   # The workspace count increases by 1 but the exclusion count stays the same,
   # proving assertion (b) fires when a new workspace build lacks the exclusion.
   local mut_ci_add
-  mut_ci_add=$(mktemp /tmp/t009h_ci_add_XXXXXX.yml)
+  mut_ci_add="${TEST_TMP}/ci-add.yml"
   {
     cat "$CI_YML"
     printf '          cargo build --release --target wasm32-wasip1 \\\n'

--- a/plugins/vsdd-factory/tests/resolver-capability-confinement.bats
+++ b/plugins/vsdd-factory/tests/resolver-capability-confinement.bats
@@ -25,6 +25,17 @@
 #   BC-4.12.004 INV1 — no panic / no crash on resolver errors
 
 # ---------------------------------------------------------------------------
+# Provenance recording (setup_file runs once per suite; output always visible)
+# ---------------------------------------------------------------------------
+
+setup_file() {
+    # Record which factory-dispatcher binary this suite exercises.
+    # D-693 / F-S2107-P6-017: auditable path + sha256 + mtime via TAP comments.
+    load "${BATS_TEST_DIRNAME}/helpers/dispatcher-provenance.bash"
+    emit_dispatcher_provenance
+}
+
+# ---------------------------------------------------------------------------
 # Setup / teardown helpers
 # ---------------------------------------------------------------------------
 
@@ -158,7 +169,7 @@ EOF
     temp_plugin_root="$(make_naughty_plugin_root)"
 
     local sink_file
-    sink_file="${BATS_TMPDIR}/cap-confinement-sink-${RANDOM}.jsonl"
+    sink_file="${FACTORY_TMP}/sink.jsonl"
 
     # Dispatcher payload: SubagentStop with wave-gate-dispatch agent_type.
     # The convergence hook has needs_context = ["naughty_resolver"], so the
@@ -245,7 +256,7 @@ waves:
 EOF
 
     local sink_file
-    sink_file="$(mktemp "${BATS_TMPDIR}/vp076d-sink-XXXXXX.jsonl")"
+    sink_file="${FACTORY_TMP}/sink.jsonl"
 
     local payload='{"event_name":"SubagentStop","session_id":"bats-vp076d","dispatcher_trace_id":"bats-vp076d-trace","agent_type":"wave-gate-dispatch","last_assistant_message":"Wave gate adversary pass completed for this iteration of the story review cycle."}'
 

--- a/plugins/vsdd-factory/tests/resolver-integration.bats
+++ b/plugins/vsdd-factory/tests/resolver-integration.bats
@@ -42,6 +42,17 @@
 # F-P3-008: concurrent resolver timeout integration test.
 
 # ---------------------------------------------------------------------------
+# Provenance recording (setup_file runs once per suite; output always visible)
+# ---------------------------------------------------------------------------
+
+setup_file() {
+    # Record which factory-dispatcher binary this suite exercises.
+    # D-693 / F-S2107-P6-017: auditable path + sha256 + mtime via TAP comments.
+    load "${BATS_TEST_DIRNAME}/helpers/dispatcher-provenance.bash"
+    emit_dispatcher_provenance
+}
+
+# ---------------------------------------------------------------------------
 # Setup / teardown helpers
 # ---------------------------------------------------------------------------
 
@@ -158,7 +169,7 @@ EOF
     # The dispatcher emits hook.block events (with the CONVERGENCE_PASSES_INSUFFICIENT code)
     # to the internal log. VSDD_SINK_FILE (debug-only) flushes them to a JSONL file.
     local sink_file
-    sink_file="$(mktemp "${BATS_TMPDIR}/resolver-sink-XXXXXX.jsonl")"
+    sink_file="${FACTORY_TMP}/sink.jsonl"
 
     # Run dispatcher with synthetic SubagentStop event via stdin.
     # CWD = PLUGIN_ROOT so resolver WASM path resolves correctly.
@@ -198,7 +209,7 @@ EOF
     # Run dispatcher with synthetic SubagentStop event via stdin.
     # last_assistant_message satisfies the handoff-validator (>= 40 non-whitespace chars).
     local sink_file
-    sink_file="$(mktemp "${BATS_TMPDIR}/resolver-sink-XXXXXX.jsonl")"
+    sink_file="${FACTORY_TMP}/sink.jsonl"
 
     local payload='{"event_name":"SubagentStop","session_id":"bats-test-session","dispatcher_trace_id":"bats-test-trace","agent_type":"wave-gate-dispatch","last_assistant_message":"Wave gate adversary pass completed for this iteration of the story review cycle."}'
     run bash -c "cd '${PLUGIN_ROOT}' && printf '%s' '${payload}' | VSDD_SINK_FILE='${sink_file}' CLAUDE_PLUGIN_ROOT='${PLUGIN_ROOT}' CLAUDE_PROJECT_DIR='${FACTORY_TMP}' '${DISPATCHER}'"
@@ -254,7 +265,7 @@ EOF
     # No cycle directory needed — no stories to check.
 
     local sink_file
-    sink_file="$(mktemp "${BATS_TMPDIR}/resolver-sink-XXXXXX.jsonl")"
+    sink_file="${FACTORY_TMP}/sink.jsonl"
 
     # Synthetic SubagentStop event with agent_type = wave-gate-dispatch and a
     # valid last_assistant_message so the handoff-validator does not block first.
@@ -315,7 +326,7 @@ EOF
     # Deliberately do NOT create .factory/cycles/test-cycle-block-001/S-NOSTATE/
 
     local sink_file
-    sink_file="${BATS_TMPDIR}/block-code-1-sink-${RANDOM}.jsonl"
+    sink_file="${FACTORY_TMP}/sink.jsonl"
 
     local payload='{"event_name":"SubagentStop","session_id":"bats-block-001","dispatcher_trace_id":"bats-block-trace","agent_type":"wave-gate-dispatch","last_assistant_message":"Wave gate adversary pass completed for this iteration of the story review cycle."}'
     run bash -c "cd '${PLUGIN_ROOT}' && printf '%s' '${payload}' | VSDD_SINK_FILE='${sink_file}' CLAUDE_PLUGIN_ROOT='${PLUGIN_ROOT}' CLAUDE_PROJECT_DIR='${FACTORY_TMP}' '${DISPATCHER}'"
@@ -366,7 +377,7 @@ EOF
 EOF
 
     local sink_file
-    sink_file="${BATS_TMPDIR}/block-code-2-sink-${RANDOM}.jsonl"
+    sink_file="${FACTORY_TMP}/sink.jsonl"
 
     local payload='{"event_name":"SubagentStop","session_id":"bats-block-002","dispatcher_trace_id":"bats-block-trace","agent_type":"wave-gate-dispatch","last_assistant_message":"Wave gate adversary pass completed for this iteration of the story review cycle."}'
     run bash -c "cd '${PLUGIN_ROOT}' && printf '%s' '${payload}' | VSDD_SINK_FILE='${sink_file}' CLAUDE_PLUGIN_ROOT='${PLUGIN_ROOT}' CLAUDE_PROJECT_DIR='${FACTORY_TMP}' '${DISPATCHER}'"
@@ -420,7 +431,7 @@ EOF
     printf 'schema_version = 1\n' > "${temp_plugin_root}/resolvers-registry.toml"
 
     local sink_file
-    sink_file="${BATS_TMPDIR}/block-code-3-sink-${RANDOM}.jsonl"
+    sink_file="${FACTORY_TMP}/sink.jsonl"
 
     local payload='{"event_name":"SubagentStop","session_id":"bats-block-003","dispatcher_trace_id":"bats-block-trace","agent_type":"wave-gate-dispatch","last_assistant_message":"Wave gate adversary pass completed for this iteration of the story review cycle."}'
     run bash -c "cd '${temp_plugin_root}' && printf '%s' '${payload}' | VSDD_SINK_FILE='${sink_file}' CLAUDE_PLUGIN_ROOT='${temp_plugin_root}' CLAUDE_PROJECT_DIR='${FACTORY_TMP}' '${DISPATCHER}'"
@@ -557,7 +568,7 @@ path_allow = []
 RESOLVER_TOML
 
     local sink_file log_dir
-    sink_file="${BATS_TMPDIR}/timeout-sink-${RANDOM}.jsonl"
+    sink_file="${FACTORY_TMP}/sink.jsonl"
     log_dir="$(mktemp -d "${BATS_TMPDIR}/timeout-log-XXXXXX")"
 
     local payload='{"event_name":"SubagentStop","session_id":"bats-timeout","dispatcher_trace_id":"bats-timeout-trace","agent_type":"wave-gate-dispatch","last_assistant_message":"Wave gate adversary pass completed for this iteration of the story review cycle."}'

--- a/plugins/vsdd-factory/tests/verify-factory-lock-read-prefix.bats
+++ b/plugins/vsdd-factory/tests/verify-factory-lock-read-prefix.bats
@@ -35,6 +35,13 @@
 # setup / teardown
 # ---------------------------------------------------------------------------
 
+setup_file() {
+    # Record which factory-dispatcher binary this suite exercises.
+    # D-693 / F-S2107-P6-017: auditable path + sha256 + mtime via TAP comments.
+    load "${BATS_TEST_DIRNAME}/helpers/dispatcher-provenance.bash"
+    emit_dispatcher_provenance
+}
+
 setup() {
   REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../../.." && pwd)"
   PLUGIN_ROOT="$REPO_ROOT/plugins/vsdd-factory"
@@ -140,7 +147,7 @@ _require_artifacts() {
   # (with sed block-comment strip) must NOT find them (output empty). If it does
   # find them, the sed chain is not stripping block comments → gate is broken.
   local mut_file
-  mut_file=$(mktemp /tmp/t001b_mutant_XXXXXX.rs)
+  mut_file="${WORK}/mutant.rs"
   printf 'fn read_data() -> i32 { /* host::read_file(path, STATE_MD_MAX_BYTES) TooLarge check */ 0 }\n' \
     > "$mut_file"
 


### PR DESCRIPTION
## Summary

Two test-harness defects fixed across 7 bats suites (17 sites):

- **macOS `mktemp` portability**: `mktemp` only expands `XXXXXX` when it is the **final** token of the template. Every call of the form `mktemp <prefix>XXXXXX.<ext>` was producing a file named literally that string. On the next run `mktemp` failed `EEXIST`, the variable came back empty, and assertions failed on an empty path. Linux CI never surfaced this because runners always start fresh. Fixed by routing all per-test temp files through already-allocated `-d` temp directories (setup/teardown pattern). This is the root cause of the long-standing observation that the full corpus produced 3-runs → 3 different failure sets, undermining D-693 attestation.

- **Dispatcher provenance** (F-S2107-P6-017): Suites exercising `factory-dispatcher` selected the binary from host state with a silent fallback and recorded nothing about which binary ran — a local GREEN was neither reproducible nor auditable against D-693. New shared helper `helpers/dispatcher-provenance.bash` exposes `emit_dispatcher_provenance()`, emitting path + sha256 + mtime as TAP comment lines (always visible). Prefers the repo-local debug build, makes fallback explicit, hard-fails under `CI_REQUIRE_ARTIFACTS=1`. Loaded via `setup_file()` in each affected suite rather than duplicated across ~250 suites.

Per CLAUDE.md: operator plugin cache only updates on release, so silently testing against it can validate the wrong binary while reporting green.

## Suites verified (each run twice in succession to exercise the EEXIST regression path)

| Suite | Pass | Runs |
|-------|------|------|
| `resolver-capability-confinement` | 2/2 | ×2 |
| `resolver-integration` | 8/8 | ×2 |
| `host-abi-hygiene` | 9/9 | ×2 |
| `read-prefix-wasm` | 8/8 | ×2 |
| `verify-factory-lock-read-prefix` | 5/5 | ×2 |
| `pr-manager-hardening` | 33/33 | ×2 |

**BW01 warning in `pr-manager-hardening` is pre-existing and unrelated to these changes.** T-017 is a macOS-only regression-pin test; its negative-control branch intentionally runs `fragment-mapfile.sh` under `/bin/bash 3.2` to verify that `mapfile` fails. Exit code 127 is the expected signal from that negative control. All 33 tests pass both runs.

## Files changed

- `plugins/vsdd-factory/tests/helpers/dispatcher-provenance.bash` — new shared helper
- `plugins/vsdd-factory/tests/f2-process-gap-lesson-gates.bats` — mktemp fix (1 site)
- `plugins/vsdd-factory/tests/host-abi-hygiene.bats` — mktemp fix (5 sites)
- `plugins/vsdd-factory/tests/pr-manager-hardening.bats` — mktemp fix (5 sites) + provenance
- `plugins/vsdd-factory/tests/read-prefix-wasm.bats` — provenance integration
- `plugins/vsdd-factory/tests/resolver-capability-confinement.bats` — mktemp fix (2 sites) + provenance
- `plugins/vsdd-factory/tests/resolver-integration.bats` — mktemp fix (2 sites) + provenance
- `plugins/vsdd-factory/tests/verify-factory-lock-read-prefix.bats` — provenance integration

## Test plan

- [ ] CI passes (cargo fmt + clippy + cargo test + bats)
- [ ] Re-run any 2 of the 6 suites locally back-to-back to confirm EEXIST regression path stays clean