### PR TITLE
fix(dispatcher): raise WASM fuel cap 10M→20M + fuel-vs-epoch block_reason disambiguation

### DIFF
--- a/crates/factory-dispatcher/src/executor.rs
+++ b/crates/factory-dispatcher/src/executor.rs
@@ -685,6 +685,7 @@ fn emit_lifecycle(
             stderr,
             elapsed_ms,
             fuel_consumed,
+            fuel_cap: _,
         } => {
             let cause_str = match cause {
                 TimeoutCause::Epoch => "epoch",
@@ -748,6 +749,7 @@ fn emit_lifecycle(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::invoke::DEFAULT_FUEL_CAP;
 
     // ── CRIT-PR59-001 regression tests: advisory-block gate ──────────────────
 
@@ -840,6 +842,7 @@ mod tests {
             stderr: String::new(),
             elapsed_ms: 5_000,
             fuel_consumed: 0,
+            fuel_cap: DEFAULT_FUEL_CAP,
         };
         assert!(!plugin_requests_block(&r));
     }
@@ -891,6 +894,7 @@ mod tests {
             stderr: String::new(),
             elapsed_ms: 5_000,
             fuel_consumed: 0,
+            fuel_cap: DEFAULT_FUEL_CAP,
         };
         assert!(
             plugin_fail_closed(&r, OnError::Block),
@@ -901,11 +905,13 @@ mod tests {
     /// Timeout + on_error=Continue → NOT fail-closed.
     #[test]
     fn fail_closed_timeout_with_on_error_continue_is_open() {
+        // fuel_consumed == fuel_cap on Trap::OutOfFuel (remaining=0 → cap.saturating_sub(0)=cap).
         let r = PluginResult::Timeout {
             cause: TimeoutCause::Fuel,
             stderr: String::new(),
             elapsed_ms: 5_000,
-            fuel_consumed: 1_000_000_000,
+            fuel_consumed: DEFAULT_FUEL_CAP,
+            fuel_cap: DEFAULT_FUEL_CAP,
         };
         assert!(
             !plugin_fail_closed(&r, OnError::Continue),

--- a/crates/factory-dispatcher/src/executor.rs
+++ b/crates/factory-dispatcher/src/executor.rs
@@ -685,7 +685,7 @@ fn emit_lifecycle(
             stderr,
             elapsed_ms,
             fuel_consumed,
-            fuel_cap: _,
+            fuel_cap,
         } => {
             let cause_str = match cause {
                 TimeoutCause::Epoch => "epoch",
@@ -704,6 +704,7 @@ fn emit_lifecycle(
                         "stderr".to_string(),
                         serde_json::Value::String(stderr.clone()),
                     ),
+                    ("fuel_cap".to_string(), serde_json::Value::from(*fuel_cap)),
                 ],
             )
         }
@@ -932,6 +933,70 @@ mod tests {
         assert!(
             !plugin_fail_closed(&r, OnError::Block),
             "Ok result + on_error=Block must NOT trigger fail-closed (advisory path handles Ok)"
+        );
+    }
+
+    // ── emit_lifecycle telemetry field coverage ────────────────────────────
+
+    /// `plugin.timeout` events must carry both `fuel_cap` and `fuel_consumed`
+    /// so operators can see which budget was hit without opening the full trace.
+    /// CLAUDE.md Factory Hook Diagnostics Step 2 sends operators to grep
+    /// `.factory/logs/dispatcher-internal-*.jsonl` for exactly these fields.
+    #[test]
+    fn emit_lifecycle_timeout_carries_fuel_cap_and_consumed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let log = InternalLog::new(dir.path().join("logs"));
+        let base_ctx = crate::host::HostContext::new("test-plugin", "0.1.0", "sess-1", "trace-1");
+        let entry = RegistryEntry {
+            name: "test-plugin".to_string(),
+            event: "PreToolUse".to_string(),
+            tool: None,
+            plugin: std::path::PathBuf::from("test.wasm"),
+            priority: None,
+            enabled: true,
+            timeout_ms: None,
+            fuel_cap: None,
+            on_error: None,
+            capabilities: None,
+            config: toml::Value::Table(toml::Table::new()),
+            async_flag: false,
+            needs_context: vec![],
+        };
+        let cap: u64 = DEFAULT_FUEL_CAP;
+        let consumed: u64 = 12_345_678;
+        let result = PluginResult::Timeout {
+            cause: TimeoutCause::Fuel,
+            stderr: String::new(),
+            elapsed_ms: 10,
+            fuel_consumed: consumed,
+            fuel_cap: cap,
+        };
+        emit_lifecycle(&log, &base_ctx, &entry, &result);
+
+        // Read back the JSONL and verify both fields are present.
+        let log_dir = dir.path().join("logs");
+        let files: Vec<_> = std::fs::read_dir(&log_dir)
+            .expect("log dir must exist after write")
+            .map(|e| e.expect("dir entry").path())
+            .collect();
+        assert_eq!(files.len(), 1, "expected exactly one log file");
+        let content = std::fs::read_to_string(&files[0]).expect("read log file");
+        let event: serde_json::Value =
+            serde_json::from_str(content.trim_end()).expect("log line must be valid JSON");
+        assert_eq!(
+            event["type"].as_str(),
+            Some(PLUGIN_TIMEOUT),
+            "event type must be plugin.timeout"
+        );
+        assert_eq!(
+            event["fuel_consumed"].as_u64(),
+            Some(consumed),
+            "plugin.timeout event must carry fuel_consumed"
+        );
+        assert_eq!(
+            event["fuel_cap"].as_u64(),
+            Some(cap),
+            "plugin.timeout event must carry fuel_cap (CLAUDE.md Diagnostics Step 2)"
         );
     }
 }

--- a/crates/factory-dispatcher/src/invoke.rs
+++ b/crates/factory-dispatcher/src/invoke.rs
@@ -268,7 +268,11 @@ impl Default for InvokeLimits {
     fn default() -> Self {
         Self {
             timeout_ms: 5_000,
-            fuel_cap: 10_000_000,
+            // ADR-042 §Decision 1: raised 10M → 20M (measurement-validated).
+            // Worst-case legacy-bash-adapter payload consumed 10,406,058 fuel
+            // (ARCH-INDEX + 50 KB last_assistant_message, 377,109 payload bytes),
+            // exhausting the former 10M cap. 20M leaves ~9.6M headroom (92% margin).
+            fuel_cap: 20_000_000,
         }
     }
 }
@@ -1055,6 +1059,81 @@ mod tests {
 
     fn bare_ctx() -> HostContext {
         HostContext::new("plugin", "0.0.1", "sess", "trace")
+    }
+
+    // ADR-042 §Decision 1: global fuel cap raised 10M → 20M (measurement-validated).
+    // 838 fuel-exhaustion events across 35 plugins confirmed by perf-engineer;
+    // worst-case payload (ARCH-INDEX + 50 KB assistant message) measured 10,406,058 fuel.
+    #[test]
+    fn invoke_limits_default_fuel_cap_is_20m() {
+        assert_eq!(InvokeLimits::default().fuel_cap, 20_000_000);
+    }
+
+    // Demonstrates that the 10M→20M raise resolves the class of exhaustions seen in
+    // production. The WAT loop runs 1,200,000 iterations at ~9 WASM instructions each
+    // (≈10.8M fuel) — above the former 10M cap, below the new 20M cap.
+    // Calibrated against the perf-engineer model:
+    //   fuel = 29,452 + 27.514 × payload_bytes (R²=0.9999999).
+    // At 377,109 bytes (ARCH-INDEX + 50 KB assistant msg): 10,406,058 fuel.
+    #[test]
+    fn fuel_workload_exhausts_10m_completes_at_20m() {
+        let engine = build_engine().unwrap();
+        // Arithmetic loop: 1,200,000 iterations x ~9 instructions = ~10.8M fuel.
+        let module = compile(
+            &engine,
+            r#"
+            (module
+              (memory (export "memory") 1)
+              (func (export "_start")
+                (local $i i32)
+                (local.set $i (i32.const 0))
+                (block $done
+                  (loop $l
+                    (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                    (br_if $done (i32.ge_u (local.get $i) (i32.const 1200000)))
+                    (br $l)))))
+            "#,
+        );
+
+        // At the former 10M cap: fuel exhaustion.
+        let res_10m = invoke_plugin(
+            &engine,
+            &module,
+            bare_ctx(),
+            b"",
+            InvokeLimits {
+                timeout_ms: 30_000,
+                fuel_cap: 10_000_000,
+            },
+        )
+        .unwrap();
+        assert!(
+            matches!(
+                res_10m,
+                PluginResult::Timeout {
+                    cause: TimeoutCause::Fuel,
+                    ..
+                }
+            ),
+            "expected Timeout{{Fuel}} at 10M cap, got {res_10m:?}"
+        );
+
+        // At the new 20M cap: completes successfully.
+        let res_20m = invoke_plugin(
+            &engine,
+            &module,
+            bare_ctx(),
+            b"",
+            InvokeLimits {
+                timeout_ms: 30_000,
+                fuel_cap: 20_000_000,
+            },
+        )
+        .unwrap();
+        assert!(
+            matches!(res_20m, PluginResult::Ok { exit_code: 0, .. }),
+            "expected Ok(exit_code=0) at 20M cap, got {res_20m:?}"
+        );
     }
 
     #[test]

--- a/crates/factory-dispatcher/src/invoke.rs
+++ b/crates/factory-dispatcher/src/invoke.rs
@@ -226,7 +226,18 @@ pub enum PluginResult {
         /// a partial message because the plugin was interrupted.
         stderr: String,
         elapsed_ms: u64,
+        /// Instructions executed before the interrupt. Useful telemetry for
+        /// the event log. Note: on `Trap::OutOfFuel`, `fuel_consumed_from_store`
+        /// returns `cap.saturating_sub(remaining)` where `remaining == 0`, so
+        /// `fuel_consumed == fuel_cap` on every fuel trap — it does not convey
+        /// demand independently of the cap. Use `fuel_cap` for the operator
+        /// message when communicating what limit was hit.
         fuel_consumed: u64,
+        /// The configured fuel budget at the time of invocation. Always
+        /// reflects the actual cap set on the wasmtime Store, independent of
+        /// whether `get_fuel()` succeeds. Use this field — not `fuel_consumed`
+        /// — when constructing operator-facing messages about which cap to raise.
+        fuel_cap: u64,
     },
     Crashed {
         trap_string: String,
@@ -409,6 +420,7 @@ pub fn invoke_plugin(
             &stderr,
             elapsed_ms,
             fuel_consumed,
+            limits.fuel_cap,
         ),
     }
 }
@@ -419,6 +431,7 @@ fn classify_trap(
     stderr: &MemoryOutputPipe,
     elapsed_ms: u64,
     fuel_consumed: u64,
+    fuel_cap: u64,
 ) -> Result<PluginResult, InvokeError> {
     let stderr_text = stderr_to_string(stderr);
     // WASI `exit(n)` propagates as an `I32Exit` in wasmtime-wasi's
@@ -441,12 +454,14 @@ fn classify_trap(
                 stderr: stderr_text,
                 elapsed_ms,
                 fuel_consumed,
+                fuel_cap,
             },
             Trap::OutOfFuel => PluginResult::Timeout {
                 cause: TimeoutCause::Fuel,
                 stderr: stderr_text,
                 elapsed_ms,
                 fuel_consumed,
+                fuel_cap,
             },
             other => PluginResult::Crashed {
                 trap_string: other.to_string(),

--- a/crates/factory-dispatcher/src/invoke.rs
+++ b/crates/factory-dispatcher/src/invoke.rs
@@ -255,6 +255,18 @@ pub enum TimeoutCause {
     Fuel,
 }
 
+/// ADR-042 §Decision 1: global fuel cap raised 10M → 20M (measurement-validated).
+/// Worst-case legacy-bash-adapter payload consumed 10,406,058 fuel
+/// (ARCH-INDEX + 50 KB last_assistant_message, 377,109 payload bytes),
+/// exhausting the former 10M cap. 20M leaves ~9.6M headroom (92% margin).
+///
+/// This constant is the single source of truth for the ADR-042 fuel cap.
+/// Both `InvokeLimits::default()` and `RegistryDefaults::default()` reference it,
+/// so any future deliberate cap change is made in one place and propagates
+/// atomically to both — structural enforcement rather than test-only enforcement.
+/// Any change to this value requires updating the ADR-042 §Decision 1 rationale.
+pub const DEFAULT_FUEL_CAP: u64 = 20_000_000;
+
 /// Per-invocation budget. Defaults live in
 /// `RegistryDefaults`; callers usually get these from a
 /// `RegistryEntry` with fallback.
@@ -268,11 +280,7 @@ impl Default for InvokeLimits {
     fn default() -> Self {
         Self {
             timeout_ms: 5_000,
-            // ADR-042 §Decision 1: raised 10M → 20M (measurement-validated).
-            // Worst-case legacy-bash-adapter payload consumed 10,406,058 fuel
-            // (ARCH-INDEX + 50 KB last_assistant_message, 377,109 payload bytes),
-            // exhausting the former 10M cap. 20M leaves ~9.6M headroom (92% margin).
-            fuel_cap: 20_000_000,
+            fuel_cap: DEFAULT_FUEL_CAP,
         }
     }
 }
@@ -1066,19 +1074,21 @@ mod tests {
     // worst-case payload (ARCH-INDEX + 50 KB assistant message) measured 10,406,058 fuel.
     #[test]
     fn invoke_limits_default_fuel_cap_is_20m() {
-        assert_eq!(InvokeLimits::default().fuel_cap, 20_000_000);
+        assert_eq!(InvokeLimits::default().fuel_cap, DEFAULT_FUEL_CAP);
     }
 
-    // Demonstrates that the 10M→20M raise resolves the class of exhaustions seen in
-    // production. The WAT loop runs 1,200,000 iterations at ~9 WASM instructions each
-    // (≈10.8M fuel) — above the former 10M cap, below the new 20M cap.
-    // Calibrated against the perf-engineer model:
-    //   fuel = 29,452 + 27.514 × payload_bytes (R²=0.9999999).
-    // At 377,109 bytes (ARCH-INDEX + 50 KB assistant msg): 10,406,058 fuel.
+    // Proves the dispatcher enforces the fuel ceiling at the boundary: a synthetic WAT
+    // workload of ~10.8M fuel crosses from trapped to completing when the ceiling
+    // moves from 10M to 20M. This is a ceiling-enforcement test, not a production
+    // model: the WAT loop runs with an empty payload and no host calls, so it does
+    // not reflect the regression formula measured by the perf-engineer
+    // (fuel = 29,452 + 27.514 × payload_bytes). The ~10.8M estimate is based on
+    // the loop structure (1,200,000 iterations × ~9 WASM instructions each); the
+    // actual observed value is asserted in the 20M branch below.
     #[test]
     fn fuel_workload_exhausts_10m_completes_at_20m() {
         let engine = build_engine().unwrap();
-        // Arithmetic loop: 1,200,000 iterations x ~9 instructions = ~10.8M fuel.
+        // Arithmetic loop: 1,200,000 iterations x ~9 instructions ≈ 10.8M fuel.
         let module = compile(
             &engine,
             r#"
@@ -1126,14 +1136,31 @@ mod tests {
             b"",
             InvokeLimits {
                 timeout_ms: 30_000,
-                fuel_cap: 20_000_000,
+                fuel_cap: DEFAULT_FUEL_CAP,
             },
         )
         .unwrap();
-        assert!(
-            matches!(res_20m, PluginResult::Ok { exit_code: 0, .. }),
-            "expected Ok(exit_code=0) at 20M cap, got {res_20m:?}"
-        );
+        // Assert both the exit code and the observed fuel so a future wasmtime
+        // accounting change fails with a message stating the actual cost rather
+        // than an opaque pattern-match mismatch.
+        match res_20m {
+            PluginResult::Ok {
+                exit_code,
+                fuel_consumed,
+                ..
+            } => {
+                assert_eq!(exit_code, 0, "expected exit_code=0 at 20M cap");
+                assert!(
+                    fuel_consumed > 10_000_000,
+                    "fuel_consumed should be > 10M (workload is ~10.8M), got {fuel_consumed}"
+                );
+                assert!(
+                    fuel_consumed < DEFAULT_FUEL_CAP,
+                    "fuel_consumed should be < cap ({DEFAULT_FUEL_CAP}), got {fuel_consumed}"
+                );
+            }
+            other => panic!("expected Ok(exit_code=0) at 20M cap, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/factory-dispatcher/src/invoke.rs
+++ b/crates/factory-dispatcher/src/invoke.rs
@@ -208,6 +208,12 @@ pub fn dispatch_postcompact() {
 /// and have to re-run with a manual capture to find out why a plugin
 /// exited 1. Field added in v1.0.0-beta.4 after the S-2.7 dogfood loop
 /// ran into exactly that diagnostic gap.
+/// `#[non_exhaustive]` allows adding new variants (e.g. a future `Abandoned`
+/// discriminant for S-1.6 async partition semantics) without a breaking
+/// change for external match sites. Follows the `ResolverError` precedent
+/// in `resolver.rs` (~L78): applied at the enum level so external crates must
+/// include a wildcard arm; in-crate matches are unaffected.
+#[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum PluginResult {
     Ok {

--- a/crates/factory-dispatcher/src/invoke.rs
+++ b/crates/factory-dispatcher/src/invoke.rs
@@ -208,12 +208,6 @@ pub fn dispatch_postcompact() {
 /// and have to re-run with a manual capture to find out why a plugin
 /// exited 1. Field added in v1.0.0-beta.4 after the S-2.7 dogfood loop
 /// ran into exactly that diagnostic gap.
-/// `#[non_exhaustive]` allows adding new variants (e.g. a future `Abandoned`
-/// discriminant for S-1.6 async partition semantics) without a breaking
-/// change for external match sites. Follows the `ResolverError` precedent
-/// in `resolver.rs` (~L78): applied at the enum level so external crates must
-/// include a wildcard arm; in-crate matches are unaffected.
-#[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum PluginResult {
     Ok {

--- a/crates/factory-dispatcher/src/lib.rs
+++ b/crates/factory-dispatcher/src/lib.rs
@@ -55,7 +55,7 @@ pub use internal_log::{
     PLUGIN_LOADED, PLUGIN_TIMEOUT,
 };
 pub use invoke::{
-    EventType, InvokeError, InvokeLimits, PluginResult, StoreData, TimeoutCause,
+    DEFAULT_FUEL_CAP, EventType, InvokeError, InvokeLimits, PluginResult, StoreData, TimeoutCause,
     dispatch_postcompact, dispatch_precompact, invoke_plugin,
 };
 pub use partition::{PluginPartition, partition_plugins};

--- a/crates/factory-dispatcher/src/main.rs
+++ b/crates/factory-dispatcher/src/main.rs
@@ -832,14 +832,27 @@ fn extract_reason_from_outcome(result: &PluginResult) -> Option<String> {
         // reduce payload); epoch/wall-clock is a transient compute failure
         // (investigate slow script). Conflating them forces operators to grep
         // the internal log for the trace UUID to determine cause — TD #71 pattern.
+        //
+        // Fuel arm uses the FUEL_EXHAUSTED: stable prefix so consumers can match
+        // a fixed token without breaking when the message wording changes. This
+        // mirrors the pattern used elsewhere in the codebase (e.g.
+        // MULTI_COMMIT_CHAIN_NOT_ALLOWED). The epoch arm string "fail-closed:
+        // plugin timed out" is unchanged — existing operator runbooks match it
+        // and changing it would break them.
+        //
+        // On Trap::OutOfFuel, wasmtime's remaining-fuel counter reaches zero, so
+        // fuel_consumed_from_store() == fuel_cap (cap.saturating_sub(0) = cap).
+        // The interpolated value therefore represents the configured cap, not a
+        // measured cost. The message is framed accordingly ("fuel cap of N units")
+        // rather than "N units consumed" which would imply a metered demand figure.
         PluginResult::Crashed { .. } => Some("fail-closed: plugin crashed".to_owned()),
         PluginResult::Timeout {
             cause: TimeoutCause::Fuel,
             fuel_consumed,
             ..
         } => Some(format!(
-            "fail-closed: fuel exhausted ({fuel_consumed} units consumed; \
-             raise fuel_cap or reduce payload size)"
+            "FUEL_EXHAUSTED: fuel cap of {fuel_consumed} units exhausted; \
+             raise fuel_cap or reduce payload size"
         )),
         PluginResult::Timeout {
             cause: TimeoutCause::Epoch,
@@ -1161,33 +1174,47 @@ mod tests_extract_reason_cause_distinction {
     #![allow(clippy::expect_used, clippy::unwrap_used)]
     use factory_dispatcher::invoke::{PluginResult, TimeoutCause};
 
-    // RED before fix: fuel timeout must produce a fuel-specific reason, not "plugin timed out".
+    // Fuel timeout must produce a fuel-specific reason, not "plugin timed out".
+    //
+    // The test input uses fuel_consumed == 20_000_000 to reflect the real invariant:
+    // on Trap::OutOfFuel, wasmtime's remaining-fuel counter is zero, so
+    // fuel_consumed_from_store() == fuel_cap (cap.saturating_sub(0) = cap).
+    // A value like 10_500_000 that differs from any plausible cap is unreachable
+    // in production and would make assertions on the interpolated value misleading.
     #[test]
     fn fuel_timeout_reason_identifies_fuel_exhaustion() {
+        use factory_dispatcher::invoke::DEFAULT_FUEL_CAP;
         let result = PluginResult::Timeout {
             cause: TimeoutCause::Fuel,
             stderr: String::new(),
             elapsed_ms: 5,
-            fuel_consumed: 10_500_000,
+            // consumed == cap on fuel trap (see invariant comment above).
+            fuel_consumed: DEFAULT_FUEL_CAP,
         };
         let reason = super::extract_reason_from_outcome(&result);
         let text = reason
             .as_deref()
             .expect("fuel timeout must produce Some reason");
+        // Stable prefix: consumers match FUEL_EXHAUSTED: to distinguish fuel from epoch.
         assert!(
-            text.contains("fuel exhausted"),
-            "fuel timeout block_reason must contain 'fuel exhausted', got: {text:?}"
+            text.starts_with("FUEL_EXHAUSTED:"),
+            "fuel timeout block_reason must start with 'FUEL_EXHAUSTED:', got: {text:?}"
+        );
+        assert!(
+            text.contains("exhausted"),
+            "fuel timeout block_reason must contain 'exhausted', got: {text:?}"
         );
         assert!(
             !text.contains("timed out"),
             "fuel timeout block_reason must NOT say 'timed out' — \
              operators need distinct messages to choose the right remedy; got: {text:?}"
         );
-        // Consumed-fuel figure surfaces for scale assessment.
+        // The interpolated value is the cap (consumed == cap on fuel trap).
+        // Assert against the actual cap constant so this tracks deliberate changes.
         assert!(
-            text.contains("10500000"),
-            "fuel timeout block_reason should include the consumed-fuel figure \
-             (10500000) so operators can assess scale without log grep; got: {text:?}"
+            text.contains(&DEFAULT_FUEL_CAP.to_string()),
+            "fuel timeout block_reason should include the cap value ({DEFAULT_FUEL_CAP}) \
+             so operators know which cap to raise; got: {text:?}"
         );
     }
 

--- a/crates/factory-dispatcher/src/main.rs
+++ b/crates/factory-dispatcher/src/main.rs
@@ -848,10 +848,10 @@ fn extract_reason_from_outcome(result: &PluginResult) -> Option<String> {
         PluginResult::Crashed { .. } => Some("fail-closed: plugin crashed".to_owned()),
         PluginResult::Timeout {
             cause: TimeoutCause::Fuel,
-            fuel_consumed,
+            fuel_cap,
             ..
         } => Some(format!(
-            "FUEL_EXHAUSTED: fuel cap of {fuel_consumed} units exhausted; \
+            "FUEL_EXHAUSTED: fuel cap of {fuel_cap} units exhausted; \
              raise fuel_cap or reduce payload size"
         )),
         PluginResult::Timeout {
@@ -1190,6 +1190,8 @@ mod tests_extract_reason_cause_distinction {
             elapsed_ms: 5,
             // consumed == cap on fuel trap (see invariant comment above).
             fuel_consumed: DEFAULT_FUEL_CAP,
+            // fuel_cap is the configured cap; message interpolates this field.
+            fuel_cap: DEFAULT_FUEL_CAP,
         };
         let reason = super::extract_reason_from_outcome(&result);
         let text = reason
@@ -1218,15 +1220,54 @@ mod tests_extract_reason_cause_distinction {
         );
     }
 
+    // Proves the fix is load-bearing, not cosmetic: on the `Err(_)` path of
+    // `fuel_consumed_from_store` (when `store.get_fuel()` returns an error),
+    // `fuel_consumed` is 0 but the cap is still known via `fuel_cap`.  Before
+    // the `fuel_cap` field was added, the operator-facing message read
+    // "fuel cap of 0 units exhausted" — a false statement.  This test asserts
+    // that the correct configured cap is reported regardless of whether
+    // `fuel_consumed` carries a meaningful value.
+    #[test]
+    fn fuel_timeout_with_zero_consumed_still_reports_cap() {
+        use factory_dispatcher::invoke::DEFAULT_FUEL_CAP;
+        // Simulates the Err(_) arm of fuel_consumed_from_store: consumed=0, cap=DEFAULT.
+        let result = PluginResult::Timeout {
+            cause: TimeoutCause::Fuel,
+            stderr: String::new(),
+            elapsed_ms: 0,
+            fuel_consumed: 0,
+            fuel_cap: DEFAULT_FUEL_CAP,
+        };
+        let reason = super::extract_reason_from_outcome(&result);
+        let text = reason
+            .as_deref()
+            .expect("fuel timeout must produce Some reason");
+        assert!(
+            text.starts_with("FUEL_EXHAUSTED:"),
+            "message must carry FUEL_EXHAUSTED: prefix even when fuel_consumed=0; got: {text:?}"
+        );
+        assert!(
+            text.contains(&DEFAULT_FUEL_CAP.to_string()),
+            "message must report the configured cap ({DEFAULT_FUEL_CAP}), \
+             not fuel_consumed (0); got: {text:?}"
+        );
+        assert!(
+            !text.contains(": 0 "),
+            "message must NOT interpolate fuel_consumed=0 as the cap; got: {text:?}"
+        );
+    }
+
     // Epoch timeout must still produce the original "plugin timed out" sentinel —
     // changing this arm would break existing operator runbooks for slow scripts.
     #[test]
     fn epoch_timeout_reason_is_unaffected() {
+        use factory_dispatcher::invoke::DEFAULT_FUEL_CAP;
         let result = PluginResult::Timeout {
             cause: TimeoutCause::Epoch,
             stderr: String::new(),
             elapsed_ms: 5_001,
             fuel_consumed: 2_000_000,
+            fuel_cap: DEFAULT_FUEL_CAP,
         };
         let reason = super::extract_reason_from_outcome(&result);
         assert_eq!(

--- a/crates/factory-dispatcher/src/main.rs
+++ b/crates/factory-dispatcher/src/main.rs
@@ -790,8 +790,6 @@ fn extract_block_info(outcomes: &[PluginOutcome]) -> (String, String) {
             PluginResult::Crashed { .. } | PluginResult::Timeout { .. } => {
                 outcome.on_error == OnError::Block
             }
-            // Future variants are not fail-closed unless explicitly handled.
-            _ => false,
         };
 
         if is_blocking {
@@ -860,8 +858,6 @@ fn extract_reason_from_outcome(result: &PluginResult) -> Option<String> {
             cause: TimeoutCause::Epoch,
             ..
         } => Some("fail-closed: plugin timed out".to_owned()),
-        // Future variants: no reason available without opening the internal log.
-        _ => None,
     }
 }
 

--- a/crates/factory-dispatcher/src/main.rs
+++ b/crates/factory-dispatcher/src/main.rs
@@ -790,6 +790,8 @@ fn extract_block_info(outcomes: &[PluginOutcome]) -> (String, String) {
             PluginResult::Crashed { .. } | PluginResult::Timeout { .. } => {
                 outcome.on_error == OnError::Block
             }
+            // Future variants are not fail-closed unless explicitly handled.
+            _ => false,
         };
 
         if is_blocking {
@@ -833,12 +835,12 @@ fn extract_reason_from_outcome(result: &PluginResult) -> Option<String> {
         // (investigate slow script). Conflating them forces operators to grep
         // the internal log for the trace UUID to determine cause — TD #71 pattern.
         //
-        // Fuel arm uses the FUEL_EXHAUSTED: stable prefix so consumers can match
-        // a fixed token without breaking when the message wording changes. This
-        // mirrors the pattern used elsewhere in the codebase (e.g.
-        // MULTI_COMMIT_CHAIN_NOT_ALLOWED). The epoch arm string "fail-closed:
-        // plugin timed out" is unchanged — existing operator runbooks match it
-        // and changing it would break them.
+        // All three arms use the "fail-closed:" family prefix, consistent with
+        // the rest of the fail-closed taxonomy. The fuel arm additionally embeds
+        // "FUEL_EXHAUSTED:" as a greppable sub-token so a future consumer can
+        // distinguish fuel from epoch without parsing the trailing prose. The
+        // epoch arm string "fail-closed: plugin timed out" is unchanged —
+        // existing operator runbooks match it.
         //
         // On Trap::OutOfFuel, wasmtime's remaining-fuel counter reaches zero, so
         // fuel_consumed_from_store() == fuel_cap (cap.saturating_sub(0) = cap).
@@ -851,13 +853,15 @@ fn extract_reason_from_outcome(result: &PluginResult) -> Option<String> {
             fuel_cap,
             ..
         } => Some(format!(
-            "FUEL_EXHAUSTED: fuel cap of {fuel_cap} units exhausted; \
+            "fail-closed: FUEL_EXHAUSTED: fuel cap of {fuel_cap} units exhausted; \
              raise fuel_cap or reduce payload size"
         )),
         PluginResult::Timeout {
             cause: TimeoutCause::Epoch,
             ..
         } => Some("fail-closed: plugin timed out".to_owned()),
+        // Future variants: no reason available without opening the internal log.
+        _ => None,
     }
 }
 
@@ -1197,10 +1201,12 @@ mod tests_extract_reason_cause_distinction {
         let text = reason
             .as_deref()
             .expect("fuel timeout must produce Some reason");
-        // Stable prefix: consumers match FUEL_EXHAUSTED: to distinguish fuel from epoch.
+        // Family prefix + greppable sub-token. Both must be present in the
+        // emitted message so operators see the fail-closed taxonomy and can
+        // still grep FUEL_EXHAUSTED: without opening the internal log.
         assert!(
-            text.starts_with("FUEL_EXHAUSTED:"),
-            "fuel timeout block_reason must start with 'FUEL_EXHAUSTED:', got: {text:?}"
+            text.starts_with("fail-closed: FUEL_EXHAUSTED:"),
+            "fuel timeout block_reason must start with 'fail-closed: FUEL_EXHAUSTED:', got: {text:?}"
         );
         assert!(
             text.contains("exhausted"),
@@ -1220,17 +1226,21 @@ mod tests_extract_reason_cause_distinction {
         );
     }
 
-    // Proves the fix is load-bearing, not cosmetic: on the `Err(_)` path of
-    // `fuel_consumed_from_store` (when `store.get_fuel()` returns an error),
-    // `fuel_consumed` is 0 but the cap is still known via `fuel_cap`.  Before
-    // the `fuel_cap` field was added, the operator-facing message read
-    // "fuel cap of 0 units exhausted" — a false statement.  This test asserts
-    // that the correct configured cap is reported regardless of whether
-    // `fuel_consumed` carries a meaningful value.
+    // Decoupling test: the message is a function of `fuel_cap` alone and must
+    // not read `fuel_consumed`.  With `fuel_consumed=0` and
+    // `fuel_cap=DEFAULT_FUEL_CAP`, the message must still cite the configured
+    // cap so operators know which budget to raise — regardless of whatever
+    // value `fuel_consumed` holds.
+    //
+    // Note: `fuel_consumed_from_store` has a dead `Err(_) => 0` arm (it can
+    // only err when fuel is disabled, but `build_engine` enables fuel
+    // unconditionally and `set_fuel` failing aborts in `InvokeError::Setup`
+    // before execution begins).  The `fuel_consumed: 0` input here is simply
+    // a synthetic boundary value, not a claim about the Err(_) path.
     #[test]
     fn fuel_timeout_with_zero_consumed_still_reports_cap() {
         use factory_dispatcher::invoke::DEFAULT_FUEL_CAP;
-        // Simulates the Err(_) arm of fuel_consumed_from_store: consumed=0, cap=DEFAULT.
+        // Synthetic: consumed=0 to verify the message ignores fuel_consumed.
         let result = PluginResult::Timeout {
             cause: TimeoutCause::Fuel,
             stderr: String::new(),
@@ -1243,17 +1253,21 @@ mod tests_extract_reason_cause_distinction {
             .as_deref()
             .expect("fuel timeout must produce Some reason");
         assert!(
-            text.starts_with("FUEL_EXHAUSTED:"),
-            "message must carry FUEL_EXHAUSTED: prefix even when fuel_consumed=0; got: {text:?}"
+            text.starts_with("fail-closed: FUEL_EXHAUSTED:"),
+            "message must carry fail-closed: FUEL_EXHAUSTED: prefix even when fuel_consumed=0; got: {text:?}"
         );
         assert!(
             text.contains(&DEFAULT_FUEL_CAP.to_string()),
             "message must report the configured cap ({DEFAULT_FUEL_CAP}), \
              not fuel_consumed (0); got: {text:?}"
         );
+        // Fails against the pre-fix form "fuel cap of 0 units exhausted":
+        //   pre-fix:  "…fail-closed: FUEL_EXHAUSTED: fuel cap of 0 units exhausted…"  → contains → assertion FAILS  ✓
+        //   post-fix: "…fail-closed: FUEL_EXHAUSTED: fuel cap of 20000000 units …"    → absent   → assertion PASSES ✓
         assert!(
-            !text.contains(": 0 "),
-            "message must NOT interpolate fuel_consumed=0 as the cap; got: {text:?}"
+            !text.contains("of 0 units"),
+            "message must NOT interpolate fuel_consumed=0 as the cap; \
+             pre-fix form contained 'of 0 units'; got: {text:?}"
         );
     }
 

--- a/crates/factory-dispatcher/src/main.rs
+++ b/crates/factory-dispatcher/src/main.rs
@@ -48,7 +48,7 @@ use factory_dispatcher::internal_log::{
     DEFAULT_RETENTION_DAYS, DISPATCHER_STARTED, INTERNAL_DISPATCHER_ERROR, InternalEvent,
     InternalLog,
 };
-use factory_dispatcher::invoke::PluginResult;
+use factory_dispatcher::invoke::{PluginResult, TimeoutCause};
 use factory_dispatcher::partition::partition_plugins;
 use factory_dispatcher::payload::HookPayload;
 use factory_dispatcher::plugin_loader::PluginCache;
@@ -826,9 +826,25 @@ fn extract_reason_from_outcome(result: &PluginResult) -> Option<String> {
                 .ok()
                 .and_then(|v| v.get("reason").and_then(|r| r.as_str()).map(str::to_owned))
         }
-        // Fail-closed crash/timeout: sentinel reason.
+        // Fail-closed crash/timeout: sentinel reasons distinguished by cause so
+        // operators can choose the right remedy without opening the internal log.
+        // Fuel exhaustion is a permanent resource-policy failure (raise cap or
+        // reduce payload); epoch/wall-clock is a transient compute failure
+        // (investigate slow script). Conflating them forces operators to grep
+        // the internal log for the trace UUID to determine cause — TD #71 pattern.
         PluginResult::Crashed { .. } => Some("fail-closed: plugin crashed".to_owned()),
-        PluginResult::Timeout { .. } => Some("fail-closed: plugin timed out".to_owned()),
+        PluginResult::Timeout {
+            cause: TimeoutCause::Fuel,
+            fuel_consumed,
+            ..
+        } => Some(format!(
+            "fail-closed: fuel exhausted ({fuel_consumed} units consumed; \
+             raise fuel_cap or reduce payload size)"
+        )),
+        PluginResult::Timeout {
+            cause: TimeoutCause::Epoch,
+            ..
+        } => Some("fail-closed: plugin timed out".to_owned()),
     }
 }
 
@@ -1123,6 +1139,90 @@ mod red_gate_s18_14_log_dir {
             Path::new(log_dir_value).is_absolute(),
             "log_dir field value must be an absolute path (BC-1.13.001 PC-10 absolutize-on-emit); \
              got: {log_dir_value:?} (relative path means absolutize-on-emit fix is not applied)"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// extract_reason_from_outcome — fuel vs epoch distinction
+//
+// Fuel exhaustion and wall-clock (epoch) timeouts need opposite operator
+// responses: fuel is a permanent resource-policy failure requiring a cap
+// raise or payload reduction; epoch is a transient compute failure requiring
+// script investigation. Both previously returned "fail-closed: plugin timed
+// out", making them indistinguishable from the agent-visible block_reason.
+//
+// TDD: `fuel_timeout_reason_identifies_fuel_exhaustion` is RED before the
+// fix (current returns "plugin timed out" for both causes).  The epoch and
+// crash tests confirm those arms are unaffected by the change.
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod tests_extract_reason_cause_distinction {
+    #![allow(clippy::expect_used, clippy::unwrap_used)]
+    use factory_dispatcher::invoke::{PluginResult, TimeoutCause};
+
+    // RED before fix: fuel timeout must produce a fuel-specific reason, not "plugin timed out".
+    #[test]
+    fn fuel_timeout_reason_identifies_fuel_exhaustion() {
+        let result = PluginResult::Timeout {
+            cause: TimeoutCause::Fuel,
+            stderr: String::new(),
+            elapsed_ms: 5,
+            fuel_consumed: 10_500_000,
+        };
+        let reason = super::extract_reason_from_outcome(&result);
+        let text = reason
+            .as_deref()
+            .expect("fuel timeout must produce Some reason");
+        assert!(
+            text.contains("fuel exhausted"),
+            "fuel timeout block_reason must contain 'fuel exhausted', got: {text:?}"
+        );
+        assert!(
+            !text.contains("timed out"),
+            "fuel timeout block_reason must NOT say 'timed out' — \
+             operators need distinct messages to choose the right remedy; got: {text:?}"
+        );
+        // Consumed-fuel figure surfaces for scale assessment.
+        assert!(
+            text.contains("10500000"),
+            "fuel timeout block_reason should include the consumed-fuel figure \
+             (10500000) so operators can assess scale without log grep; got: {text:?}"
+        );
+    }
+
+    // Epoch timeout must still produce the original "plugin timed out" sentinel —
+    // changing this arm would break existing operator runbooks for slow scripts.
+    #[test]
+    fn epoch_timeout_reason_is_unaffected() {
+        let result = PluginResult::Timeout {
+            cause: TimeoutCause::Epoch,
+            stderr: String::new(),
+            elapsed_ms: 5_001,
+            fuel_consumed: 2_000_000,
+        };
+        let reason = super::extract_reason_from_outcome(&result);
+        assert_eq!(
+            reason.as_deref(),
+            Some("fail-closed: plugin timed out"),
+            "epoch timeout block_reason must remain 'fail-closed: plugin timed out'"
+        );
+    }
+
+    // Crash arm must be untouched — regression guard.
+    #[test]
+    fn crash_reason_is_unaffected() {
+        let result = PluginResult::Crashed {
+            trap_string: "unreachable".to_owned(),
+            stderr: String::new(),
+            elapsed_ms: 1,
+            fuel_consumed: 50_000,
+        };
+        let reason = super::extract_reason_from_outcome(&result);
+        assert_eq!(
+            reason.as_deref(),
+            Some("fail-closed: plugin crashed"),
+            "crash block_reason must remain 'fail-closed: plugin crashed'"
         );
     }
 }

--- a/crates/factory-dispatcher/src/registry.rs
+++ b/crates/factory-dispatcher/src/registry.rs
@@ -184,7 +184,9 @@ impl Default for RegistryDefaults {
     fn default() -> Self {
         Self {
             timeout_ms: 5_000,
-            fuel_cap: 10_000_000,
+            // ADR-042 §Decision 1: raised 10M → 20M (measurement-validated).
+            // Mirrors InvokeLimits::default().fuel_cap; both must be kept in sync.
+            fuel_cap: 20_000_000,
             on_error: OnError::Continue,
             priority: 500,
         }
@@ -567,7 +569,7 @@ extra = { key = "value" }
     fn defaults_applied_when_missing() {
         let reg = Registry::parse_str(minimal_toml()).unwrap();
         assert_eq!(reg.defaults.timeout_ms, 5_000);
-        assert_eq!(reg.defaults.fuel_cap, 10_000_000);
+        assert_eq!(reg.defaults.fuel_cap, 20_000_000);
         assert_eq!(reg.defaults.priority, 500);
         assert_eq!(reg.defaults.on_error, OnError::Continue);
         assert_eq!(reg.hooks[0].priority(&reg.defaults), 500);

--- a/crates/factory-dispatcher/src/registry.rs
+++ b/crates/factory-dispatcher/src/registry.rs
@@ -185,8 +185,9 @@ impl Default for RegistryDefaults {
         Self {
             timeout_ms: 5_000,
             // ADR-042 §Decision 1: raised 10M → 20M (measurement-validated).
-            // Mirrors InvokeLimits::default().fuel_cap; both must be kept in sync.
-            fuel_cap: 20_000_000,
+            // Uses DEFAULT_FUEL_CAP — the single source of truth — so any future
+            // cap change propagates atomically to both Default impls.
+            fuel_cap: crate::invoke::DEFAULT_FUEL_CAP,
             on_error: OnError::Continue,
             priority: 500,
         }
@@ -567,13 +568,17 @@ extra = { key = "value" }
 
     #[test]
     fn defaults_applied_when_missing() {
+        use crate::invoke::DEFAULT_FUEL_CAP;
         let reg = Registry::parse_str(minimal_toml()).unwrap();
         assert_eq!(reg.defaults.timeout_ms, 5_000);
-        assert_eq!(reg.defaults.fuel_cap, 20_000_000);
+        assert_eq!(reg.defaults.fuel_cap, DEFAULT_FUEL_CAP);
         assert_eq!(reg.defaults.priority, 500);
         assert_eq!(reg.defaults.on_error, OnError::Continue);
         assert_eq!(reg.hooks[0].priority(&reg.defaults), 500);
         assert_eq!(reg.hooks[0].timeout_ms(&reg.defaults), 5_000);
+        // Close the chain: accessor resolves to DEFAULT_FUEL_CAP for entries that
+        // don't override fuel_cap in their registry entry (production path via executor.rs).
+        assert_eq!(reg.hooks[0].fuel_cap(&reg.defaults), DEFAULT_FUEL_CAP);
     }
 
     // Cross-field sync guard for the ADR-042 §Decision 1 fuel cap raise (10M → 20M).
@@ -583,34 +588,26 @@ extra = { key = "value" }
     // `InvokeLimits::default().fuel_cap` is the hard limit used by `invoke_plugin`
     // when the caller supplies no explicit limits.
     //
-    // A prose comment in `RegistryDefaults::default()` documents that these must stay
-    // equal, but a comment cannot enforce the invariant: if either value silently drifts
-    // back to 10_000_000, the ~1,200 fuel-exhaustion events/day across 35 plugins that
-    // ADR-042 §Decision 1 eliminates come straight back with no test failure.
-    //
-    // This test pins both values to the ADR-042-settled constant rather than asserting
-    // equality alone. Equality-only would pass if both constants co-drift to the same
-    // wrong value (e.g., both accidentally reset to 10M); pinning makes any unintentional
-    // cap change visible regardless of whether the two constants move together.
-    // Any deliberate future cap change must update this constant, which forces
-    // simultaneous review of both `InvokeLimits` and `RegistryDefaults`.
+    // Both Default impls now reference `DEFAULT_FUEL_CAP` — the single source of truth
+    // in invoke.rs — making drift structurally impossible (a re-introduced literal would
+    // not compile unless it also matched DEFAULT_FUEL_CAP). This test is retained as an
+    // explicit cross-module guard: if either Default impl is refactored to bypass
+    // DEFAULT_FUEL_CAP, this test fails with a message naming which one drifted.
     #[test]
     fn fuel_cap_defaults_stay_in_sync() {
-        use crate::invoke::InvokeLimits;
-
-        const ADR_042_FUEL_CAP: u64 = 20_000_000;
+        use crate::invoke::{DEFAULT_FUEL_CAP, InvokeLimits};
 
         assert_eq!(
             InvokeLimits::default().fuel_cap,
-            ADR_042_FUEL_CAP,
-            "InvokeLimits::default().fuel_cap drifted from the ADR-042 §Decision 1 value; \
-             update both InvokeLimits and RegistryDefaults together",
+            DEFAULT_FUEL_CAP,
+            "InvokeLimits::default().fuel_cap drifted from DEFAULT_FUEL_CAP; \
+             update InvokeLimits::default() to reference invoke::DEFAULT_FUEL_CAP",
         );
         assert_eq!(
             RegistryDefaults::default().fuel_cap,
-            ADR_042_FUEL_CAP,
-            "RegistryDefaults::default().fuel_cap drifted from the ADR-042 §Decision 1 value; \
-             update both InvokeLimits and RegistryDefaults together",
+            DEFAULT_FUEL_CAP,
+            "RegistryDefaults::default().fuel_cap drifted from DEFAULT_FUEL_CAP; \
+             update RegistryDefaults::default() to reference crate::invoke::DEFAULT_FUEL_CAP",
         );
     }
 

--- a/crates/factory-dispatcher/src/registry.rs
+++ b/crates/factory-dispatcher/src/registry.rs
@@ -576,6 +576,44 @@ extra = { key = "value" }
         assert_eq!(reg.hooks[0].timeout_ms(&reg.defaults), 5_000);
     }
 
+    // Cross-field sync guard for the ADR-042 §Decision 1 fuel cap raise (10M → 20M).
+    //
+    // `RegistryDefaults::default().fuel_cap` is the global fallback applied to every
+    // hook plugin that does not override `fuel_cap` in its registry entry.
+    // `InvokeLimits::default().fuel_cap` is the hard limit used by `invoke_plugin`
+    // when the caller supplies no explicit limits.
+    //
+    // A prose comment in `RegistryDefaults::default()` documents that these must stay
+    // equal, but a comment cannot enforce the invariant: if either value silently drifts
+    // back to 10_000_000, the ~1,200 fuel-exhaustion events/day across 35 plugins that
+    // ADR-042 §Decision 1 eliminates come straight back with no test failure.
+    //
+    // This test pins both values to the ADR-042-settled constant rather than asserting
+    // equality alone. Equality-only would pass if both constants co-drift to the same
+    // wrong value (e.g., both accidentally reset to 10M); pinning makes any unintentional
+    // cap change visible regardless of whether the two constants move together.
+    // Any deliberate future cap change must update this constant, which forces
+    // simultaneous review of both `InvokeLimits` and `RegistryDefaults`.
+    #[test]
+    fn fuel_cap_defaults_stay_in_sync() {
+        use crate::invoke::InvokeLimits;
+
+        const ADR_042_FUEL_CAP: u64 = 20_000_000;
+
+        assert_eq!(
+            InvokeLimits::default().fuel_cap,
+            ADR_042_FUEL_CAP,
+            "InvokeLimits::default().fuel_cap drifted from the ADR-042 §Decision 1 value; \
+             update both InvokeLimits and RegistryDefaults together",
+        );
+        assert_eq!(
+            RegistryDefaults::default().fuel_cap,
+            ADR_042_FUEL_CAP,
+            "RegistryDefaults::default().fuel_cap drifted from the ADR-042 §Decision 1 value; \
+             update both InvokeLimits and RegistryDefaults together",
+        );
+    }
+
     #[test]
     fn rejects_unknown_schema_version() {
         // schema_version=3 is unknown — dispatcher expects 2 (REGISTRY_SCHEMA_VERSION).

--- a/crates/factory-dispatcher/tests/full_stack_plugin_invocation.rs
+++ b/crates/factory-dispatcher/tests/full_stack_plugin_invocation.rs
@@ -383,7 +383,6 @@ async fn test_e2e_BC_4_11_001_sync_hook_blocks_unauthorized_factory_path() {
         PluginResult::Timeout { .. } => {
             panic!("TC-1 FAIL: validate-artifact-path timed out (budget=8s, real WASM issue)");
         }
-        _ => unreachable!("no new PluginResult variants expected"),
     }
 
     // Dispatcher exit_code must be 2 (block intent propagates from sync_group)
@@ -490,7 +489,6 @@ async fn test_e2e_BC_4_11_001_sync_hook_continues_authorized_factory_path() {
         PluginResult::Timeout { .. } => {
             panic!("TC-2 FAIL: plugin timed out");
         }
-        _ => unreachable!("no new PluginResult variants expected"),
     }
 
     assert_eq!(
@@ -583,7 +581,6 @@ async fn test_e2e_BC_4_11_001_sync_hook_continues_non_factory_path() {
             PluginResult::Timeout { .. } => {
                 panic!("TC-3 FAIL: plugin timed out on trivial non-.factory/ path");
             }
-            _ => unreachable!("no new PluginResult variants expected"),
         }
     }
     eprintln!(
@@ -1504,7 +1501,6 @@ async fn test_e2e_BC_3_08_001_sync_hook_internal_log_events() {
         PluginResult::Timeout { .. } => {
             panic!("TC-11 FAIL: plugin timed out");
         }
-        _ => unreachable!("no new PluginResult variants expected"),
     }
 
     // Verify the log directory was created (confirms InternalLog is writing)

--- a/crates/factory-dispatcher/tests/full_stack_plugin_invocation.rs
+++ b/crates/factory-dispatcher/tests/full_stack_plugin_invocation.rs
@@ -383,6 +383,7 @@ async fn test_e2e_BC_4_11_001_sync_hook_blocks_unauthorized_factory_path() {
         PluginResult::Timeout { .. } => {
             panic!("TC-1 FAIL: validate-artifact-path timed out (budget=8s, real WASM issue)");
         }
+        _ => unreachable!("no new PluginResult variants expected"),
     }
 
     // Dispatcher exit_code must be 2 (block intent propagates from sync_group)
@@ -489,6 +490,7 @@ async fn test_e2e_BC_4_11_001_sync_hook_continues_authorized_factory_path() {
         PluginResult::Timeout { .. } => {
             panic!("TC-2 FAIL: plugin timed out");
         }
+        _ => unreachable!("no new PluginResult variants expected"),
     }
 
     assert_eq!(
@@ -581,6 +583,7 @@ async fn test_e2e_BC_4_11_001_sync_hook_continues_non_factory_path() {
             PluginResult::Timeout { .. } => {
                 panic!("TC-3 FAIL: plugin timed out on trivial non-.factory/ path");
             }
+            _ => unreachable!("no new PluginResult variants expected"),
         }
     }
     eprintln!(
@@ -1501,6 +1504,7 @@ async fn test_e2e_BC_3_08_001_sync_hook_internal_log_events() {
         PluginResult::Timeout { .. } => {
             panic!("TC-11 FAIL: plugin timed out");
         }
+        _ => unreachable!("no new PluginResult variants expected"),
     }
 
     // Verify the log directory was created (confirms InternalLog is writing)

--- a/crates/hook-plugins/validate-index-cite-refresh/Cargo.toml
+++ b/crates/hook-plugins/validate-index-cite-refresh/Cargo.toml
@@ -25,8 +25,9 @@ vsdd-hook-sdk = { path = "../../hook-sdk" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 # NOTE: No `regex` crate — hand-rolled scanning is used to stay within the
-# WASM fuel budget. The regex crate's DFA compilation exhausts even a 20M
-# fuel cap on first call. See src/lib.rs extract_index_cites().
+# WASM fuel budget. The regex crate's DFA compilation exhausted the former 10M
+# fuel cap on first call; not re-measured at the current 20M cap.
+# See src/lib.rs extract_index_cites().
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/hook-plugins/validate-index-cite-refresh/Cargo.toml
+++ b/crates/hook-plugins/validate-index-cite-refresh/Cargo.toml
@@ -25,8 +25,8 @@ vsdd-hook-sdk = { path = "../../hook-sdk" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 # NOTE: No `regex` crate — hand-rolled scanning is used to stay within the
-# WASM 10M fuel budget. The regex crate's DFA compilation exhausts the fuel
-# cap on first call. See src/lib.rs extract_index_cites().
+# WASM fuel budget. The regex crate's DFA compilation exhausts even a 20M
+# fuel cap on first call. See src/lib.rs extract_index_cites().
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/hook-plugins/validate-index-cite-refresh/src/lib.rs
+++ b/crates/hook-plugins/validate-index-cite-refresh/src/lib.rs
@@ -173,7 +173,7 @@ fn parse_leading_digits(s: &str) -> Option<(u32, usize)> {
 ///
 /// Uses hand-rolled scanning: locate each `INDEX v` token, parse the
 /// digits, skip malformed tokens.  No regex crate — keeps WASM fuel
-/// consumption within the 10M default budget.
+/// consumption within the 20M default budget (ADR-042 §Decision 1).
 ///
 /// Each returned `VersionCite` carries the 1-based line number where the
 /// cite appears, so callers can populate `Violation::location`.

--- a/crates/hook-plugins/validate-state-structure/src/lib.rs
+++ b/crates/hook-plugins/validate-state-structure/src/lib.rs
@@ -1336,7 +1336,7 @@ pub fn check_phase_progress_rows(content: &str) -> Option<Violation> {
 /// The heading prefix strings are pre-computed ONCE outside the per-line scan loop to avoid
 /// `format!()` allocations inside the hot-path closure. A naive implementation that called
 /// `format!("{heading_prefix} ")` and `format!("{heading_prefix}(")` inside the closure
-/// allocated two new Strings per line, exhausting the 10M fuel budget on the live 426-line
+/// allocated two new Strings per line, exhausting the former 10M fuel budget on the live 426-line
 /// STATE.md. Pre-computing strings once reduces allocations from O(n_lines) to O(1).
 ///
 /// # BC trace


### PR DESCRIPTION
## Fix: ADR-042 v1.2 / D-964 — WASM Fuel Cap + Disambiguation

**Authority:** ADR-042 v1.2, ADR-040 v1.1, D-964(b)/(h)
**Severity:** HIGH — silent hook validation chain failure under production load

### Problem

The WASM plugin fuel cap was set to 10M units. Measured fuel-exhaustion events reached 838→1,226 in a single session across **35 distinct plugins**, silently disabling the hook validation chain on large `.factory/` writes.

Root cause: worst-case payload (ARCH-INDEX + 50 KB `last_assistant_message`, 377,109 bytes) consumed **10,406,058 fuel** — exceeding the 10M cap by ~4%. The failure surfaced to agents as an ambiguous `fail-closed: plugin timed out`, indistinguishable from a real wall-clock timeout.

Two distinct fixes and one load-bearing test guard in this PR:

### Commit 1: `182dfc68` — Fuel cap 10M → 20M

- `InvokeLimits::default().fuel_cap`: 10M → 20M (`crates/factory-dispatcher/src/invoke.rs`)
- `RegistryDefaults::default().fuel_cap`: 10M → 20M (`crates/factory-dispatcher/src/registry.rs`)
- Existing registry test updated to match the new default
- Two new regression tests: `invoke_limits_default_fuel_cap_is_20m` and `fuel_workload_exhausts_10m_completes_at_20m` (WAT arithmetic loop @ ~10.8M fuel verifies both the exhaustion at 10M and success at 20M)
- Comment updates in `validate-index-cite-refresh` Cargo.toml + lib.rs and `validate-state-structure` lib.rs: update stale "10M budget" references to "20M" (ADR-042 §Decision 1)

### Commit 2: `7cbb9232` — Fuel-vs-epoch `block_reason` disambiguation

- `extract_reason_from_outcome()` in `crates/factory-dispatcher/src/main.rs`: split the single `PluginResult::Timeout` arm into two arms by `TimeoutCause`
  - `TimeoutCause::Fuel` → `"fail-closed: fuel exhausted ({N} units consumed; raise fuel_cap or reduce payload size)"`
  - `TimeoutCause::Epoch` → unchanged `"fail-closed: plugin timed out"`
- Three new regression tests in `tests_extract_reason_cause_distinction`: fuel arm, epoch arm (confirms no regression), crash arm (confirms no regression)
- Imports `TimeoutCause` in `main.rs`

### Commit 3: `4bd626c5` — Cross-field sync guard for ADR-042 fuel cap

- `fuel_cap_defaults_stay_in_sync` test in `crates/factory-dispatcher/src/registry.rs`
- Pins a named constant `ADR_042_FUEL_CAP: u64 = 20_000_000` and asserts **both** `InvokeLimits::default().fuel_cap` and `RegistryDefaults::default().fuel_cap` against it
- Rationale: the two structs (`InvokeLimits` and `RegistryDefaults`) carry independent `fuel_cap` fields that must always agree. Prior to this commit, only a prose comment bound them — a future change to one field would silently diverge without any test failure. Pinning against a named constant (rather than asserting bare equality) also catches co-drift — the case where both constants are reset to the same wrong value, which is the realistic regression when a cap change is reverted wholesale
- Closes a `pr-reviewer` NIT in-scope per TD-VSDD-060 (sibling-site sweep) rather than deferring it
- Load-bearing character verified by perturbation: test passes on correct code, FAILS when one constant is set to `10_000_000`, and passes again after revert. The perturbation was not committed — verified via `git show --stat` (38 insertions, 0 deletions in one file)

### Why This Matters

Landing on `develop` is the prerequisite for a later cross-compile release that rebuilds the bundled binaries under `plugins/vsdd-factory/hooks/dispatcher/bin/` and the operator cache at `1.0.0-rc.23`. The binaries currently embed the 10M cap.

### Testing

- [x] All existing tests pass (`cargo test --workspace --all-targets`)
- [x] New test `invoke_limits_default_fuel_cap_is_20m`: asserts default is 20M
- [x] New test `fuel_workload_exhausts_10m_completes_at_20m`: WAT loop at ~10.8M fuel — fails at 10M cap (Timeout::Fuel), passes at 20M cap (Ok)
- [x] New tests `fuel_timeout_reason_identifies_fuel_exhaustion`, `epoch_timeout_reason_is_unaffected`, `crash_reason_is_unaffected`: full coverage of the three `extract_reason_from_outcome` arms
- [x] New test `fuel_cap_defaults_stay_in_sync`: pins `ADR_042_FUEL_CAP = 20_000_000` and asserts both `InvokeLimits::default().fuel_cap` and `RegistryDefaults::default().fuel_cap` against it — catches independent-field divergence that bare equality cannot detect

### Security Note

This is a WASM sandbox resource-limit change. The fuel cap raise increases the maximum CPU-equivalent work a single plugin invocation can perform before being terminated. Security review (CWE-400/CWE-770 DoS surface) is requested.