### PR TITLE
fix(hooks): linear ID-strip + awk length guard to stop CPU-runaway backtracking on 195KB lines

### DIFF
--- a/plugins/vsdd-factory/hooks/validate-count-propagation.sh
+++ b/plugins/vsdd-factory/hooks/validate-count-propagation.sh
@@ -97,18 +97,24 @@ fi
 _is_historical_heading() {
   case "${1,,}" in
     "## changelog"* | "## change log"* | "## historical content"* | \
-    "## phase progress"* | "## decisions log"*)
+    "## phase progress"* | "## decisions log"* | "## drift items"*)
       return 0 ;;
   esac
   return 1
 }
 
 # Extract count-bearing pairs from a file.
-# Outputs lines of format: KEYWORD:COUNT
+# Outputs lines of format: KEYWORD:COUNT:RANK
+#   RANK 0 — authoritative (YAML frontmatter keys like total_bcs:, total_vps:)
+#   RANK 1 — prose (pattern-matched text like "42 BCs")
+# Using a rank allows callers to prefer frontmatter over prose when both appear
+# in the same file (e.g., STATE.md has "total_vps: 107" and also "19 VPs per
+# §VP Anchors" in prose — rank 0 wins).
+#
 # Supported patterns:
-#   "NNN BCs" / "NNN,NNN BCs" — count before keyword
-#   "BCs | NNN" / "BCs: NNN" — keyword before count (table or YAML)
-#   "total_bcs: NNN" / "total_vps: NNN" — YAML frontmatter keys
+#   "NNN BCs" / "NNN,NNN BCs" — count before keyword (rank 1)
+#   "BCs | NNN" / "BCs: NNN" — keyword before count (table or YAML) (rank 1)
+#   "total_bcs: NNN" / "total_vps: NNN" — YAML frontmatter keys (rank 0)
 # Count mentions inside historical H2 sections (see _is_historical_heading) are
 # skipped so frozen records are never compared against the current count (#567).
 _extract_counts() {
@@ -127,10 +133,11 @@ _extract_counts() {
   #     Skipping (not truncating) avoids token-split artefacts: a
   #     mid-ID truncation could produce a phantom digit sequence.
   #     Semantic delta: pre-fix, the hook hung on >8192-char lines and never
-  #     emitted a verdict; post-fix, it completes and uses the correct totals
-  #     (stale changelog entries are skipped explicitly via the frontmatter guard
-  #     above and implicitly via this length filter). This is an intentional
-  #     improvement, not a no-op.
+  #     emitted a verdict; post-fix, it completes. The length filter removes
+  #     oversized lines (typically frozen changelog blobs) from extraction
+  #     scope, so stale counts embedded in those blobs no longer shadow
+  #     authoritative frontmatter values. This is an intentional improvement,
+  #     not a no-op.
   #     S-25.01 / fix/count-propagation-cpu-runaway.
   #
   #   Pass 2 — sed -E ID-strip: remove <letters>-<digits-and-dots> tokens
@@ -140,17 +147,29 @@ _extract_counts() {
   #     and GNU sed (Linux).
   #
   #     Contrast with the prior extglob form "${line//+([A-Za-z])-+([0-9.])/}":
-  #     that form ran per-line inside the loop.  Two failure modes:
-  #       a) On a single ~195KB line, bash's global-replace did O(n*k) string
-  #          copies (n = line length, k = match count ≈ 8000), spinning a full
-  #          core for >12s in PostToolUse and orphaning the process at PPID 1.
-  #       b) Even for short lines, 2595 per-line subshell invocations of
-  #          `printf '%s' … | sed …` added ~20s of fork-overhead on macOS.
+  #     that form ran per-line inside the loop. On a single ~195KB line, bash's
+  #     global-replace did O(n*k) string copies (n = line length,
+  #     k = match count ≈ 8000), spinning a full core for >12s in PostToolUse
+  #     and orphaning the process at PPID 1.
   #     A single whole-file sed pass has O(1) spawn cost and O(n) scan cost.
+  #
+  #   Error propagation: a process substitution `done < <(awk | sed)` silently
+  #     discards awk/sed failures under set -e (the pipe runs in a subshell,
+  #     so set -e does not propagate to the parent loop). Explicit temp file +
+  #     || error path guarantees the pipeline failure is detected and the
+  #     function returns 1 rather than silently producing zero counts
+  #     (false-pass: "no drift found").
   #
   #   Heading lines (## …) are inspected AFTER both passes; canonical heading
   #   names used by _is_historical_heading contain no ID tokens, so the strip
   #   does not affect historical-section boundary detection.
+  local _preproc_tmp
+  _preproc_tmp="$(mktemp)"
+  awk 'length <= 8192' "$path" | sed -E 's/[A-Za-z]+-[0-9.]+//g' > "$_preproc_tmp" || {
+    echo "validate-count-propagation: preprocessing pipeline failed for $path" >&2
+    rm -f "$_preproc_tmp"
+    return 1
+  }
   while IFS= read -r line; do
     local count keyword
     # Skip YAML frontmatter changelog scalars — frozen historical records,
@@ -159,42 +178,56 @@ _extract_counts() {
     # totals; they should never be treated as the source-of-truth quantity.
     # S-25.01 review cycle 2 fix (BLOCKING-1).
     [[ "$line" =~ ^[[:space:]]*(last_amended|change): ]] && continue
+    # Skip all blockquote lines (any line starting with ">").
+    # In factory index files, blockquotes are exclusively historical or documentary
+    # records (e.g., "> Updated 2026-05-07: … 15 BCs", "> **E-8 batch authoring:**
+    # … 22 BCs anchored", "> D-443(b)(i) exemption …").  None carry an authoritative
+    # live count — they record past operations or policy notes.  Skipping all ">"-
+    # prefixed lines is simpler, more complete, and safe for the project convention.
+    [[ "$line" =~ ^[[:space:]]*'>' ]] && continue
     # Track historical-section boundaries; skip counts while inside one.
     if [[ "$line" =~ ^##[[:space:]] ]]; then
       if _is_historical_heading "$line"; then in_historical=1; else in_historical=0; fi
     fi
     [[ "$in_historical" -eq 1 ]] && continue
-    # Pattern A: count before keyword
+    # Pattern A: count before keyword (rank 1 — prose)
     if [[ "$line" =~ ([0-9][0-9,]+)[[:space:]]+(BCs|VPs|stories|capabilities|subsystems) ]]; then
       keyword="${BASH_REMATCH[2]}"
       count="${BASH_REMATCH[1]//,/}"
-      echo "${keyword}:${count}"
+      echo "${keyword}:${count}:1"
     fi
-    # Pattern B: keyword before count (table cell or colon-value)
+    # Pattern B: keyword before count (table cell or colon-value) (rank 1 — prose)
     if [[ "$line" =~ (BCs|VPs|stories|capabilities)[[:space:]]*[|:][[:space:]]*([0-9][0-9,]+) ]]; then
       keyword="${BASH_REMATCH[1]}"
       count="${BASH_REMATCH[2]//,/}"
-      echo "${keyword}:${count}"
+      echo "${keyword}:${count}:1"
     fi
-    # Pattern C: YAML "total_bcs: NNN"
+    # Pattern C: YAML "total_bcs: NNN" (rank 0 — authoritative frontmatter)
     if [[ "$line" =~ total_bcs:[[:space:]]*([0-9][0-9,]+) ]]; then
       count="${BASH_REMATCH[1]//,/}"
-      echo "BCs:${count}"
+      echo "BCs:${count}:0"
     fi
-    # Pattern D: YAML "total_vps: NNN"
+    # Pattern D: YAML "total_vps: NNN" (rank 0 — authoritative frontmatter)
     if [[ "$line" =~ total_vps:[[:space:]]*([0-9][0-9,]+) ]]; then
       count="${BASH_REMATCH[1]//,/}"
-      echo "VPs:${count}"
+      echo "VPs:${count}:0"
     fi
-  done < <(awk 'length <= 8192' "$path" | sed -E 's/[A-Za-z]+-[0-9.]+//g')
+  done < "$_preproc_tmp"
+  rm -f "$_preproc_tmp"
 }
 
-# Extract counts from modified file (first occurrence per keyword wins)
+# Extract counts from modified file using rank-based precedence.
+# Frontmatter keys (rank 0) beat prose patterns (rank 1) for the same keyword,
+# so "total_vps: 107" wins over "19 VPs per §VP Anchors" appearing earlier.
 declare -A SOURCE_COUNTS
-while IFS=: read -r kw cnt; do
+declare -A COUNT_RANK
+while IFS=: read -r kw cnt rnk; do
   [[ -z "$kw" || -z "$cnt" ]] && continue
-  if [[ -z "${SOURCE_COUNTS[$kw]:-}" ]]; then
+  _new_rank="${rnk:-9}"
+  _stored_rank="${COUNT_RANK[$kw]:-9}"
+  if [[ "$_new_rank" -lt "$_stored_rank" ]]; then
     SOURCE_COUNTS["$kw"]="$cnt"
+    COUNT_RANK["$kw"]="$_new_rank"
   fi
 done < <(_extract_counts "$FILE_PATH")
 
@@ -217,12 +250,18 @@ for keyword in "${!SOURCE_COUNTS[@]}"; do
   source_count="${SOURCE_COUNTS[$keyword]}"
 
   for sibling in "${SIBLING_FILES[@]}"; do
-    # Extract first matching count for this keyword from sibling
+    # Extract best-ranked count for this keyword from sibling using rank precedence.
+    # Read all entries (no early break) so a rank-0 entry appearing after a rank-1
+    # entry in the same file is not missed.
     sib_count=""
-    while IFS=: read -r kw cnt; do
+    _sib_rank=9
+    while IFS=: read -r kw cnt rnk; do
       if [[ "$kw" == "$keyword" ]]; then
-        sib_count="$cnt"
-        break
+        _entry_rank="${rnk:-9}"
+        if [[ "$_entry_rank" -lt "$_sib_rank" ]]; then
+          sib_count="$cnt"
+          _sib_rank="$_entry_rank"
+        fi
       fi
     done < <(_extract_counts "$sibling")
 

--- a/plugins/vsdd-factory/hooks/validate-count-propagation.sh
+++ b/plugins/vsdd-factory/hooks/validate-count-propagation.sh
@@ -94,6 +94,13 @@ fi
 # current count — comparing it as drift is the #567 false positive. Boundaries
 # use the same "^## opens, next ^## closes" idiom as
 # validate-changelog-monotonicity.sh.
+#
+# "## Drift Items" is included as defence-in-depth consistent with the historical
+# heading convention: if a drift-items section ever appears earlier in a file than
+# the authoritative live count, table cells in that section (e.g., stale snapshots
+# of BCs/VPs counts at the time the item was recorded) must not shadow the live
+# count. This does not change the verdict for any file in the current corpus —
+# all live authoritative counts appear outside drift-items sections today.
 _is_historical_heading() {
   case "${1,,}" in
     "## changelog"* | "## change log"* | "## historical content"* | \
@@ -107,9 +114,13 @@ _is_historical_heading() {
 # Outputs lines of format: KEYWORD:COUNT:RANK
 #   RANK 0 — authoritative (YAML frontmatter keys like total_bcs:, total_vps:)
 #   RANK 1 — prose (pattern-matched text like "42 BCs")
-# Using a rank allows callers to prefer frontmatter over prose when both appear
-# in the same file (e.g., STATE.md has "total_vps: 107" and also "19 VPs per
-# §VP Anchors" in prose — rank 0 wins).
+# Rank-precedence is forward-looking hardening: if a corpus file ever has a
+# rank-0 frontmatter key that appears after a rank-1 prose mention in file
+# order, the rank-0 value still wins. No current corpus file exercises this
+# today — VP-INDEX.md and BC-INDEX.md have total_vps: / total_bcs: frontmatter
+# keys (rank-0) but they appear before any prose count mentions in file order,
+# so rank precedence is not decisive in practice. STATE.md has no total_vps:
+# or total_bcs: frontmatter keys at all.
 #
 # Supported patterns:
 #   "NNN BCs" / "NNN,NNN BCs" — count before keyword (rank 1)
@@ -165,6 +176,7 @@ _extract_counts() {
   #   does not affect historical-section boundary detection.
   local _preproc_tmp
   _preproc_tmp="$(mktemp)"
+  trap 'rm -f "$_preproc_tmp"' RETURN
   awk 'length <= 8192' "$path" | sed -E 's/[A-Za-z]+-[0-9.]+//g' > "$_preproc_tmp" || {
     echo "validate-count-propagation: preprocessing pipeline failed for $path" >&2
     rm -f "$_preproc_tmp"
@@ -179,11 +191,14 @@ _extract_counts() {
     # S-25.01 review cycle 2 fix (BLOCKING-1).
     [[ "$line" =~ ^[[:space:]]*(last_amended|change): ]] && continue
     # Skip all blockquote lines (any line starting with ">").
-    # In factory index files, blockquotes are exclusively historical or documentary
-    # records (e.g., "> Updated 2026-05-07: … 15 BCs", "> **E-8 batch authoring:**
-    # … 22 BCs anchored", "> D-443(b)(i) exemption …").  None carry an authoritative
-    # live count — they record past operations or policy notes.  Skipping all ">"-
-    # prefixed lines is simpler, more complete, and safe for the project convention.
+    # Factory files use blockquotes for both historical records AND live banner-cite
+    # content (e.g., STATE.md Session Resume Checkpoint, refreshed every Commit E,
+    # carries current totals like "1,993 BCs", "107 VPs", "175 stories" on blockquote
+    # lines).  Both categories are skipped: historical records must not shadow live
+    # counts (#567 class); live banner-cite counts are redundant with the same values
+    # on non-blockquote lines in the same file, so no detection is lost by excluding
+    # blockquote lines.  Skipping all ">"-prefixed lines is simpler and more complete
+    # than trying to classify blockquote intent at parse time.
     [[ "$line" =~ ^[[:space:]]*'>' ]] && continue
     # Track historical-section boundaries; skip counts while inside one.
     if [[ "$line" =~ ^##[[:space:]] ]]; then
@@ -217,10 +232,21 @@ _extract_counts() {
 }
 
 # Extract counts from modified file using rank-based precedence.
-# Frontmatter keys (rank 0) beat prose patterns (rank 1) for the same keyword,
-# so "total_vps: 107" wins over "19 VPs per §VP Anchors" appearing earlier.
+# Frontmatter keys (rank 0) beat prose patterns (rank 1) for the same keyword.
+# Rank-precedence is forward-looking hardening: should a file ever have a
+# rank-0 entry appearing after a rank-1 entry in file order, the rank-0 value
+# still wins. No current corpus file exercises this for STATE.md, but
+# VP-INDEX.md and BC-INDEX.md both have total_vps: / total_bcs: frontmatter
+# keys at rank 0.
 declare -A SOURCE_COUNTS
 declare -A COUNT_RANK
+_src_tmp="$(mktemp)"
+_sib_tmp="$(mktemp)"
+trap 'rm -f "$_src_tmp" "$_sib_tmp"' EXIT
+if ! _extract_counts "$FILE_PATH" > "$_src_tmp"; then
+  echo "validate-count-propagation: count extraction failed for $FILE_PATH" >&2
+  exit 2
+fi
 while IFS=: read -r kw cnt rnk; do
   [[ -z "$kw" || -z "$cnt" ]] && continue
   _new_rank="${rnk:-9}"
@@ -229,7 +255,7 @@ while IFS=: read -r kw cnt rnk; do
     SOURCE_COUNTS["$kw"]="$cnt"
     COUNT_RANK["$kw"]="$_new_rank"
   fi
-done < <(_extract_counts "$FILE_PATH")
+done < "$_src_tmp"
 
 # Nothing to compare if no count patterns found.
 # Guard via ${arr[*]:-} rather than ${#arr[@]}: under `set -u`, expanding the
@@ -255,6 +281,10 @@ for keyword in "${!SOURCE_COUNTS[@]}"; do
     # entry in the same file is not missed.
     sib_count=""
     _sib_rank=9
+    if ! _extract_counts "$sibling" > "$_sib_tmp"; then
+      echo "validate-count-propagation: count extraction failed for $sibling" >&2
+      exit 2
+    fi
     while IFS=: read -r kw cnt rnk; do
       if [[ "$kw" == "$keyword" ]]; then
         _entry_rank="${rnk:-9}"
@@ -263,7 +293,7 @@ for keyword in "${!SOURCE_COUNTS[@]}"; do
           _sib_rank="$_entry_rank"
         fi
       fi
-    done < <(_extract_counts "$sibling")
+    done < "$_sib_tmp"
 
     # Absence of keyword in sibling is NOT drift — only report mismatch
     if [[ -n "$sib_count" ]] && [[ "$sib_count" != "$source_count" ]]; then

--- a/plugins/vsdd-factory/hooks/validate-count-propagation.sh
+++ b/plugins/vsdd-factory/hooks/validate-count-propagation.sh
@@ -118,10 +118,19 @@ _extract_counts() {
   # per-line operation ever sees a mega-line or a raw ID token:
   #
   #   Pass 1 — awk length filter: drop lines > 8192 chars.
-  #     A legitimate count keyword ("42 BCs", "total_bcs: 42") is a short
-  #     token that cannot live in a 195KB line (the BC-INDEX.md last_amended:
-  #     blob).  Skipping (not truncating) avoids token-split artefacts: a
+  #     A legitimate count keyword ("42 BCs", "total_bcs: 42") is typically a
+  #     short token. Additionally, lines > 8192 chars are frozen historical
+  #     changelog records (e.g., last_amended: blobs) whose embedded counts are
+  #     stale and must not shadow real totals — the explicit frontmatter skip
+  #     below handles the named fields, but the length guard provides
+  #     defence-in-depth for any other oversized record.
+  #     Skipping (not truncating) avoids token-split artefacts: a
   #     mid-ID truncation could produce a phantom digit sequence.
+  #     Semantic delta: pre-fix, the hook hung on >8192-char lines and never
+  #     emitted a verdict; post-fix, it completes and uses the correct totals
+  #     (stale changelog entries are skipped explicitly via the frontmatter guard
+  #     above and implicitly via this length filter). This is an intentional
+  #     improvement, not a no-op.
   #     S-25.01 / fix/count-propagation-cpu-runaway.
   #
   #   Pass 2 — sed -E ID-strip: remove <letters>-<digits-and-dots> tokens
@@ -144,6 +153,12 @@ _extract_counts() {
   #   does not affect historical-section boundary detection.
   while IFS= read -r line; do
     local count keyword
+    # Skip YAML frontmatter changelog scalars — frozen historical records,
+    # same rationale as _is_historical_heading (#567), which only reaches H2 sections.
+    # The last_amended: and change: scalars embed stale counts that shadow current
+    # totals; they should never be treated as the source-of-truth quantity.
+    # S-25.01 review cycle 2 fix (BLOCKING-1).
+    [[ "$line" =~ ^[[:space:]]*(last_amended|change): ]] && continue
     # Track historical-section boundaries; skip counts while inside one.
     if [[ "$line" =~ ^##[[:space:]] ]]; then
       if _is_historical_heading "$line"; then in_historical=1; else in_historical=0; fi

--- a/plugins/vsdd-factory/hooks/validate-count-propagation.sh
+++ b/plugins/vsdd-factory/hooks/validate-count-propagation.sh
@@ -175,7 +175,15 @@ _extract_counts() {
   #   names used by _is_historical_heading contain no ID tokens, so the strip
   #   does not affect historical-section boundary detection.
   local _preproc_tmp
-  _preproc_tmp="$(mktemp)"
+  # S-1 fail-closed hardening: only exit 2 is blocking under this project's
+  # hook semantics (see below); mktemp failure must not degrade to a silent
+  # non-blocking "no verdict" on a TMPDIR-exhausted / read-only-tmp host.
+  # exit here (not return 1) so a mktemp failure inside this function cannot
+  # be swallowed by a caller that forgets to gate on the return code.
+  _preproc_tmp="$(mktemp)" || {
+    echo "validate-count-propagation: mktemp failed in _extract_counts" >&2
+    exit 2
+  }
   trap 'rm -f "$_preproc_tmp"' RETURN
   awk 'length <= 8192' "$path" | sed -E 's/[A-Za-z]+-[0-9.]+//g' > "$_preproc_tmp" || {
     echo "validate-count-propagation: preprocessing pipeline failed for $path" >&2
@@ -190,16 +198,37 @@ _extract_counts() {
     # totals; they should never be treated as the source-of-truth quantity.
     # S-25.01 review cycle 2 fix (BLOCKING-1).
     [[ "$line" =~ ^[[:space:]]*(last_amended|change): ]] && continue
-    # Skip all blockquote lines (any line starting with ">").
-    # Factory files use blockquotes for both historical records AND live banner-cite
-    # content (e.g., STATE.md Session Resume Checkpoint, refreshed every Commit E,
-    # carries current totals like "1,993 BCs", "107 VPs", "175 stories" on blockquote
-    # lines).  Both categories are skipped: historical records must not shadow live
-    # counts (#567 class); live banner-cite counts are redundant with the same values
-    # on non-blockquote lines in the same file, so no detection is lost by excluding
-    # blockquote lines.  Skipping all ">"-prefixed lines is simpler and more complete
-    # than trying to classify blockquote intent at parse time.
-    [[ "$line" =~ ^[[:space:]]*'>' ]] && continue
+    # Skip ONLY genuinely documentary/historical blockquote forms — not every
+    # ">"-prefixed line (cycle-4 BLOCKING-C fix). A blanket "^>" skip is wrong:
+    # BC-INDEX.md's SOLE carrier of the live "subsystems" count is a blockquote
+    # banner line ("> Master index of all N behavioral contracts across M
+    # subsystems."), so a blanket skip silently kills subsystems drift
+    # detection for that file. Two blockquote FORMS are, by corpus convention,
+    # reliably historical/documentary narrative rather than a live count:
+    #
+    #   1. Date-stamped changelog notes: "> Updated YYYY-MM-DD: ..." or the
+    #      "> Updated in <label> (YYYY-MM-DD): ..." variant (STORY-INDEX.md
+    #      changelog blockquotes). These record what happened on a past date;
+    #      any count embedded in them (e.g., a per-burst point tally) is a
+    #      frozen historical snapshot, not the current corpus total.
+    #   2. Bold-prefixed narrative prose: "> **...**" (e.g., STORY-INDEX.md's
+    #      "> **E-8 Tier 1 batch authoring (2026-04-30):** ... 22 BCs
+    #      anchored ...", or wave/pass re-anchor summaries). These are
+    #      per-story/per-wave/per-pass local tallies, not corpus totals, and
+    #      were the original #567-class false-positive source this guard
+    #      exists to suppress.
+    #
+    # A plain (non-bold, non-"Updated") blockquote line — such as the
+    # BC-INDEX.md master-index banner — is NOT skipped: it falls through to
+    # the normal Pattern A-D extraction below like any other line, so a live
+    # count that happens to be blockquote-formatted is still checked for
+    # drift.
+    if [[ "$line" =~ ^[[:space:]]*'>' ]]; then
+      if [[ "$line" =~ ^[[:space:]]*'>'[[:space:]]*Updated[[:space:]] ]] \
+        || [[ "$line" =~ ^[[:space:]]*'>'[[:space:]]*\*\* ]]; then
+        continue
+      fi
+    fi
     # Track historical-section boundaries; skip counts while inside one.
     if [[ "$line" =~ ^##[[:space:]] ]]; then
       if _is_historical_heading "$line"; then in_historical=1; else in_historical=0; fi
@@ -240,8 +269,15 @@ _extract_counts() {
 # keys at rank 0.
 declare -A SOURCE_COUNTS
 declare -A COUNT_RANK
-_src_tmp="$(mktemp)"
-_sib_tmp="$(mktemp)"
+# S-1 fail-closed hardening: gate both mktemp calls to exit 2 explicitly.
+# Under `set -e` a bare `var="$(mktemp)"` failure already terminates the
+# script, but with mktemp's own exit status (1) rather than 2 — and this
+# project's hook semantics treat ONLY exit 2 as blocking; any other non-zero
+# code is silently non-blocking. Without this explicit gate, a
+# TMPDIR-exhausted / read-only-tmp host would degrade the hook to
+# "no verdict, not blocking" instead of failing closed.
+_src_tmp="$(mktemp)" || { echo "validate-count-propagation: mktemp failed for source temp file" >&2; exit 2; }
+_sib_tmp="$(mktemp)" || { echo "validate-count-propagation: mktemp failed for sibling temp file" >&2; exit 2; }
 trap 'rm -f "$_src_tmp" "$_sib_tmp"' EXIT
 if ! _extract_counts "$FILE_PATH" > "$_src_tmp"; then
   echo "validate-count-propagation: count extraction failed for $FILE_PATH" >&2

--- a/plugins/vsdd-factory/hooks/validate-count-propagation.sh
+++ b/plugins/vsdd-factory/hooks/validate-count-propagation.sh
@@ -12,12 +12,16 @@
 #   4. Exit 0 on no drift OR if count is absent from a sibling file (absence != drift).
 #
 # Scope limit: reports drift, does not modify files, does not interpret semantics.
-# Performance: deterministic, <200ms on typical corpus.
+# Performance: O(n) two-pass pre-processing (awk length filter + sed ID-strip) before
+# the per-line loop; <1s on real corpus files including BC-INDEX.md with 2595 lines
+# and a single ~195KB last_amended: blob (S-25.01 CPU-runaway fix).
 #
 # S-7.02 / BC-7.05.001, BC-7.05.002
 
 set -euo pipefail
-shopt -s extglob
+# extglob is no longer needed: the ID-token strip moved to a whole-file sed pass
+# (S-25.01 fix/count-propagation-cpu-runaway). Kept disabled to prevent accidental
+# re-introduction of extglob patterns that could backtrack on long lines.
 
 # Source canonical block-message helper if available (provides block_pre).
 _SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -110,27 +114,41 @@ _is_historical_heading() {
 _extract_counts() {
   local path="$1"
   local in_historical=0
+  # Pre-process the file in two O(n) passes BEFORE the per-line loop so no
+  # per-line operation ever sees a mega-line or a raw ID token:
+  #
+  #   Pass 1 — awk length filter: drop lines > 8192 chars.
+  #     A legitimate count keyword ("42 BCs", "total_bcs: 42") is a short
+  #     token that cannot live in a 195KB line (the BC-INDEX.md last_amended:
+  #     blob).  Skipping (not truncating) avoids token-split artefacts: a
+  #     mid-ID truncation could produce a phantom digit sequence.
+  #     S-25.01 / fix/count-propagation-cpu-runaway.
+  #
+  #   Pass 2 — sed -E ID-strip: remove <letters>-<digits-and-dots> tokens
+  #     (BC-1.18.003, VP-105, E-11, S-3, TD-001) so their embedded digits are
+  #     not parsed as quantities (#690).  sed -E uses a provably-linear NFA;
+  #     no backtracking is possible.  `sed -E` is portable to BSD sed (macOS)
+  #     and GNU sed (Linux).
+  #
+  #     Contrast with the prior extglob form "${line//+([A-Za-z])-+([0-9.])/}":
+  #     that form ran per-line inside the loop.  Two failure modes:
+  #       a) On a single ~195KB line, bash's global-replace did O(n*k) string
+  #          copies (n = line length, k = match count ≈ 8000), spinning a full
+  #          core for >12s in PostToolUse and orphaning the process at PPID 1.
+  #       b) Even for short lines, 2595 per-line subshell invocations of
+  #          `printf '%s' … | sed …` added ~20s of fork-overhead on macOS.
+  #     A single whole-file sed pass has O(1) spawn cost and O(n) scan cost.
+  #
+  #   Heading lines (## …) are inspected AFTER both passes; canonical heading
+  #   names used by _is_historical_heading contain no ID tokens, so the strip
+  #   does not affect historical-section boundary detection.
   while IFS= read -r line; do
     local count keyword
     # Track historical-section boundaries; skip counts while inside one.
-    # Runs BEFORE the ID-token drop below so headings are inspected verbatim
-    # and historical lines skip the per-line mutation entirely.
     if [[ "$line" =~ ^##[[:space:]] ]]; then
       if _is_historical_heading "$line"; then in_historical=1; else in_historical=0; fi
     fi
     [[ "$in_historical" -eq 1 ]] && continue
-    # Drop identifier tokens (E-11, S-3, BC-2.1.001, TD-001, SS-01) before
-    # count extraction: the digits inside an ID are not a quantity. Without
-    # this, "5 E-11 stories" mis-parses "11 stories" as a phantom count and
-    # fires a false count-propagation drift (#690). Matches <letters>-<digits-
-    # and-dots> so multi-part BC/VP ids are dropped whole. Deliberately flat:
-    # a nested extglob (`?(*(.+([0-9])))`) matches the same ID tokens but
-    # backtracks super-linearly on long dotted-id lines (33s on a 600-char
-    # line of BC-N.NN.NN tokens vs 0.5s flat), and this runs per line on
-    # repo-controlled content. The flat class additionally eats dots glued to
-    # an ID (e.g. a sentence period in "delivered E-11."), which is harmless
-    # here — a whitespace-separated count token can never contain them.
-    line="${line//+([A-Za-z])-+([0-9.])/}"
     # Pattern A: count before keyword
     if [[ "$line" =~ ([0-9][0-9,]+)[[:space:]]+(BCs|VPs|stories|capabilities|subsystems) ]]; then
       keyword="${BASH_REMATCH[2]}"
@@ -153,7 +171,7 @@ _extract_counts() {
       count="${BASH_REMATCH[1]//,/}"
       echo "VPs:${count}"
     fi
-  done < "$path"
+  done < <(awk 'length <= 8192' "$path" | sed -E 's/[A-Za-z]+-[0-9.]+//g')
 }
 
 # Extract counts from modified file (first occurrence per keyword wins)

--- a/plugins/vsdd-factory/tests/hooks.bats
+++ b/plugins/vsdd-factory/tests/hooks.bats
@@ -533,9 +533,10 @@ EOF
   # NIT-1: invoke hook directly (shebang #!/bin/bash controls interpreter,
   # consistent with require_bash4_hook_interp which checks /bin/bash).
   # SUGGESTION-2: capture exit status in a file for post-timeout assertion.
-  { echo '{"tool_input":{"file_path":".factory/BC-INDEX.md"}}' \
-      | "$HOOKS/validate-count-propagation.sh"
-    echo $? > "$BATS_TEST_TMPDIR/exit_status.txt"; } &
+  {
+    echo '{"tool_input":{"file_path":".factory/BC-INDEX.md"}}' \
+      | "$HOOKS/validate-count-propagation.sh" && echo 0 > "$BATS_TEST_TMPDIR/exit_status.txt" || echo $? > "$BATS_TEST_TMPDIR/exit_status.txt"
+  } &
   local pid=$!
 
   local timed_out=0
@@ -556,12 +557,12 @@ EOF
   fi
 
   [ "$timed_out" -eq 0 ] \
-    || fail "Hook still running after 3s on 200KB line — length guard or linear-sed fix not applied"
+    || { echo "FAIL: Hook still running after 3s on 200KB line — length guard or linear-sed fix not applied" >&2; return 1; }
   # SUGGESTION-2: assert hook exited 0 (oversized all-ID line: no counts after awk
   # filter, SOURCE_COUNTS empty, hook takes the early-exit-0 path).
   [ -f "$BATS_TEST_TMPDIR/exit_status.txt" ] \
     && [ "$(cat "$BATS_TEST_TMPDIR/exit_status.txt")" -eq 0 ] \
-    || fail "hook exited non-zero: $(cat "$BATS_TEST_TMPDIR/exit_status.txt" 2>/dev/null)"
+    || { echo "FAIL: hook exited non-zero: $(cat "$BATS_TEST_TMPDIR/exit_status.txt" 2>/dev/null)" >&2; return 1; }
 }
 
 @test "validate-count-propagation: sed ID-strip removes BC/VP/DI tokens, genuine BCs count survives drift check" {

--- a/plugins/vsdd-factory/tests/hooks.bats
+++ b/plugins/vsdd-factory/tests/hooks.bats
@@ -497,3 +497,70 @@ EOF
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }
+
+# ---------- validate-count-propagation (CPU-runaway fix — S-25.01) ----------
+#
+# Regression + correctness tests for the catastrophic-backtracking fix:
+#   - length guard: skip lines > 8192 chars before any regex/extglob processing
+#   - linear sed: replace extglob ID-strip with sed -E 's/[A-Za-z]+-[0-9.]+//g'
+#
+# Root cause: BC-INDEX.md contains a single ~195KB "last_amended:" blob line;
+# the extglob substitution line="${line//+([A-Za-z])-+([0-9.])/}" spins a full
+# CPU core for >12s on that input (PostToolUse → orphaned hook at PPID 1).
+
+@test "validate-count-propagation: 200KB ID-dense single line completes in <3s (cpu-runaway fix)" {
+  require_bash4_hook_interp
+  # BC-INDEX.md with a single ~200KB line of ID tokens reproduces the CPU-runaway
+  # bug. On unfixed code the extglob substitution hangs >12s; with the length guard
+  # the line is skipped in O(1) and the hook exits cleanly in <1s.
+  #
+  # A STATE.md sibling is required: without a sibling the hook exits early at the
+  # "no siblings" guard before calling _extract_counts, so the bug is never reached.
+  perl -e 'print("BC-1.18.003 VP-105 DI-007 " x 8000 . "\n")' > .factory/BC-INDEX.md
+  printf '# STATE — no count keywords\n' > .factory/STATE.md
+
+  # Verify the fixture is large enough to reproduce the bug.
+  local size
+  size=$(wc -c < .factory/BC-INDEX.md | tr -d ' ')
+  [ "$size" -gt 150000 ] || skip "Fixture too small (${size}B); perl may be unavailable"
+
+  # Portable timeout: background process + polling kill.
+  # macOS/BSD has no `timeout` command; GNU/Linux has it but we avoid the
+  # dependency. The fork+poll pattern works on both platforms.
+  # Budget: 3s. Unfixed code hangs >12s on this input (confirmed per bug report).
+  { echo '{"tool_input":{"file_path":".factory/BC-INDEX.md"}}' \
+      | bash "$HOOKS/validate-count-propagation.sh"; } &
+  local pid=$!
+
+  local timed_out=0
+  local ticks=0
+  while kill -0 "$pid" 2>/dev/null && [ "$ticks" -lt 30 ]; do
+    sleep 0.1
+    ticks=$((ticks + 1))
+  done
+
+  if kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" 2>/dev/null
+    wait "$pid" 2>/dev/null || true
+    timed_out=1
+  else
+    wait "$pid" 2>/dev/null || true
+  fi
+
+  [ "$timed_out" -eq 0 ] \
+    || fail "Hook still running after 3s on 200KB line — length guard or linear-sed fix not applied"
+}
+
+@test "validate-count-propagation: sed ID-strip removes BC/VP/DI tokens, genuine BCs count survives drift check" {
+  require_bash4_hook_interp
+  # Line: "BC-1.18.003 VP-105 42 BCs DI-007" — three ID tokens stripped by the
+  # linear sed; genuine count "42 BCs" preserved.  Sibling (BC-INDEX) disagrees
+  # with total_bcs: 38 → drift must still fire.  If the sed over-aggressively
+  # stripped digits from "42 BCs" the count would be lost and the hook would exit
+  # 0 (empty SOURCE_COUNTS) — a false negative caught by requiring exit 2 here.
+  printf '# STATE\nBC-1.18.003 VP-105 42 BCs DI-007\n' > .factory/STATE.md
+  printf '%s\n' '---' 'total_bcs: 38' '---' '# BC-INDEX' > .factory/BC-INDEX.md
+  run bash -c "echo '{\"tool_input\":{\"file_path\":\".factory/STATE.md\"}}' | \"$HOOKS/validate-count-propagation.sh\" 2>&1"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"42 BCs"* ]]
+}

--- a/plugins/vsdd-factory/tests/hooks.bats
+++ b/plugins/vsdd-factory/tests/hooks.bats
@@ -516,20 +516,26 @@ EOF
   #
   # A STATE.md sibling is required: without a sibling the hook exits early at the
   # "no siblings" guard before calling _extract_counts, so the bug is never reached.
-  perl -e 'print("BC-1.18.003 VP-105 DI-007 " x 8000 . "\n")' > .factory/BC-INDEX.md
+  # SUGGESTION-3: use awk instead of perl (perl may be unavailable; awk is universal).
+  awk 'BEGIN { s=""; for(i=0;i<8000;i++) s=s "BC-1.18.003 VP-105 DI-007 "; print s }' \
+    > .factory/BC-INDEX.md
   printf '# STATE — no count keywords\n' > .factory/STATE.md
 
   # Verify the fixture is large enough to reproduce the bug.
   local size
   size=$(wc -c < .factory/BC-INDEX.md | tr -d ' ')
-  [ "$size" -gt 150000 ] || skip "Fixture too small (${size}B); perl may be unavailable"
+  [ "$size" -gt 150000 ] || skip "Fixture too small (${size}B); generation failed"
 
   # Portable timeout: background process + polling kill.
   # macOS/BSD has no `timeout` command; GNU/Linux has it but we avoid the
   # dependency. The fork+poll pattern works on both platforms.
   # Budget: 3s. Unfixed code hangs >12s on this input (confirmed per bug report).
+  # NIT-1: invoke hook directly (shebang #!/bin/bash controls interpreter,
+  # consistent with require_bash4_hook_interp which checks /bin/bash).
+  # SUGGESTION-2: capture exit status in a file for post-timeout assertion.
   { echo '{"tool_input":{"file_path":".factory/BC-INDEX.md"}}' \
-      | bash "$HOOKS/validate-count-propagation.sh"; } &
+      | "$HOOKS/validate-count-propagation.sh"
+    echo $? > "$BATS_TEST_TMPDIR/exit_status.txt"; } &
   local pid=$!
 
   local timed_out=0
@@ -540,7 +546,9 @@ EOF
   done
 
   if kill -0 "$pid" 2>/dev/null; then
-    kill "$pid" 2>/dev/null
+    # SUGGESTION-1: reap bash/awk/sed descendants before killing parent.
+    pkill -P "$pid" 2>/dev/null || true
+    kill "$pid" 2>/dev/null || true
     wait "$pid" 2>/dev/null || true
     timed_out=1
   else
@@ -549,6 +557,11 @@ EOF
 
   [ "$timed_out" -eq 0 ] \
     || fail "Hook still running after 3s on 200KB line — length guard or linear-sed fix not applied"
+  # SUGGESTION-2: assert hook exited 0 (oversized all-ID line: no counts after awk
+  # filter, SOURCE_COUNTS empty, hook takes the early-exit-0 path).
+  [ -f "$BATS_TEST_TMPDIR/exit_status.txt" ] \
+    && [ "$(cat "$BATS_TEST_TMPDIR/exit_status.txt")" -eq 0 ] \
+    || fail "hook exited non-zero: $(cat "$BATS_TEST_TMPDIR/exit_status.txt" 2>/dev/null)"
 }
 
 @test "validate-count-propagation: sed ID-strip removes BC/VP/DI tokens, genuine BCs count survives drift check" {

--- a/plugins/vsdd-factory/tests/hooks.bats
+++ b/plugins/vsdd-factory/tests/hooks.bats
@@ -498,6 +498,56 @@ EOF
   [ -z "$output" ]
 }
 
+# ---------- validate-count-propagation (narrowed blockquote guard — cycle-4 BLOCKING-C) ----------
+#
+# Cycle-3 added a BLANKET skip for every line starting with ">", to suppress a
+# false positive from a "> **...batch authoring:** ... 22 BCs anchored ..."
+# narrative note in STORY-INDEX.md. But BC-INDEX.md's SOLE carrier of the live
+# "subsystems" count is itself a blockquote line ("> Master index of all N
+# behavioral contracts across M subsystems."), so the blanket skip silently
+# killed subsystems drift detection for that file. The fix narrows the guard
+# to skip only two genuinely documentary/historical blockquote FORMS
+# ("> Updated YYYY-MM-DD: ..." and "> **...**" bold-prefixed narrative), so a
+# live count that happens to be blockquote-formatted is still scanned.
+
+@test "validate-count-propagation: blockquote-formatted live count (subsystems banner) is still checked for drift (BLOCKING-C)" {
+  require_bash4_hook_interp
+  # BC-INDEX.md's master-index banner is a PLAIN blockquote (no bold prefix,
+  # no "Updated" date-stamp) carrying the live subsystems count. It must NOT
+  # be skipped by the narrowed guard: ARCH-INDEX.md disagrees (11 vs 10), so
+  # this must still fire drift. (Both counts use 2+ digits: Pattern A's
+  # "[0-9][0-9,]+" requires at least two characters, so a single-digit count
+  # would not match at all — that would test the regex's digit-count floor,
+  # not the blockquote guard.)
+  printf '# BC-INDEX\n> Master index of all 1,967 behavioral contracts across 10 subsystems.\n> Source of truth for BC count, status, and subsystem assignment.\n' > .factory/BC-INDEX.md
+  printf '# ARCH-INDEX\nSubsystem registry: 11 subsystems total.\n' > .factory/ARCH-INDEX.md
+  run bash -c 'echo "{\"tool_input\":{\"file_path\":\"'$WORK'/.factory/BC-INDEX.md\"}}" | "'"$HOOKS"'/validate-count-propagation.sh" 2>&1'
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"COUNT DRIFT DETECTED"* ]]
+  [[ "$output" == *"subsystems"* ]]
+}
+
+@test "validate-count-propagation: bold-prefixed batch-authoring blockquote note is still skipped (BLOCKING-C)" {
+  require_bash4_hook_interp
+  # STORY-INDEX.md carries a genuinely documentary bold-prefixed blockquote
+  # note citing a per-wave local tally ("22 BCs anchored") that disagrees with
+  # the file's own live current-count line ("41 BCs total") and with the
+  # sibling's authoritative total_bcs: 41. If the note were NOT skipped, its
+  # "22 BCs" (first-seen, same rank) would win over the live "41 BCs" and
+  # falsely disagree with the sibling — firing drift. With the note correctly
+  # skipped, only the live "41 BCs" is extracted, which matches the sibling,
+  # so this must exit clean.
+  printf '%s\n' \
+    '# STORY-INDEX' \
+    '> **E-8 Tier 1 batch authoring (2026-04-30):** 9 Tier 1 hook port stories authored across 2 bursts; 22 BCs anchored (BC-7.03.* + BC-7.04.*); 33 base story points.' \
+    'Current corpus: 41 BCs total.' \
+    > .factory/STORY-INDEX.md
+  printf '%s\n' '---' 'total_bcs: 41' '---' '# BC-INDEX' > .factory/BC-INDEX.md
+  run bash -c 'echo "{\"tool_input\":{\"file_path\":\"'$WORK'/.factory/STORY-INDEX.md\"}}" | "'"$HOOKS"'/validate-count-propagation.sh" 2>&1'
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
 # ---------- validate-count-propagation (CPU-runaway fix — S-25.01) ----------
 #
 # Regression + correctness tests for the catastrophic-backtracking fix:
@@ -601,4 +651,18 @@ EOF
   run bash -c "PATH=\"$_broken_sed_dir:\$PATH\" bash \"$HOOKS/validate-count-propagation.sh\" 2>&1 <<< '{\"tool_input\":{\"file_path\":\".factory/STATE.md\"}}'"
   rm -rf "$_broken_sed_dir"
   [ "$status" -eq 2 ]
+  # S-2 test-rigor fix: asserting on exit status alone is vacuous — a
+  # genuine COUNT DRIFT DETECTED exit (the fixture above is deliberately
+  # drift-shaped: source "42 BCs" vs sibling total_bcs: 38) also exits 2, so
+  # this test would pass even if fail-closed were wired to the wrong path
+  # and preprocessing failure were silently swallowed. Discriminate on the
+  # actual stderr message instead: the preprocessing-failure path emits
+  # "preprocessing pipeline failed for ..." from inside _extract_counts,
+  # which is then reported to the caller as "count extraction failed for
+  # ...". The drift-detection path never emits either string — it emits
+  # "COUNT DRIFT DETECTED" instead. Assert BOTH: the preprocessing-failure
+  # message is present, AND the drift message is absent, so this test can
+  # only pass via the preprocessing-failure branch.
+  [[ "$output" == *"preprocessing pipeline failed for"* ]]
+  [[ "$output" != *"COUNT DRIFT DETECTED"* ]]
 }

--- a/plugins/vsdd-factory/tests/hooks.bats
+++ b/plugins/vsdd-factory/tests/hooks.bats
@@ -578,3 +578,27 @@ EOF
   [ "$status" -eq 2 ]
   [[ "$output" == *"42 BCs"* ]]
 }
+
+@test "validate-count-propagation: preprocessing failure exits 2, not 0 (fail-closed)" {
+  require_bash4_hook_interp
+  # Install a broken sed shim at the front of PATH that always exits 1.
+  # This simulates a preprocessing pipeline failure (awk | sed) inside
+  # _extract_counts.  Before BLOCKING-A fix, the process substitution
+  # `done < <(_extract_counts ...)` swallowed the failure and the hook
+  # returned exit 0 (false-pass: "no drift found").  After the fix,
+  # the caller-managed temp file + direct function call gates on the exit
+  # status and exits 2 (fail-closed).
+  _broken_sed_dir="$(mktemp -d)"
+  printf '#!/bin/bash\nexit 1\n' > "$_broken_sed_dir/sed"
+  chmod +x "$_broken_sed_dir/sed"
+
+  # Create a file with genuine drift so the hook would normally fire exit 2
+  # for drift — but with the broken sed shim it must STILL exit 2, just for
+  # the preprocessing-failure path rather than the drift-detection path.
+  printf '# STATE\n42 BCs\n' > .factory/STATE.md
+  printf '%s\n' '---' 'total_bcs: 38' '---' '# BC-INDEX' > .factory/BC-INDEX.md
+
+  run bash -c "PATH=\"$_broken_sed_dir:\$PATH\" bash \"$HOOKS/validate-count-propagation.sh\" 2>&1 <<< '{\"tool_input\":{\"file_path\":\".factory/STATE.md\"}}'"
+  rm -rf "$_broken_sed_dir"
+  [ "$status" -eq 2 ]
+}


### PR DESCRIPTION
# fix(hooks): CPU-runaway backtracking fix in validate-count-propagation

**Mode:** maintenance hotfix
**Branch:** `fix/count-propagation-cpu-runaway` → `develop`

![Tests](https://img.shields.io/badge/tests-62%2F62-brightgreen)
![Bats](https://img.shields.io/badge/bats-62%20PASS-brightgreen)

This PR fixes a catastrophic CPU-runaway in `plugins/vsdd-factory/hooks/validate-count-propagation.sh`
caused by an extglob pattern that backtracked super-linearly on the ~195KB single-line
`last_amended:` blob in `.factory/specs/behavioral-contracts/BC-INDEX.md`. The hook was
orphaning PostToolUse processes to PID 1 that pegged the CPU indefinitely (observed: 52 procs,
~1043% CPU, load 105 on a 16-core Mac). The fix replaces the per-line extglob with a two-pass
O(n) whole-file pre-processing step that is provably linear on any input.

---

## Architecture Changes

```mermaid
graph TD
    HookChain["PostToolUse Hook Chain"] -->|dispatches| VCP["validate-count-propagation.sh"]
    VCP -->|"old: per-line extglob<br/>O(n·k) on 195KB line"| BL["BACKTRACK LOOP (CPU runaway)"]
    VCP -->|"new: awk + sed whole-file<br/>O(n) two-pass pre-process"| PASS["_extract_counts loop\n(linear, bounded)"]
    style BL fill:#ff9999
    style PASS fill:#90EE90
```

<details>
<summary><strong>Root cause & fix decision</strong></summary>

**Context:** `validate-count-propagation.sh` calls `_extract_counts` on every `.factory/**/*.md`
file that a tool write touches. The function used `line="${line//+([A-Za-z])-+([0-9.])/}"` — a
bash extglob global-replace — inside the per-line loop to strip identifier tokens (BC-1.18.003,
VP-105, etc.) before extracting quantities.

**Root cause:** On the ~195KB `last_amended:` blob in BC-INDEX.md (a single line containing
≈8000 ID matches), bash's global-replace algorithm performs O(n·k) string copies (n = line
length, k = match count). This spun a full CPU core for >12s in PostToolUse, then orphaned
the process at PPID 1 where it ran indefinitely.

**Decision:** Replace per-line extglob with two O(n) whole-file pre-processing stages,
writing to temp files with exit-status gates, executed once per file before the loop:
1. `awk 'length <= 8192'` — drops lines > 8192 chars in one O(n) scan (defensive guard;
   a genuine count keyword is a short token that cannot live in a 195KB line).
2. `sed -E 's/[A-Za-z]+-[0-9.]+//g'` — strips ID tokens using a provably-linear NFA;
   BSD sed (macOS) and GNU sed (Linux) both supported via `-E` flag.

**Alternatives rejected:**
1. Truncate rather than skip over-long lines — rejected because mid-ID truncation could
   produce phantom digit sequences that would fire false drift alerts.
2. Raise extglob per-line with a length guard — rejected because the O(n·k) behaviour is
   intrinsic to bash global-replace and cannot be bounded without eliminating the extglob.
3. Rewrite hook in Rust — out of scope for a hotfix; this is a valid future direction.

**Consequences:**
- BC-INDEX.md: 0.55s (was >12s hang). VP-INDEX.md: 0.28s.
- One awk + one sed invocation per file replaces the per-line extglob substitution that
  previously ran on every one of BC-INDEX.md's 2595 lines (in-process bash param-expansion,
  the super-linear step on the ~195KB line).
- `shopt -s extglob` removed; kept as a disabled comment to prevent re-introduction.
- **Semantic delta (intentional improvement, not a no-op):** Lines > 8192 chars are
  dropped before extraction. These are frozen historical changelog records (e.g.,
  `last_amended:` blobs) whose embedded counts are stale. Pre-fix, the hook hung
  on these lines and never emitted a verdict. Post-fix, stale changelog counts in
  over-long frontmatter lines no longer shadow real totals in later lines.
  Empirically, VP-INDEX.md now correctly extracts 107 VPs (was 85 from frontmatter
  blob) and BC-INDEX.md extracts 13 stories (was 29 from blob). An explicit
  `last_amended:` / `change:` frontmatter skip is also added for named fields.

</details>

---

## Story Dependencies

This is a standalone maintenance hotfix. No story dependency graph.

```mermaid
graph LR
    FIX["fix/count-propagation-cpu-runaway<br/>this PR"] --> DEV["develop"]
```

---

## Spec Traceability

No formal story spec. The fix is traced to the CPU-runaway symptom and the hook's own
inline comments (S-7.02 / BC-7.05.001, BC-7.05.002 scope declaration).

```mermaid
flowchart LR
    SYM["Symptom: 52 procs<br/>1043% CPU<br/>load 105"] --> RC["Root cause: line-133<br/>extglob O(n·k)<br/>on 195KB line"]
    RC --> FIX["Fix: awk length guard<br/>+ sed linear ID-strip<br/>whole-file O(n) → temp file<br/>+ exit-status gate"]
    FIX --> T1["regression test:<br/>timeout-bounded ~200KB line"]
    FIX --> T2["correctness test:<br/>IDs stripped, counts preserved"]
    FIX --> T3["cycle-4 tests:<br/>blockquote-guard narrowing +<br/>fail-closed preprocessing"]
    T1 --> BATS["hooks.bats 62/62 PASS"]
    T2 --> BATS
    T3 --> BATS
```

---

## Test Evidence

### Coverage Summary

| Metric | Value | Status |
|--------|-------|--------|
| Bats suite total | 62/62 PASS | PASS |
| New tests added in this PR | 5 added | PASS |
| Timeout-bounded test (~200KB line) | ~3s budget, portable fork+poll (pre-fix: hangs) | PASS |
| Correctness test (IDs stripped, counts preserved) | PASS | PASS |
| BLOCKING-C blockquote-guard narrowing (subsystems drift still detected) | 2 tests | PASS |
| S-2 fail-closed preprocessing (asserts stderr content) | PASS | PASS |
| BC-INDEX.md real-file timing | 0.55s (was >12s hang) | PASS |
| VP-INDEX.md real-file timing | 0.28s | PASS |

### Test Flow

```mermaid
graph LR
    Reg["Regression test\n~200KB single line\nportable fork+poll"] --> P1["PASS (~3s)"]
    Corr["Correctness test\nIDs stripped\ncounts preserved\ndrift still detected"] --> P2["PASS"]
    Cyc4["Cycle-4 tests\n2x blockquote-guard\n+ fail-closed preproc"] --> P4["PASS"]
    Full["Full hooks.bats\n62 tests"] --> P3["62/62 PASS"]
    style P1 fill:#90EE90
    style P2 fill:#90EE90
    style P3 fill:#90EE90
    style P4 fill:#90EE90
```

<details>
<summary><strong>New tests in this PR</strong></summary>

All five tests are in `plugins/vsdd-factory/tests/hooks.bats` and use the same `/bin/bash >= 4`
guard (`require_bash4_hook_interp`) as all existing count-propagation tests (skip on macOS
/bin/bash 3.x per Darwin-leg discipline). Two cover the cycle-4 BLOCKING-C blockquote-guard
narrowing; three cover the CPU-runaway fix and its cycle-4 fail-closed hardening.

| Test | Description | Result |
|------|-------------|--------|
| `blockquote-formatted live count (subsystems banner) is still checked for drift (BLOCKING-C)` | A plain (non-bold, non-"Updated") blockquote line — BC-INDEX.md's sole `subsystems` carrier — must NOT be skipped by the narrowed guard. ARCH-INDEX.md disagrees (11 vs 10 subsystems), so drift must still fire (exit 2). Proves the cycle-4 narrowing restores subsystems drift detection. | PASS |
| `bold-prefixed batch-authoring blockquote note is still skipped (BLOCKING-C)` | A genuinely documentary `> **...batch authoring:** ... 22 BCs anchored ...` note (a per-wave local tally) is still skipped so it cannot shadow the file's live `41 BCs` count; the hook exits clean (exit 0). | PASS |
| `200KB ID-dense single line completes in <3s (cpu-runaway fix)` | Synthetic ~200KB single line of concatenated IDs; asserts the hook completes within a ~3s budget via a portable background fork + 0.1s-poll loop (no `timeout(1)` dependency). Pre-fix: hangs >12s. Also asserts exit 0. | PASS |
| `sed ID-strip removes BC/VP/DI tokens, genuine BCs count survives drift check` | `BC-1.18.003 VP-105 42 BCs DI-007` — the linear `sed -E` strips the three ID tokens without eating the genuine `42 BCs`; sibling `total_bcs: 38` disagrees, so drift must still fire (exit 2). Guards against over-aggressive stripping. | PASS |
| `preprocessing failure exits 2, not 0 (fail-closed)` | Installs a broken `sed` shim (always exits 1) to force a preprocessing-pipeline failure. The temp-file + exit-status gate must fail closed (exit 2), NOT swallow the error. **S-2 rigor fix:** asserts on stderr content — `preprocessing pipeline failed for` MUST be present AND `COUNT DRIFT DETECTED` MUST be absent — so the test can only pass via the fail-closed branch, not via a coincidental drift exit 2. | PASS |

</details>

---

## Holdout Evaluation

N/A — maintenance hotfix; no holdout scenarios defined.

---

## Adversarial Review

N/A — maintenance hotfix per fix-pr-delivery flow. Fresh-eyes PR diff review dispatched
in lieu of full adversarial review (see review section below).

---

## Security Review

**Surface assessed:** `validate-count-propagation.sh` — a PostToolUse bash hook.

```mermaid
graph LR
    Critical["Critical: 0"] --> OK1["CLEAR"]
    High["High: 0"] --> OK2["CLEAR"]
    Medium["Medium: 0"] --> OK3["CLEAR"]
    Low["Low: 0"] --> OK4["CLEAR"]
    style OK1 fill:#90EE90
    style OK2 fill:#90EE90
    style OK3 fill:#90EE90
    style OK4 fill:#90EE90
```

<details>
<summary><strong>Security assessment</strong></summary>

**Injection surface:** The hook receives file paths from the Claude Code harness's own
PostToolUse event payload — not from user-controlled CLI input. The `awk` and `sed`
invocations receive the file path as a positional argument, written to a temp file with
an exit-status gate — standard shell idiom with no `eval` or dynamic command construction.

**CWE-78 (OS Command Injection):** Not applicable. `$path` is consumed as a filename
argument to `awk`, not interpolated into a command string. The hook uses `set -euo pipefail`
throughout; unset variables cause immediate exit.

**CWE-400 (Uncontrolled Resource Consumption):** This IS the fix. The prior extglob
pattern was the resource exhaustion vector. The replacement uses `awk 'length <= 8192'`
as a hard bound, making input size the only remaining factor and eliminating the
super-linear branch.

**S-1 fail-closed hardening (cycle-4):** All three `mktemp` sites in the hook — the
`_preproc_tmp` inside `_extract_counts` and the top-level `_src_tmp` / `_sib_tmp` — are
gated to `exit 2` on failure. Under this project's hook semantics ONLY exit 2 is blocking;
a bare `var="$(mktemp)"` failure under `set -e` would terminate with mktemp's own exit
status (1), which is silently non-blocking. Without the explicit gate a TMPDIR-exhausted /
read-only-tmp host would degrade the hook to "no verdict, not blocking" instead of failing
closed. Extraction-pipeline failures are likewise routed to `exit 2` (fail-closed), verified
by the `preprocessing failure exits 2, not 0` test.

**Dependency audit:** No new dependencies introduced. Pure bash + awk + sed (system tools).

</details>

---

## Risk Assessment & Deployment

### Blast Radius
- **Systems affected:** PostToolUse hook chain — `validate-count-propagation.sh` only.
- **User impact:** Without this fix, any tool write that touches a file containing a
  very long line (>~10KB ID-heavy content) can orphan a CPU-pegging process. This is
  a production-blocking defect for any user of the vsdd-factory plugin with a large
  BC-INDEX.md.
- **Data impact:** None — the hook is read-only (reports drift, does not modify files).
- **Risk level:** LOW-MEDIUM. The awk/sed mechanism is correct and the CPU runaway
  is eliminated. However, the fix intentionally changes which first-wins count is
  extracted on files whose `last_amended:` frontmatter blob contained stale embedded
  counts — those counts no longer shadow real totals. This is an improvement but is
  a semantic change, not a no-op. All five live index files must exit 0 post-fix.

### Performance Impact

| Metric | Before | After | Delta | Status |
|--------|--------|-------|-------|--------|
| BC-INDEX.md hook runtime | >12s (hangs) | 0.55s | -11.45s | RESOLVED |
| VP-INDEX.md hook runtime | ~0.28s | 0.28s | ~0s | OK |
| CPU usage (PostToolUse) | 1043% / load 105 | nominal | eliminated | RESOLVED |

<details>
<summary><strong>Rollback instructions</strong></summary>

```bash
# Immediate rollback: revert the squash commit on develop
git revert <MERGE_COMMIT_SHA>
git push origin develop
```

Verification after rollback: run `plugins/vsdd-factory/tests/run-all.sh` — the CPU-runaway
regression test (`200KB ID-dense single line completes in <3s`) will time out / hang
(expected; that confirms rollback was applied).

</details>

### Feature Flags
None — this is a hotfix to an always-active hook.

### Operator-level impact
> **Important:** The running hook at operator level is the marketplace-cache copy
> (`~/.claude/plugins/cache/claude-mp/vsdd-factory/<version>/`). This fix will only
> take effect at operator level after a new release is cut and installed. A follow-up
> release task is needed to expose this fix to end users.

---

## Traceability

| Symptom | Root Cause | Fix | Test | Status |
|---------|-----------|-----|------|--------|
| CPU runaway on 195KB BC-INDEX line | `line="${line//+([A-Za-z])-+([0-9.])/}"` extglob O(n·k) | `awk length<=8192` + `sed -E` linear ID-strip, whole-file → temp file + exit-status gate | portable fork+poll regression test | PASS |
| False drift from ID token digits | Same extglob (phantom count extraction) | Same fix — ID tokens stripped before loop | Correctness bats test (`sed ID-strip ... survives drift check`) | PASS |
| Blanket `^>` skip killed subsystems drift detection (cycle-4 BLOCKING-C) | Over-broad blockquote guard skipped BC-INDEX.md's sole `subsystems` carrier | Narrow guard to skip only `> Updated <date>` and `> **...**` forms; plain banner still extracted | 2 BLOCKING-C bats tests | PASS |
| Preprocessing failure silently swallowed (cycle-4 S-1/S-2) | mktemp / awk|sed failure could exit non-blocking or via process-sub subshell | Temp file + exit-status gate → `exit 2` fail-closed at all three mktemp sites | `preprocessing failure exits 2, not 0` (asserts stderr content) | PASS |

---

## Known follow-up items (out of scope for this PR)

1. **BC-INDEX.md `last_amended:` data defect (STATE-MANAGER DATA DEFECT):**
   The ~195KB single line in `last_amended:` is caused by changelog markers being
   appended unbounded to a single YAML scalar. This hook fix makes the hook robust
   to that data bug, but the underlying defect remains. A separate follow-up is
   required: cap the `last_amended:` field, rotate historical entries to a multi-line
   block, or move changelog history to a dedicated section. This must be tracked as a
   state-manager data cleanup task and addressed before BC-INDEX.md grows further.

2. **Operator-level release required:**
   The running hook at operator level is the marketplace-cache copy. This fix does
   not take effect for end users until a new release is cut (follow-up release task).

> **Resolved in this PR (cycle-4 BLOCKING-C):** An earlier revision of this branch used a
> blanket `^>` blockquote skip, which silently killed `subsystems` drift detection because
> BC-INDEX.md's sole `subsystems` carrier is a plain blockquote banner line. The cycle-4 fix
> **narrows** the guard to skip only two genuinely documentary blockquote forms
> (`> Updated YYYY-MM-DD: ...` date-stamps and `> **...**` bold-prefixed narrative), so the
> plain subsystems banner falls through to normal extraction and its drift is still detected.
> `subsystems` coverage from BC-INDEX.md is therefore retained, not lost — this is no longer
> an accepted narrowing. The two BLOCKING-C tests above assert both halves (plain banner
> still checked; bold-prefixed note still skipped).

---

## AI Pipeline Metadata

<details>
<summary><strong>Pipeline details</strong></summary>

```yaml
ai-generated: true
pipeline-mode: maintenance
factory-version: "1.0.0-rc.24"
pipeline-stages:
  spec-crystallization: N/A (hotfix)
  story-decomposition: N/A (hotfix)
  tdd-implementation: N/A (fix pre-authored by human)
  holdout-evaluation: N/A
  adversarial-review: N/A (fresh-eyes PR review in lieu)
  formal-verification: skipped (bash hook, not Rust)
  convergence: N/A
models-used:
  pr-manager: claude-sonnet-4-6
generated-at: "2026-08-31"
```

</details>

---

## Pre-Merge Checklist

- [ ] All CI status checks passing
- [x] No critical/high security findings (none found)
- [x] Rollback procedure documented
- [x] No feature flags needed
- [x] Operator-level release follow-up noted in PR body
- [x] BC-INDEX.md data defect follow-up noted in PR body
- [ ] Fresh-eyes PR review: APPROVE
- [ ] Human review (if autonomy level requires)

