### PR TITLE
fix(deps): bump wasmtime + wasmtime-wasi 46.0.2→46.0.3 (RUSTSEC-2026-0268 MEDIUM + RUSTSEC-2026-0269 HIGH sandbox-escape)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "cap-fs-ext"
-version = "3.4.5"
+version = "3.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5528f85b1e134ae811704e41ef80930f56e795923f866813255bc342cc20654"
+checksum = "476f0d0003a760918ed4b1e039a59e11769030416f79c8222551d22785f7f70d"
 dependencies = [
  "cap-primitives",
  "cap-std",
@@ -277,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "cap-net-ext"
-version = "3.4.5"
+version = "3.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a158160765c6a7d0d8c072a53d772e4cb243f38b04bfcf6b4939cfbe7482e7"
+checksum = "150941cefd3df4de2fea24604ba4949371576f62e527410298333f7d431a1bc6"
 dependencies = [
  "cap-primitives",
  "cap-std",
@@ -289,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "cap-primitives"
-version = "3.4.5"
+version = "3.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6cf3aea8a5081171859ef57bc1606b1df6999df4f1110f8eef68b30098d1d3a"
+checksum = "8e0bf07d379916947be6c4a07f43684153d710a2896c31f9e97781362895596c"
 dependencies = [
  "ambient-authority",
  "fs-set-times",
@@ -307,9 +307,9 @@ dependencies = [
 
 [[package]]
 name = "cap-std"
-version = "3.4.5"
+version = "3.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6dc3090992a735d23219de5c204927163d922f42f575a0189b005c62d37549a"
+checksum = "a59e59fa26472d29680ece6a9f8ee8b0551a719a33df2f5240bde065ecbddfd7"
 dependencies = [
  "cap-primitives",
  "io-extras",
@@ -319,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "cap-time-ext"
-version = "3.4.5"
+version = "3.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def102506ce40c11710a9b16e614af0cde8e76ae51b1f48c04b8d79f4b671a80"
+checksum = "b54c289326c70f1c697ebf0a31842a480932e5942b5fac92fcc46e87286b48e2"
 dependencies = [
  "ambient-authority",
  "cap-primitives",
@@ -510,27 +510,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47ca6361f42d0c945fadc1103501e1c07438e034fd5a86896a3074eff3e860bd"
+checksum = "0aadfd45214f09461ba0406f7dacecce5cac39bf0bdb4890eeb468f4ef090e07"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1dbc96db7cebf747bd5722d482338a5acff91d6be43b6bec145f9471327ffa"
+checksum = "57069faede9bd1f926364b4cf69ccc9bebc6f4af5ab897083581b7bc991bf20a"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353b309eef494e4adb4c6cca76f30ef27daa907534db7d05b5986500f51aa4e1"
+checksum = "0b1221450f2f9efaa996d916bf53a0a4d13346a4a75468afb828390209a4fdd4"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -538,9 +538,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3cafe127a4c5d9765b1df54052245d2cbaca7238782805bb5ac94986ccdb591"
+checksum = "97706f2b466d67bdf0f69d1cf5c5c4a5cd31087cf1fa2e8e5fe0450dddc8661d"
 dependencies = [
  "serde",
  "serde_derive",
@@ -549,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3964f31c6dc9d21e926ef884d3eec2f1ca83266a233521da4a737143262ceb84"
+checksum = "432246ee44b2fc0140b412dca55801d200d6fb25d2d7d18c44bb29e8cd71268b"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -580,9 +580,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2f8b35746603b792e4ae34499a39251f310a06c98d4bc2ca02cf4bd29ce3c84"
+checksum = "b5aa51eff0949f06a5c8f3d5adefef94a12ea99f71cd8985047b91d45f367150"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -593,24 +593,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "584bd91987927dfe35e79c5d6dd52a117cb64c4fce26df881d02dcc17bd59a8f"
+checksum = "6095e7095930b6169490138b4262fe7ec24290d3f604d7fe62e1e3138e740daa"
 
 [[package]]
 name = "cranelift-control"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af277352af76db01bb42fa4978b672a44406715798edb693cc02e363e12dc505"
+checksum = "e61dfa0766c0eadf42b3febd145a35f81f31086e207f534e5fb406fc3d08fc47"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ad4f0c556d3d57580d07477be9e665f4d2a826971a5ab4642ead20a19df443"
+checksum = "e93867a79a06dd5d9ffeb96f7563dc7b6b142b5d89e42ab77e458a408a8aa9d5"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -620,9 +620,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29d69a6b7d8412c716e8599c7330dfbd122c1bc145f3bda05a9e237fba20419d"
+checksum = "d1991dc32fefa54f14d2a63570d1e963826257605e478558733f83450b7e7661"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.17.0",
@@ -633,15 +633,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52fcdcd4a5c7fa8bfea35e72c0979ad5a699c836364870f0a84169d02a085a88"
+checksum = "784546de9988ff6e1df0fd4d2450760469a7607344156c661e69ec28082c5da4"
 
 [[package]]
 name = "cranelift-native"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fee933cf8ec90e58e68163a02bdb0e4d29f2260a7592b3f09cbba52fcd34d12"
+checksum = "7107a4ae4a2ba48b5df8648365e638b08322fa1da11e86206bf5eddb862b21dd"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -650,9 +650,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.133.2"
+version = "0.133.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd75e1e2719808c80af27ebe168d2220ec10e519e1d5a52bdbed9bd5cac1a32"
+checksum = "4b3f161aa81ee5dd8d7b0eb8828988f57baf2f78d288e62b6b3714b37aa6d6a1"
 
 [[package]]
 name = "crc32fast"
@@ -2051,9 +2051,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3683e69168d2e2374cea51a79fce2e9870e7c622366b8bf7af87fb5c2428a2a9"
+checksum = "3f647f8aefd39efd5e38b484a8b7a926dd035ae366127df75c1d94d196f0a4ba"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -2063,9 +2063,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ebbd6dada1e3df36ea4a4b8feca2ed230aa92d59e55bf5714eb4286cdd632b0"
+checksum = "3e902032e329008b189b67498b1be7784d5849276f32402eca17441df08a6bcb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3840,9 +3840,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed27b4a4a5271d2608406a99c8d1cf8aea1e894fe4ec361d470063bcf342f1d7"
+checksum = "d39226663bd765601279a79b88645a7c4a4d3c2fe73040afdc27bead02ee6659"
 dependencies = [
  "addr2line",
  "async-trait",
@@ -3893,9 +3893,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7712f99b0920d4638023405eb9723ef200efd6d39bfc7466c92e926ca5d130f0"
+checksum = "2595a168541e8a7faeacf21e3d59da93628ee71468cd69fee9fc2a92c9b1c7d8"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -3924,9 +3924,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb07d96412d6958817749712969cfd6416cbce11639c3f3431dc659816d84ace"
+checksum = "a37d629957320219db11336663e0947e19afe77150403509cac21c47ead60c69"
 dependencies = [
  "base64",
  "directories-next",
@@ -3944,9 +3944,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60f3492a55dbd4eb2e4f1f33ed0626d141f5f4cf4c0194168a4c5006f6601b0"
+checksum = "9abf0fb4ce458eb6edbfaf6cbf13fcbf4216eac5a85febfe90224a1f6064c990"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -3959,15 +3959,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c777c83bb4c3414b23fe84fecd47a46016a0a0b0a39aa786cad0a701fe3cbc7f"
+checksum = "0e50df18c9a8e0deec353ad1e6364ef50538231719a12d80fa5dcb300be8d36b"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb54b5de8723a9acf2c0bc531df8e773462796a5f87e8f49a3d5ea5c3b32ef7"
+checksum = "93b097389e5fad89c8ff8ee0aeafd16447b5a288d52aa1131f17ab4c19fd5be3"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.0",
@@ -3977,9 +3977,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c60bb70116a88791ccceef605b31010c4888a7305e450f01dc7d4f430ad25f0"
+checksum = "08b3e909115836655b83c8bdef7c2e20a34293e785218d9f71a4e5382a09c6b0"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -4004,9 +4004,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24bdf54907e0bad31ad6676d03ed1008fa21489725635136f9c38979c39a98ed"
+checksum = "a000d1124dd40417ce8433d07de1063ecc9be7cac21745c8de7f9cf7684c3ead"
 dependencies = [
  "cc",
  "cfg-if",
@@ -4019,9 +4019,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4edaf07e20511f3ca070a4a0f026c407969f09e536075729872f548ca6f8d4"
+checksum = "a7439956e78ba68e2cd766f34c3f056d625fad9a055eafb0c4569ac91c09e6b4"
 dependencies = [
  "cc",
  "object",
@@ -4031,9 +4031,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f96a6d7eb246d1306b7db8915a169cd8628a9e6b8299d1d1f8ab109801ef0a66"
+checksum = "ee3a381a9dd1ffe3893507733300b420605f465655d78c7a75a965a09d7b43d5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -4043,9 +4043,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39472572ea3eb11b7cc7fe7bd6df0005cef87b580eb06a3378d103ac99d45bc3"
+checksum = "22f951f78a1a09001547838fa557522d56655385db97e47307d0f582ca866974"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -4056,9 +4056,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bf2eff1c108b01566a7c8870de34821e7bda7d327e86e12a548c026e1e3677d"
+checksum = "51e06f9fabbe647e5c2ed186e6920ab1fb48174688d7d3fdadbda537b8499b51"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4067,9 +4067,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1d9d3ffd05d6e864adc35cff702f56307c454caec3b1d2d89dd6c843219b663"
+checksum = "f49ac5121036c2255bdc203b1b75a1c04544744cd5f51c93240b58bddca9f0f1"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -4080,9 +4080,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88f243a21e600902fd03bd970df7e4671d760d724c9fad202166fd98c842548"
+checksum = "16d23668f18d6fd0a932c1fc58600bbb8a2e4f9b217f08bb61841e2c275d4ce3"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -4109,9 +4109,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0373c9dc92c9373aa9cee05963ea438bc318bf07bb284bede77a9ce24b39f682"
+checksum = "0df5ffcd5aca96285be7745d4677ca5e2851245ca7c066a98c0fbee5bc6375f1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4163,9 +4163,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9914a7e8ac8cb37be90753103e2aa96959e9e5d2f549a2d081bcfeb8fa97e08d"
+checksum = "a77deefc2b0fe8c258316372ec322da627ce8c5b5ea9eec3b001190e9f8f2f69"
 dependencies = [
  "bitflags",
  "thiserror 2.0.18",
@@ -4177,9 +4177,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "789b4c6d82c1ae0f5003eb6c5b9d3c9fb80112c4be50ad2690eb7347f0edd852"
+checksum = "0a52145d29793eb1e0c5be9b6be5a74552b9236f01866c769ec1c3270584085f"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -4191,9 +4191,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "46.0.2"
+version = "46.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5be72b12200c1270ee5cc9c6c30450e9ba5abdcb5fe8d09d08b516b7bd974d3"
+checksum = "c26242c5c54d0f2837e1fecc933e1581e45d39cde1b1f6b3ad72955e0851ec20"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,8 +79,8 @@ thiserror = "2.0"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time", "fs", "io-util", "process"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
-wasmtime = "46.0.2"
-wasmtime-wasi = "46.0.2"
+wasmtime = "46.0.3"
+wasmtime-wasi = "46.0.3"
 clap = { version = "4", features = ["derive"] }
 proc-macro2 = "1.0"
 quote = "1.0"


### PR DESCRIPTION
# [SEC] bump wasmtime + wasmtime-wasi 46.0.2→46.0.3 (RUSTSEC-2026-0268 MEDIUM + RUSTSEC-2026-0269 HIGH sandbox-escape)

**Epic:** Security Advisory Response
**Mode:** maintenance (security dependency bump — patch version, no API changes)
**Convergence:** N/A — security-only dependency bump, no behavioral contract changes

![Tests](https://img.shields.io/badge/tests-cargo%20build%2Ftest%2Ffmt%2Fclippy-brightgreen)
![cargo deny](https://img.shields.io/badge/cargo--deny-advisories%20ok-brightgreen)
![RUSTSEC-2026-0268](https://img.shields.io/badge/RUSTSEC--2026--0268-CLEARED-brightgreen)
![RUSTSEC-2026-0269](https://img.shields.io/badge/RUSTSEC--2026--0269-CLEARED-brightgreen)

Bumps `wasmtime` and `wasmtime-wasi` from 46.0.2 to 46.0.3 in the workspace `Cargo.toml`. This patch release from the Bytecode Alliance clears two security advisories that affect the `vsdd-factory` dispatcher's WASM sandbox host: RUSTSEC-2026-0268 (WASIp3 host-heap DoS, MEDIUM) and RUSTSEC-2026-0269 (wasmtime filesystem sandbox escape via wasmtime-wasi, HIGH CVSS 4.0: 8.8). The bump is a patch version with no breaking API changes for the dispatcher — `Config`, fuel, epoch, and preopens interfaces are unchanged. `cargo deny check advisories` now exits clean (`advisories ok`).

> **Operator-binary gap (develop-vs-operator, same class as ADR-042/DEFAULT_FUEL_CAP):** This PR clears the advisories in **source builds on develop**. The pre-built dispatcher binaries committed to `plugins/vsdd-factory/hooks/dispatcher/bin/` are stamped by the release pipeline and still link wasmtime 46.0.2 (they were built for rc.24, which was tagged from the 46.0.2 tree). The operator-level plugin cache at `~/.claude/plugins/cache/claude-mp/vsdd-factory/1.0.0-rc.24/` is unaffected by this merge. The sandbox-escape and heap-DoS vulnerabilities are only closed at the operator level once **rc.25 is cut** and the release pipeline rebuilds the dispatcher binaries against 46.0.3. Track as follow-up: cut rc.25 promptly after this merges.

---

## Architecture Changes

```mermaid
graph TD
    Dispatcher["factory-dispatcher (binary)"]
    WasmtimeHost["wasmtime host runtime\n46.0.2 → 46.0.3"]
    WasmtimeWasi["wasmtime-wasi WASI host\n46.0.2 → 46.0.3"]
    HookPlugins["hook-plugins (*.wasm guests)"]
    Dispatcher -->|"executes"| HookPlugins
    Dispatcher -->|"hosts via"| WasmtimeHost
    WasmtimeHost -->|"provides WASI to"| WasmtimeWasi
    WasmtimeWasi -->|"sandbox"| HookPlugins
    style WasmtimeHost fill:#90EE90
    style WasmtimeWasi fill:#90EE90
```

<details>
<summary><strong>Change Rationale</strong></summary>

### Security Patch: wasmtime 46.0.3

**Context:** Two RUSTSEC advisories were published against wasmtime 46.0.2:
- **RUSTSEC-2026-0268** (MEDIUM): WASIp3 host-heap DoS — a crafted WASM module could cause unbounded host-heap allocation via WASIp3 stream operations, leading to OOM denial-of-service on the host.
- **RUSTSEC-2026-0269** (HIGH, CVSS 4.0: AV:N/AC:L/AT:P/PR:L/UI:P/VC:H/VI:H/VA:L/SC:H/SI:H/SA:L = 8.8): `wasmtime` package (filesystem sandbox escape via wasmtime-wasi cap-std path resolution) — under specific preopened-directory conditions (trailing slashes, symlinks), a guest WASM module could read/write host paths outside the declared sandbox boundary on platforms without Linux `openat2` (macOS, older Linux).

**Decision:** Patch bump to 46.0.3. Bytecode Alliance confirmed the fix in release notes; no API breakage for users of `Config`, fuel limits, epoch interruption, or WASI preopens.

**Rationale:** CVSS 4.0 score 8.8 (High) filesystem sandbox escape is a P0 security issue for a project that executes untrusted hook-plugin WASM. The patch is minimal risk (lock-cascade only, no API changes).

**Alternatives Considered:**
1. Pin to 46.0.2 with cargo-deny `ignore` — rejected: suppresses a CVSS 8.8 finding with no actual fix.
2. Jump to wasmtime 47.x — deferred: requires API migration assessment; patch 46.0.3 delivers the security fix without that scope.

**Consequences:**
- WASM sandbox escape and heap-DoS vectors closed.
- Transitive crate cascade: wasmtime-internal-* 46.0.3, cranelift 0.133.3, cap-std 3.4.6, wiggle 46.0.3, pulley 46.0.3.
- `cargo deny check advisories` result: `advisories ok` (both advisories cleared).

</details>

---

## Story Dependencies

```mermaid
graph LR
    FindingE["Finding E\n(PR #803 cargo-deny gate)"] --> ThisPR["fix/wasmtime-46.0.3\nthis PR"]
    style ThisPR fill:#FFD700
    style FindingE fill:#90EE90
```

No story dependencies. Standalone security advisory response. Clears Finding E from PR #803 cargo-deny gate.

---

## Spec Traceability

N/A — this PR carries no behavioral contract changes. It is a security dependency patch:
- No new BCs introduced
- No AC changes
- No story spec

Traceability chain: Security advisory RUSTSEC-2026-0268 + RUSTSEC-2026-0269 → `cargo deny check advisories` → `deny.toml` advisory policy → `Cargo.toml` wasmtime/wasmtime-wasi version bump → `Cargo.lock` cascade.

---

## Test Evidence

### Coverage Summary

| Metric | Value | Threshold | Status |
|--------|-------|-----------|--------|
| `cargo build` (workspace) | GREEN | must pass | PASS |
| `cargo test --workspace --all-targets` | GREEN | must pass | PASS |
| `cargo fmt --check --all` | GREEN | no diff | PASS |
| `cargo clippy --workspace --all-targets -- -D warnings` | GREEN | 0 warnings | PASS |
| `cargo deny check advisories` | `advisories ok` | 0 unresolved | PASS |
| `bats` integration suite | GREEN (2 pre-existing failures noted below) | — | PASS* |

*Two pre-existing macOS-only bats failures are present and **unrelated to this PR**:
- `dim7-dispatched-count-sweep` — macOS herestring-deadlock in bash 3.2 shell (known issue)
- `executable-bit` — macOS-specific permission test (known issue)

Both failures pre-date this branch and are tracked separately. They do not affect wasmtime or the dependency bump in any way.

### Test Flow

```mermaid
graph LR
    CargoBuild["cargo build\n(workspace)"]
    CargoTest["cargo test\n(all targets)"]
    Fmt["cargo fmt --check"]
    Clippy["cargo clippy\n(-D warnings)"]
    CargoDeny["cargo deny\ncheck advisories"]
    Bats["bats\nintegration suite"]

    CargoBuild --> PassBuild["PASS"]
    CargoTest --> PassTest["PASS"]
    Fmt --> PassFmt["PASS"]
    Clippy --> PassClippy["PASS"]
    CargoDeny --> PassDeny["PASS (advisories ok)"]
    Bats --> PassBats["PASS* (2 pre-existing macOS failures, unrelated)"]

    style PassBuild fill:#90EE90
    style PassTest fill:#90EE90
    style PassFmt fill:#90EE90
    style PassClippy fill:#90EE90
    style PassDeny fill:#90EE90
    style PassBats fill:#FFD700
```

| Metric | Value |
|--------|-------|
| **New tests** | 0 (deps-only change) |
| **Modified tests** | 0 |
| **Regressions** | None (cargo test full suite green) |
| **cargo deny** | `advisories ok` — RUSTSEC-2026-0268 and RUSTSEC-2026-0269 cleared |

---

## Holdout Evaluation

N/A — evaluated at wave gate. This PR contains no behavioral changes to evaluate.

---

## Adversarial Review

N/A — evaluated at Phase 5. This PR is a security dependency patch with no spec changes.

---

## Security Review

```mermaid
graph LR
    Critical["Critical: 0"]
    High["High: 0 (was 1 — CLEARED)"]
    Medium["Medium: 0 (was 1 — CLEARED)"]
    Low["Low: 0"]

    style Critical fill:#90EE90
    style High fill:#90EE90
    style Medium fill:#90EE90
    style Low fill:#90EE90
```

<details>
<summary><strong>Security Scan Details</strong></summary>

### Advisories Cleared by This PR

| Advisory | Severity | CVSS | Description | Status |
|----------|----------|------|-------------|--------|
| RUSTSEC-2026-0269 | HIGH | CVSS 4.0: AV:N/AC:L/AT:P/PR:L/UI:P/VC:H/VI:H/VA:L/SC:H/SI:H/SA:L (8.8) | `wasmtime` package — filesystem sandbox escape via cap-std path resolution (trailing slashes/symlinks in wasmtime-wasi); guest WASM can read/write host paths outside preopened boundary on platforms without Linux `openat2` (macOS, older Linux) | **CLEARED** by wasmtime 46.0.3 |
| RUSTSEC-2026-0268 | MEDIUM | — | WASIp3 host-heap DoS — crafted WASM module triggers unbounded host-heap allocation via WASIp3 stream operations | **CLEARED** by wasmtime 46.0.3 |

### Transitive Advisory Note (non-blocking)

| Advisory | Severity | Description | Status |
|----------|----------|-------------|--------|
| `chacha20 0.10.1` YANKED | WARNING | `chacha20` 0.10.1 is yanked from crates.io (via rand → wasmtime-wasi transitive dependency). `cargo deny check advisories` still passes (`advisories ok`) because yanked packages pass the advisory check unless explicitly denied. This is an advisory-level warning — not a blocker for this PR. Flagged as a possible future follow-up (bump rand or await wasmtime-wasi transitive resolution). | Advisory-level; not blocking |

### Dependency Audit
- `cargo deny check advisories`: **`advisories ok`** (RUSTSEC-2026-0268 and RUSTSEC-2026-0269 cleared; chacha20 yanked warning is advisory-level only)
- `cargo audit`: equivalent to deny result — both advisories cleared

### Diff scope
This PR touches only `Cargo.toml` (version pins) and `Cargo.lock` (cascade). No production Rust source files changed. Zero attack-surface changes to the dispatcher binary logic.

</details>

---

## Risk Assessment & Deployment

### Blast Radius
- **Systems affected:** `factory-dispatcher` binary (WASM host runtime); hook-plugin execution sandbox
- **User impact:** If rollback needed: revert to wasmtime 46.0.2 reintroduces RUSTSEC-2026-0269 (CVSS 4.0: 8.8 High) sandbox escape in source builds; operator-level binaries are unaffected until rc.25
- **Data impact:** None (deps-only; no data schema or migration changes)
- **Risk Level:** LOW (patch bump; API unchanged; test suite green)

### Performance Impact
| Metric | Before | After | Delta | Status |
|--------|--------|-------|-------|--------|
| Binary size | wasmtime 46.0.2 baseline | wasmtime 46.0.3 | Negligible patch delta | OK |
| WASM guest execution | Unchanged | Unchanged | 0 | OK |

<details>
<summary><strong>Rollback Instructions</strong></summary>

**Immediate rollback (< 5 min):**
```bash
git revert 1db2ab65
git push origin develop
```

**Note:** Rollback reintroduces RUSTSEC-2026-0269 (CVSS 4.0: 8.8 High). Only roll back if 46.0.3 introduces a critical regression confirmed by `cargo test`.

**Verification after rollback:**
- `cargo deny check advisories` will again show RUSTSEC-2026-0268 and RUSTSEC-2026-0269
- `cargo test --workspace` should still pass

</details>

### Feature Flags
None — dependency version bump has no feature-flag surface.

---

## Traceability

| Requirement | Source | Verification | Status |
|-------------|--------|-------------|--------|
| RUSTSEC-2026-0269 cleared | wasmtime 46.0.3 changelog + RUSTSEC advisory | `cargo deny check advisories` → `advisories ok` | PASS |
| RUSTSEC-2026-0268 cleared | wasmtime 46.0.3 changelog + RUSTSEC advisory | `cargo deny check advisories` → `advisories ok` | PASS |
| No API breakage | Bytecode Alliance release notes: patch-only | `cargo build --workspace` green; `cargo test --workspace` green | PASS |
| No regression | Full test suite | `cargo test --workspace --all-targets` green | PASS |

---

## AI Pipeline Metadata

<details>
<summary><strong>Pipeline Details</strong></summary>

```yaml
ai-generated: true
pipeline-mode: maintenance (security advisory response)
factory-version: "1.0.0-rc.24"
pipeline-stages:
  spec-crystallization: N/A
  story-decomposition: N/A
  tdd-implementation: N/A
  holdout-evaluation: N/A
  adversarial-review: N/A
  formal-verification: N/A
  convergence: N/A
security-advisory-response:
  rustsec-2026-0268: cleared
  rustsec-2026-0269: cleared
models-used:
  pr-manager: claude-sonnet-4-6
generated-at: "2026-08-31"
```

</details>

---

## Pre-Merge Checklist

- [x] All CI status checks passing (`cargo build`, `cargo test`, `cargo fmt`, `cargo clippy`, `cargo deny check advisories`)
- [x] `cargo deny check advisories` = `advisories ok` (deny-advisories CI check green)
- [x] No critical/high security findings unresolved (RUSTSEC-2026-0268 + RUSTSEC-2026-0269 both cleared)
- [x] Rollback procedure validated (simple `git revert`)
- [x] No feature flag changes
- [x] Diff scope: `Cargo.toml` + `Cargo.lock` only (deps-only, no source changes)
- [x] 2 pre-existing bats failures noted (macOS-only, unrelated to wasmtime bump)
- [x] `chacha20 0.10.1` yanked warning noted (advisory-level, non-blocking, possible future follow-up)
- [ ] Human explicit merge go-ahead required (HIGH-severity security bump — held for human authorization)
