### PR TITLE
chore(config): register prd-supplement artifact path pattern

### DIFF
--- a/plugins/vsdd-factory/config/artifact-path-registry.yaml
+++ b/plugins/vsdd-factory/config/artifact-path-registry.yaml
@@ -143,6 +143,15 @@ artifacts:
     description: Product requirements document
     enforcement_level: block
 
+  - artifact_type: prd-supplement
+    canonical_path_pattern: ".factory/specs/prd-supplements/{slug}.md"
+    description: >
+      PRD supplement extracted from the monolithic PRD per DF-021 (interface-definitions.md,
+      error-taxonomy.md, test-vectors.md, nfr-catalog.md). Producer: product-owner. Added
+      S-25.02 F2 fix-burst (F-S2502-F2-006) closing a pre-existing gap — prd.md §5.1/§5b/§4/§3
+      have referenced this directory since before this registry entry existed.
+    enforcement_level: block
+
   - artifact_type: state
     canonical_path_pattern: ".factory/STATE.md"
     description: Pipeline state document


### PR DESCRIPTION
## What Changed

Registers the `prd-supplement` artifact-path pattern in
`plugins/vsdd-factory/config/artifact-path-registry.yaml` so that
`.factory/specs/prd-supplements/*.md` is recognized as a valid write target
by the factory-dispatcher path-validation hook chain.

This is a standalone infrastructure/config fix — not a story delivery. No
code, tests, stubs, or demo evidence are involved.

## Why

The S-25.02 F2 burst needed to materialize `error-taxonomy.md` under
`.factory/specs/prd-supplements/`, but that path pattern was not yet
registered in the artifact-path registry, causing the write to be blocked
by the path-validation guard. This PR closes that gap so future writes to
`.factory/specs/prd-supplements/*.md` are permitted without requiring an
ad hoc bypass.

## Diff Summary

- `plugins/vsdd-factory/config/artifact-path-registry.yaml`: +9 lines,
  registering the `prd-supplement` pattern.

## Testing

- [x] YAML-only change; no code paths affected.
- [x] No new tests required — config registration only.
- [ ] Demo recorded — N/A (non-behavior-changing infra config chore).

## Pre-Merge Checklist

- [x] Branch based on current `origin/develop`.
- [x] Single, minimal diff (9-line addition only).
- [x] No AI attribution in commit/PR per project convention.
- [ ] CI green (fmt/clippy/test/bats).
- [ ] PR review convergence (pr-reviewer APPROVE).

https://claude.ai/code/session_01Y45N2GutCTbmvLPG8cv9xu
